### PR TITLE
Add Alembic migrations and CI integration

### DIFF
--- a/.github/workflows/fly-deploy-prod.yml
+++ b/.github/workflows/fly-deploy-prod.yml
@@ -31,6 +31,22 @@ jobs:
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@v1
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install app & Alembic
+        run: |
+          python -m pip install --upgrade pip
+          pip install . alembic
+
+      - name: Run Alembic migrations (prod)
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          alembic upgrade head
+
       # Set prod secrets on the prod app (idempotent; safe to run every deploy)
       - name: Ensure prod secrets exist
         env:

--- a/.github/workflows/fly-deploy-review.yml
+++ b/.github/workflows/fly-deploy-review.yml
@@ -1,4 +1,4 @@
-name: Deploy Review App
+name: Deploy Review App on PR
 on:
   # Run this workflow on every PR event. Existing review apps will be updated when the PR is updated.
   pull_request:

--- a/.github/workflows/fly-deploy-stage.yml
+++ b/.github/workflows/fly-deploy-stage.yml
@@ -26,6 +26,21 @@ jobs:
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@v1
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install app & Alembic
+        run: |
+          python -m pip install --upgrade pip
+          pip install . alembic
+
+      - name: Run Alembic migrations (stage)
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          alembic upgrade head
 
       - name: Deploy
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR /app
 
 RUN python -m venv .venv
-COPY pyproject.toml ./
+COPY pyproject.toml README.md ./
+COPY app ./app
 RUN .venv/bin/pip install .
 FROM python:3.12-slim
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 HOST ?= 0.0.0.0
 PORT ?= 8000
 
-.PHONY: dev run
+.PHONY: dev run mig.revision mig.up mig.down mig.history mig.current
 
 # Start FastAPI with auto-reload (development)
 dev:
@@ -10,3 +10,18 @@ dev:
 # Start FastAPI without reload (production-like)
 run:
 	python -m uvicorn app.main:app --host $(HOST) --port $(PORT)
+
+mig.revision:
+	alembic revision --autogenerate -m "$(m)"
+
+mig.up:
+	alembic upgrade head
+
+mig.down:
+	alembic downgrade -1
+
+mig.history:
+	alembic history --verbose
+
+mig.current:
+	alembic current

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Alternative run commands:
   - `pip install -e .` (runtime only)
   - `pip install -e .[dev]` (runtime + lint/test tooling)
 
+- Run database migrations with Alembic (requires `DATABASE_URL` pointing at the target Neon branch or Postgres instance):
+  - `export DATABASE_URL="postgresql+asyncpg://user:pass@host/db?sslmode=require"`
+  - `make mig.up` — upgrade to the latest revision
+  - `make mig.revision m="describe change"` — autogenerate a new revision file
+  - `make mig.history` — view migration history
+  - `make mig.current` — show the current revision applied to the database
+  - `make mig.down` — revert the most recent revision (use with care!)
+
 - Refresh `requirements.txt` snapshot (e.g., for deployment targets without Conda):
   - `conda run --no-capture-output -n draftguru python -m pip freeze --exclude-editable > requirements.txt`
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/README.md
+++ b/alembic/README.md
@@ -1,0 +1,18 @@
+# Database Migrations
+
+This project uses [Alembic](https://alembic.sqlalchemy.org/) to manage schema and data migrations. Revisions are stored in
+`alembic/versions/` and target the SQLModel metadata defined in the application.
+
+## Common Commands
+
+```bash
+export DATABASE_URL="postgresql+asyncpg://USER:PASSWORD@HOST/DB?sslmode=require"
+make mig.revision m="add new table"
+make mig.up
+make mig.down
+make mig.history
+make mig.current
+```
+
+Always run migrations against the correct Neon branch before deploying. For risky deployments, cut a new Neon branch from
+production, apply migrations there, validate, and only then update the production `DATABASE_URL` secret.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -2,8 +2,10 @@
 import asyncio
 import os
 from logging.config import fileConfig
+from pathlib import Path
 
 from alembic import context
+from dotenv import load_dotenv
 from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlmodel import SQLModel
@@ -15,6 +17,10 @@ config = context.config
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
+
+# Load local .env file when present so local migrations work without manual exports.
+env_path = Path(__file__).resolve().parent.parent / ".env"
+load_dotenv(env_path, override=False)
 
 DB_URL = os.getenv("DATABASE_URL")
 if not DB_URL:

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,69 @@
+"""Alembic environment configuration for DraftGuru."""
+import asyncio
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlmodel import SQLModel
+
+# Import models so SQLModel metadata is populated.
+from app.schemas import players  # noqa: F401
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+DB_URL = os.getenv("DATABASE_URL")
+if not DB_URL:
+    raise RuntimeError("DATABASE_URL is required for Alembic migrations")
+
+config.set_main_option("sqlalchemy.url", DB_URL)
+
+target_metadata = SQLModel.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    context.configure(
+        url=DB_URL,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True,
+        compare_server_default=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection) -> None:
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        compare_type=True,
+        compare_server_default=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    connectable: AsyncEngine = create_async_engine(
+        DB_URL, poolclass=pool.NullPool, future=True
+    )
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,21 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/20240924_000001_initial.py
+++ b/alembic/versions/20240924_000001_initial.py
@@ -6,6 +6,7 @@ Create Date: 2024-09-24 00:00:01
 """
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 revision = "20240924_000001"
 down_revision = None
@@ -14,13 +15,22 @@ depends_on = None
 
 
 def upgrade() -> None:
+    player_position_enum = postgresql.ENUM(
+        "guard",
+        "forward",
+        "center",
+        name="player_position_enum",
+        create_type=False,
+    )
+    player_position_enum.create(op.get_bind(), checkfirst=True)
+
     op.create_table(
         "players",
         sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
         sa.Column("name", sa.String(), nullable=False),
         sa.Column(
             "player_position",
-            sa.Enum("guard", "forward", "center", name="player_position_enum"),
+            player_position_enum,
             nullable=False,
         ),
         sa.Column("school", sa.String(), nullable=False),
@@ -33,4 +43,11 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index("ix_players_deleted_at", table_name="players")
     op.drop_table("players")
-    op.execute("DROP TYPE IF EXISTS player_position_enum")
+    player_position_enum = postgresql.ENUM(
+        "guard",
+        "forward",
+        "center",
+        name="player_position_enum",
+        create_type=False,
+    )
+    player_position_enum.drop(op.get_bind(), checkfirst=True)

--- a/alembic/versions/20240924_000001_initial.py
+++ b/alembic/versions/20240924_000001_initial.py
@@ -1,0 +1,36 @@
+"""Initial schema for players table.
+
+Revision ID: 20240924_000001
+Revises:
+Create Date: 2024-09-24 00:00:01
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20240924_000001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "players",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column(
+            "player_position",
+            sa.Enum("guard", "forward", "center", name="player_position_enum"),
+            nullable=False,
+        ),
+        sa.Column("school", sa.String(), nullable=False),
+        sa.Column("birth_date", sa.Date(), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index("ix_players_deleted_at", "players", ["deleted_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_players_deleted_at", table_name="players")
+    op.drop_table("players")
+    op.execute("DROP TYPE IF EXISTS player_position_enum")

--- a/app/schemas/players.py
+++ b/app/schemas/players.py
@@ -8,4 +8,6 @@ from app.models.players import PlayerBase
 from app.schemas.base import SoftDeleteMixin
 
 class PlayerTable(PlayerBase, SoftDeleteMixin, table=True):
+    __tablename__ = "players"
+
     id: Optional[int] = SQLField(default=None, primary_key=True)

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - pydantic-settings
   - psycopg
   - asyncpg
+  - alembic
   - pip
   - pip:
       - -e .[dev]

--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -4,6 +4,9 @@ primary_region = 'ewr'
 
 [build]
 
+[deploy]
+  release_command = "/app/.venv/bin/alembic upgrade head"
+
 [http_service]
   internal_port = 8080
   force_https = true

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,9 @@ primary_region = 'ewr'
 
 [build]
 
+[deploy]
+  release_command = "/app/.venv/bin/alembic upgrade head"
+
 [http_service]
   internal_port = 8080
   force_https = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pydantic-settings",
     "psycopg",
     "asyncpg",
+    "alembic>=1.13",
 ]
 
 [project.optional-dependencies]

--- a/scratch/bin/testscript
+++ b/scratch/bin/testscript
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+import sys,os
+print(os.getcwd())
+print(sys.path)


### PR DESCRIPTION
## Summary
- add Alembic configuration and a baseline migration for the players table
- integrate Alembic into deployment workflows and Fly release commands
- document migration usage and add Make targets for common tasks

## Testing
- pytest *(fails: missing dependency `pytest_asyncio` because pip cannot reach package index in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b05c22b083269670123058cad671