### PR TITLE
Add PR pytest workflow

### DIFF
--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -1,0 +1,35 @@
+name: Run Tests on PR
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+      PYTEST_ALLOW_DB: ${{ secrets.PYTEST_ALLOW_DB }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[dev]"
+
+      - name: Run Alembic migrations
+        env:
+          DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+        run: alembic upgrade head
+
+      - name: Run pytest suite
+        run: pytest tests


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs on pull requests targeting main
- install project dependencies, run alembic migrations against the test database, and execute pytest

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d9d90dcc388326926ca6c3a9f83e15