### PR TITLE
ci: add pytest workflow for pull requests

### DIFF
--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -1,0 +1,33 @@
+name: Run Tests on PR
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+      TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+      PYTEST_ALLOW_DB: ${{ secrets.PYTEST_ALLOW_DB }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[dev]"
+
+      - name: Run Alembic migrations
+        run: alembic upgrade head
+
+      - name: Run pytest suite
+        run: pytest tests


### PR DESCRIPTION
## Summary
- add a pull request workflow that installs dependencies and runs pytest
- ensure Alembic migrations run against the test database prior to executing tests

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d9d90dcc388326926ca6c3a9f83e15