### PR TITLE
ci: add PR PR-tests workflow with Alembic and fork-safe setup

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -54,21 +54,10 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
 
-      - name: Install dependencies (pinned if available)
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -s constraints.txt ]; then
-            echo "Installing pinned constraints.txt"
-            pip install -r constraints.txt
-            pip install -e . --no-deps
-          elif [ -s requirements.txt ] && ! grep -q "@ file:" requirements.txt; then
-            echo "Installing pinned requirements.txt"
-            pip install -r requirements.txt
-            pip install -e . --no-deps
-          else
-            echo "No pip-friendly pins found; installing from project metadata"
-            pip install -e .[dev]
-          fi
+          pip install -e .[dev]
 
       - name: Alembic upgrade head
         run: alembic upgrade head
@@ -102,21 +91,10 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
 
-      - name: Install dependencies (pinned if available)
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -s constraints.txt ]; then
-            echo "Installing pinned constraints.txt"
-            pip install -r constraints.txt
-            pip install -e . --no-deps
-          elif [ -s requirements.txt ] && ! grep -q "@ file:" requirements.txt; then
-            echo "Installing pinned requirements.txt"
-            pip install -r requirements.txt
-            pip install -e . --no-deps
-          else
-            echo "No pip-friendly pins found; installing from project metadata"
-            pip install -e .[dev]
-          fi
+          pip install -e .[dev]
 
       - name: Prepare DB URLs from environment secrets
         # Prefer TEST_DATABASE_URL (from draft-app-dev), fallback to DATABASE_URL

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           activate-environment: draftguru
           environment-file: environment.yml
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           use-mamba: true
 
       - name: Alembic upgrade head
@@ -83,7 +83,7 @@ jobs:
         with:
           activate-environment: draftguru
           environment-file: environment.yml
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           use-mamba: true
 
       - name: Prepare DB URLs from environment secrets

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -46,19 +46,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Conda (draftguru)
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          activate-environment: draftguru
-          environment-file: environment.yml
-          miniforge-variant: Miniforge3
-          use-mamba: true
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
 
       - name: Alembic upgrade head
-        run: conda run --no-capture-output -n draftguru alembic upgrade head
+        run: alembic upgrade head
 
       - name: Run tests
-        run: conda run --no-capture-output -n draftguru pytest -q
+        run: pytest -q
 
   tests-secrets:
     # Same-repo PRs: use environment secrets from draft-app-stage
@@ -78,13 +83,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Conda (draftguru)
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          activate-environment: draftguru
-          environment-file: environment.yml
-          miniforge-variant: Miniforge3
-          use-mamba: true
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
 
       - name: Prepare DB URLs from environment secrets
         # Prefer TEST_DATABASE_URL (from draft-app-dev), fallback to DATABASE_URL
@@ -104,7 +114,7 @@ jobs:
           fi
 
       - name: Alembic upgrade head
-        run: conda run --no-capture-output -n draftguru alembic upgrade head
+        run: alembic upgrade head
 
       - name: Run tests
-        run: conda run --no-capture-output -n draftguru pytest -q
+        run: pytest -q

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -57,12 +57,16 @@ jobs:
       - name: Install dependencies (pinned if available)
         run: |
           python -m pip install --upgrade pip
-          if [ -s requirements.txt ]; then
+          if [ -s constraints.txt ]; then
+            echo "Installing pinned constraints.txt"
+            pip install -r constraints.txt
+            pip install -e . --no-deps
+          elif [ -s requirements.txt ] && ! grep -q "@ file:" requirements.txt; then
             echo "Installing pinned requirements.txt"
             pip install -r requirements.txt
             pip install -e . --no-deps
           else
-            echo "requirements.txt empty or missing; installing from project metadata"
+            echo "No pip-friendly pins found; installing from project metadata"
             pip install -e .[dev]
           fi
 
@@ -101,12 +105,16 @@ jobs:
       - name: Install dependencies (pinned if available)
         run: |
           python -m pip install --upgrade pip
-          if [ -s requirements.txt ]; then
+          if [ -s constraints.txt ]; then
+            echo "Installing pinned constraints.txt"
+            pip install -r constraints.txt
+            pip install -e . --no-deps
+          elif [ -s requirements.txt ] && ! grep -q "@ file:" requirements.txt; then
             echo "Installing pinned requirements.txt"
             pip install -r requirements.txt
             pip install -e . --no-deps
           else
-            echo "requirements.txt empty or missing; installing from project metadata"
+            echo "No pip-friendly pins found; installing from project metadata"
             pip install -e .[dev]
           fi
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -54,10 +54,17 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
 
-      - name: Install dependencies
+      - name: Install dependencies (pinned if available)
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev]
+          if [ -s requirements.txt ]; then
+            echo "Installing pinned requirements.txt"
+            pip install -r requirements.txt
+            pip install -e . --no-deps
+          else
+            echo "requirements.txt empty or missing; installing from project metadata"
+            pip install -e .[dev]
+          fi
 
       - name: Alembic upgrade head
         run: alembic upgrade head
@@ -91,10 +98,17 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
 
-      - name: Install dependencies
+      - name: Install dependencies (pinned if available)
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev]
+          if [ -s requirements.txt ]; then
+            echo "Installing pinned requirements.txt"
+            pip install -r requirements.txt
+            pip install -e . --no-deps
+          else
+            echo "requirements.txt empty or missing; installing from project metadata"
+            pip install -e .[dev]
+          fi
 
       - name: Prepare DB URLs from environment secrets
         # Prefer TEST_DATABASE_URL (from draft-app-dev), fallback to DATABASE_URL

--- a/README.md
+++ b/README.md
@@ -34,9 +34,20 @@ Alternative run commands:
   - `make mig.current` — show the current revision applied to the database
   - `make mig.down` — revert the most recent revision (use with care!)
 
-- Refresh `requirements.txt` snapshot (pin exact versions for CI/pip installs):
-  - `conda run --no-capture-output -n draftguru python -m pip freeze --exclude-editable > requirements.txt`
-  - CI will detect a non-empty `requirements.txt`, install it first, then install the app with `--no-deps` to avoid re-resolving.
+- Pin versions for CI (pip-friendly):
+  - Generate a constraints file from your active env that avoids conda-specific file URLs:
+    ```bash
+    conda run --no-capture-output -n draftguru python - <<'PY'
+    try:
+        from importlib.metadata import distributions  # Python 3.8+
+    except Exception:  # pragma: no cover
+        from importlib_metadata import distributions  # backport
+    pins = sorted({f"{d.metadata['Name']}=={d.version}" for d in distributions() if d.metadata.get('Name')})
+    print("\n".join(pins))
+    PY
+    ```
+    Save the output to `constraints.txt` and commit it.
+  - CI prefers `constraints.txt`; if missing, it falls back to a pip-friendly `requirements.txt` (no `@ file:` entries). Otherwise it installs from project metadata.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ Alternative run commands:
   - `make mig.current` — show the current revision applied to the database
   - `make mig.down` — revert the most recent revision (use with care!)
 
-- Refresh `requirements.txt` snapshot (e.g., for deployment targets without Conda):
+- Refresh `requirements.txt` snapshot (pin exact versions for CI/pip installs):
   - `conda run --no-capture-output -n draftguru python -m pip freeze --exclude-editable > requirements.txt`
+  - CI will detect a non-empty `requirements.txt`, install it first, then install the app with `--no-deps` to avoid re-resolving.
 
 ## Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,21 +9,21 @@ description = "FastAPI + SQLModel skeleton for a draft analytics app."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "fastapi[standard]",
-    "sqlmodel",
-    "pydantic-settings",
-    "psycopg",
-    "asyncpg",
-    "alembic>=1.13",
+    "fastapi[standard]==0.116.1",
+    "sqlmodel==0.0.24",
+    "pydantic-settings==2.10.1",
+    "psycopg==3.2.9",
+    "asyncpg==0.30.0",
+    "alembic==1.16.5",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest",
-    "pytest-asyncio",
-    "httpx",
-    "ruff",
-    "mypy",
+    "pytest==8.4.2",
+    "pytest-asyncio==1.2.0",
+    "httpx==0.28.1",
+    "ruff==0.13.0",
+    "mypy==1.18.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = strict
+asyncio_default_fixture_loop_scope = session
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 asyncio_mode = strict
 asyncio_default_fixture_loop_scope = session
-
+asyncio_default_test_loop_scope = session

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,65 @@
+alembic==1.16.5
+annotated-types @ file:///home/conda/feedstock_root/build_artifacts/annotated-types_1733247046149/work
+anyio @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_anyio_1754315087/work
+async-timeout @ file:///home/conda/feedstock_root/build_artifacts/async-timeout_1733235340728/work
+asyncpg @ file:///Users/runner/miniforge3/conda-bld/asyncpg_1756924976170/work
+certifi @ file:///home/conda/feedstock_root/build_artifacts/certifi_1754231422783/work/certifi
+click @ file:///home/conda/feedstock_root/build_artifacts/click_1747811314515/work
+dnspython @ file:///home/conda/feedstock_root/build_artifacts/dnspython_1733256735222/work
+email-validator @ file:///home/conda/feedstock_root/build_artifacts/email-validator-meta_1756221362582/work
+exceptiongroup @ file:///home/conda/feedstock_root/build_artifacts/exceptiongroup_1746947292760/work
+fastapi @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_fastapi-core_1752617909/work
+fastapi-cli @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_fastapi-cli_1756670155/work
+fastapi-cloud-cli==0.2.1
+greenlet @ file:///Users/runner/miniforge3/conda-bld/greenlet_1756752171818/work
+h11 @ file:///home/conda/feedstock_root/build_artifacts/h11_1745526374115/work
+h2 @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_h2_1756364871/work
+hpack @ file:///home/conda/feedstock_root/build_artifacts/hpack_1737618293087/work
+httpcore @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_httpcore_1745602916/work
+httptools @ file:///Users/runner/miniforge3/conda-bld/httptools_1756754398008/work
+httpx @ file:///home/conda/feedstock_root/build_artifacts/httpx_1733663348460/work
+hyperframe @ file:///home/conda/feedstock_root/build_artifacts/hyperframe_1737618333194/work
+idna @ file:///home/conda/feedstock_root/build_artifacts/idna_1733211830134/work
+iniconfig==2.1.0
+Jinja2 @ file:///home/conda/feedstock_root/build_artifacts/jinja2_1741263328855/work
+Mako==1.3.10
+markdown-it-py @ file:///home/conda/feedstock_root/build_artifacts/markdown-it-py_1754951200865/work
+MarkupSafe @ file:///Users/runner/miniforge3/conda-bld/markupsafe_1733219728782/work
+mdurl @ file:///home/conda/feedstock_root/build_artifacts/mdurl_1733255585584/work
+mypy==1.18.1
+mypy_extensions==1.1.0
+packaging==25.0
+pathspec==0.12.1
+pluggy==1.6.0
+psycopg @ file:///home/conda/feedstock_root/build_artifacts/psycopg-split_1747238784361/work/psycopg
+psycopg-c @ file:///Users/runner/miniforge3/conda-bld/psycopg-split_1756316794933/work/psycopg-c
+pydantic @ file:///home/conda/feedstock_root/build_artifacts/pydantic_1749927112905/work
+pydantic-settings @ file:///home/conda/feedstock_root/build_artifacts/pydantic-settings_1750801564484/work
+pydantic_core @ file:///Users/runner/miniforge3/conda-bld/bld/rattler-build_pydantic-core_1746625327/work
+Pygments @ file:///home/conda/feedstock_root/build_artifacts/pygments_1750615794071/work
+pytest==8.4.2
+pytest-asyncio==1.2.0
+python-dotenv @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_python-dotenv_1750789290/work
+python-multipart @ file:///home/conda/feedstock_root/build_artifacts/python-multipart_1734420773152/work
+PyYAML @ file:///Users/runner/miniforge3/conda-bld/pyyaml_1737454693669/work
+rich @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_rich_1753436991/work/dist
+rich-toolkit @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_rich-toolkit_1755001296/work
+rignore==0.6.4
+ruff==0.13.0
+sentry-sdk==2.39.0
+setuptools==80.9.0
+shellingham @ file:///home/conda/feedstock_root/build_artifacts/shellingham_1733300899265/work
+sniffio @ file:///home/conda/feedstock_root/build_artifacts/sniffio_1733244044561/work
+SQLAlchemy @ file:///Users/runner/miniforge3/conda-bld/sqlalchemy_1754983830007/work
+sqlmodel @ file:///home/conda/feedstock_root/build_artifacts/sqlmodel_1741350287606/work
+starlette @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_starlette_1756076609/work
+typer==0.16.1
+typer-slim==0.16.1
+typing-inspection @ file:///home/conda/feedstock_root/build_artifacts/typing-inspection_1747870647094/work
+typing_extensions @ file:///home/conda/feedstock_root/build_artifacts/bld/rattler-build_typing_extensions_1756220668/work
+urllib3==2.5.0
+uvicorn @ file:///home/conda/feedstock_root/build_artifacts/uvicorn_1751201600733/work
+uvloop @ file:///Users/runner/miniforge3/conda-bld/uvloop_1730214386743/work
+watchfiles @ file:///Users/runner/miniforge3/conda-bld/watchfiles_1750053934318/work
+websockets @ file:///Users/runner/miniforge3/conda-bld/bld/rattler-build_websockets_1756476404/work/dist
+wheel==0.45.1

--- a/tests/test_players.py
+++ b/tests/test_players.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_list_players_returns_200(app_client):
     response = await app_client.get("/players")
     assert response.status_code == 200


### PR DESCRIPTION
- Environment: draft-app-dev; use TEST_DATABASE_URL
- Fallback to DATABASE_URL when needed
- Miniforge3 for setup-miniconda to avoid 404
- Run alembic upgrade head before pytest
- Disable AUTO_INIT_DB in CI to rely on Alembic + fixtures