### PR TITLE
feat: Convert mockups to Jinja templates with CSS/JS modules

### DIFF
--- a/app/routes/ui.py
+++ b/app/routes/ui.py
@@ -1,14 +1,319 @@
+"""UI Routes - Renders Jinja templates for the frontend."""
+
+from datetime import datetime
+from typing import Any
+
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 
 router = APIRouter()
 
+# Footer columns - shared across all pages
+FOOTER_COLUMNS = [
+    {
+        "title": "About",
+        "links": [
+            {"text": "Our Story", "url": "#"},
+            {"text": "Team", "url": "#"},
+            {"text": "Careers", "url": "#"},
+            {"text": "Press", "url": "#"},
+        ],
+    },
+    {
+        "title": "Resources",
+        "links": [
+            {"text": "Draft Guide", "url": "#"},
+            {"text": "Mock Drafts", "url": "#"},
+            {"text": "Player Rankings", "url": "#"},
+            {"text": "Analytics", "url": "#"},
+        ],
+    },
+    {
+        "title": "Community",
+        "links": [
+            {"text": "Forums", "url": "#"},
+            {"text": "Discord", "url": "#"},
+            {"text": "Twitter", "url": "#"},
+            {"text": "Newsletter", "url": "#"},
+        ],
+    },
+    {
+        "title": "Legal",
+        "links": [
+            {"text": "Terms of Service", "url": "#"},
+            {"text": "Privacy Policy", "url": "#"},
+            {"text": "Cookie Policy", "url": "#"},
+            {"text": "Disclaimer", "url": "#"},
+        ],
+    },
+]
+
 
 @router.get("/", response_class=HTMLResponse)
 async def home(request: Request):
-    """Render the Home Page"""
+    """Render the Homepage with consensus mock draft, prospects, VS arena, and news feed."""
+
+    # Hardcoded placeholder data - backend connection added later
+    mock_picks: list[dict[str, Any]] = [
+        {
+            "pick": 1,
+            "name": "Cooper Flagg",
+            "slug": "cooper-flagg",
+            "position": "F",
+            "college": "Duke",
+            "avgRank": 1.2,
+            "change": 1,
+        },
+        {
+            "pick": 2,
+            "name": "Ace Bailey",
+            "slug": "ace-bailey",
+            "position": "G/F",
+            "college": "Rutgers",
+            "avgRank": 2.8,
+            "change": -1,
+        },
+        {
+            "pick": 3,
+            "name": "Dylan Harper",
+            "slug": "dylan-harper",
+            "position": "G",
+            "college": "Rutgers",
+            "avgRank": 3.4,
+            "change": 2,
+        },
+        {
+            "pick": 4,
+            "name": "VJ Edgecombe",
+            "slug": "vj-edgecombe",
+            "position": "G",
+            "college": "Baylor",
+            "avgRank": 4.1,
+            "change": 0,
+        },
+        {
+            "pick": 5,
+            "name": "Kon Knueppel",
+            "slug": "kon-knueppel",
+            "position": "G/F",
+            "college": "Duke",
+            "avgRank": 5.7,
+            "change": -2,
+        },
+    ]
+
+    players = [
+        {
+            "name": p["name"],
+            "slug": p["slug"],
+            "position": p["position"],
+            "college": p["college"],
+            "img": f"https://placehold.co/320x420/edf2f7/1f2937?text={str(p['name']).replace(' ', '+')}",
+            "change": p["change"],
+            "measurables": {
+                "ht": 80 + (int(p["pick"]) % 3),
+                "ws": 84 + (int(p["pick"]) % 5),
+                "vert": 34 + (int(p["pick"]) % 7),
+            },
+        }
+        for p in mock_picks
+    ]
+
+    feed_items = [
+        {
+            "source": "@DraftExpress",
+            "title": "Ace Bailey wingspan causes chaos at Elite Camp",
+            "time": "3m",
+            "tag": "Riser",
+        },
+        {
+            "source": "No Ceilings",
+            "title": "Dylan Harper rim deterrence study: early returns",
+            "time": "12m",
+            "tag": "Riser",
+        },
+        {
+            "source": "The Ringer",
+            "title": "VJ Edgecombe fit questions with top-5 teams",
+            "time": "27m",
+            "tag": "Faller",
+        },
+        {
+            "source": "BR",
+            "title": "Flagg off-ball value and scheme versatility",
+            "time": "1h",
+            "tag": "Riser",
+        },
+    ]
 
     return request.app.state.templates.TemplateResponse(
-        "base.html",
-        {"request": request, "players": []},
+        "home.html",
+        {
+            "request": request,
+            "mock_picks": mock_picks,
+            "players": players,
+            "feed_items": feed_items,
+            "footer_columns": FOOTER_COLUMNS,
+            "current_year": datetime.now().year,
+        },
+    )
+
+
+@router.get("/players/{slug}", response_class=HTMLResponse)
+async def player_detail(request: Request, slug: str):
+    """Render the Player Detail page with bio, scoreboard, percentiles, comps, and news.
+
+    Uses slug-based routing (e.g., /players/cooper-flagg).
+    For duplicate names, append a numeric suffix (e.g., john-smith-2).
+    """
+
+    # Hardcoded placeholder data - backend connection added later
+    # In production, fetch player by slug from database
+    player = {
+        "id": 1,
+        "slug": slug,
+        "name": "Cooper Flagg",
+        "position": "Forward",
+        "college": "Duke",
+        "height": "6'9\"",
+        "weight": "205 lbs",
+        "age": 18,
+        "class": "Freshman",
+        "hometown": "Newport, ME",
+        "wingspan": "7'2\"",
+        "photo_url": "https://placehold.co/400x533/edf2f7/1f2937?text=Cooper+Flagg",
+        "metrics": {
+            "consensusRank": 1,
+            "consensusChange": 1,
+            "buzzScore": 94,
+            "truePosition": 1.0,
+            "trueRange": 0.3,
+            "winsAdded": 8.2,
+            "trendDirection": "rising",
+        },
+    }
+
+    percentile_data = {
+        "anthropometrics": [
+            {"metric": "Height", "value": "6'9\"", "percentile": 92, "unit": ""},
+            {"metric": "Weight", "value": "205", "percentile": 78, "unit": " lbs"},
+            {"metric": "Wingspan", "value": "7'2\"", "percentile": 95, "unit": ""},
+            {
+                "metric": "Standing Reach",
+                "value": "9'2\"",
+                "percentile": 94,
+                "unit": "",
+            },
+        ],
+        "combinePerformance": [
+            {
+                "metric": "Lane Agility",
+                "value": "10.84",
+                "percentile": 89,
+                "unit": " sec",
+            },
+            {"metric": "3/4 Sprint", "value": "3.15", "percentile": 91, "unit": " sec"},
+            {
+                "metric": "Max Vertical",
+                "value": "36.0",
+                "percentile": 87,
+                "unit": " in",
+            },
+            {
+                "metric": "Standing Vertical",
+                "value": "32.5",
+                "percentile": 85,
+                "unit": " in",
+            },
+        ],
+        "advancedStats": [
+            {
+                "metric": "Points Per Game",
+                "value": "21.4",
+                "percentile": 96,
+                "unit": " PPG",
+            },
+            {
+                "metric": "Rebounds Per Game",
+                "value": "8.9",
+                "percentile": 93,
+                "unit": " RPG",
+            },
+            {
+                "metric": "Assists Per Game",
+                "value": "4.2",
+                "percentile": 88,
+                "unit": " APG",
+            },
+            {"metric": "PER", "value": "28.6", "percentile": 97, "unit": ""},
+        ],
+    }
+
+    comparison_data = [
+        {
+            "name": "Chet Holmgren",
+            "position": "F/C",
+            "school": "Gonzaga (2022)",
+            "similarity": 92,
+            "img": "https://placehold.co/320x420/edf2f7/1f2937?text=Chet+Holmgren",
+            "stats": {"ht": "84", "ws": "90", "vert": "28"},
+        },
+        {
+            "name": "Jaren Jackson Jr.",
+            "position": "F",
+            "school": "Michigan State (2018)",
+            "similarity": 87,
+            "img": "https://placehold.co/320x420/edf2f7/1f2937?text=Jaren+Jackson+Jr",
+            "stats": {"ht": "83", "ws": "88", "vert": "33"},
+        },
+        {
+            "name": "Evan Mobley",
+            "position": "F/C",
+            "school": "USC (2021)",
+            "similarity": 85,
+            "img": "https://placehold.co/320x420/edf2f7/1f2937?text=Evan+Mobley",
+            "stats": {"ht": "84", "ws": "87", "vert": "30"},
+        },
+        {
+            "name": "Paolo Banchero",
+            "position": "F",
+            "school": "Duke (2022)",
+            "similarity": 78,
+            "img": "https://placehold.co/320x420/edf2f7/1f2937?text=Paolo+Banchero",
+            "stats": {"ht": "82", "ws": "85", "vert": "29"},
+        },
+    ]
+
+    player_feed = [
+        {
+            "source": "@DraftExpress",
+            "title": "Flagg dominates Duke scrimmage with 28 points",
+            "time": "2h",
+            "tag": "Highlight",
+        },
+        {
+            "source": "The Athletic",
+            "title": "Breaking down Flagg's defensive versatility",
+            "time": "5h",
+            "tag": "Analysis",
+        },
+        {
+            "source": "ESPN",
+            "title": "Why Flagg is the consensus #1 pick",
+            "time": "1d",
+            "tag": "Riser",
+        },
+    ]
+
+    return request.app.state.templates.TemplateResponse(
+        "player-detail.html",
+        {
+            "request": request,
+            "player": player,
+            "percentile_data": percentile_data,
+            "comparison_data": comparison_data,
+            "player_feed": player_feed,
+            "footer_columns": FOOTER_COLUMNS,
+            "current_year": datetime.now().year,
+        },
     )

--- a/app/static/css/home.css
+++ b/app/static/css/home.css
@@ -1,0 +1,507 @@
+/* ============================================================================
+   HOME.CSS - Homepage-specific styles
+   ========================================================================= */
+
+/* ============================================================================
+   TICKER / MARKET MOVES
+   Animated scrolling ticker for risers and fallers
+   ========================================================================= */
+.ticker-container {
+  border-radius: var(--border-radius);
+  border: 1px solid var(--color-slate-200);
+  background: var(--color-white);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  /* Tile background pattern */
+  background-image:
+    linear-gradient(#ffffff, #ffffff),
+    radial-gradient(circle at 1px 1px, rgba(99, 102, 241, 0.06) 1px, transparent 1px);
+  background-size: 100% 100%, 12px 12px;
+  outline: 2px solid rgba(99, 102, 241, 0.6);
+}
+
+.ticker-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  border-bottom: 1px solid var(--color-slate-200);
+  background: var(--color-slate-50);
+}
+
+.ticker-header span:first-of-type {
+  font-weight: 600;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.ticker-header span:last-of-type {
+  color: var(--color-slate-500);
+  font-family: var(--font-mono);
+}
+
+.ticker-wrapper {
+  position: relative;
+  overflow: hidden;
+}
+
+.ticker-content {
+  display: flex;
+  gap: 2rem;
+  white-space: nowrap;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  animation: tickerScroll 35s linear infinite;
+}
+
+@keyframes tickerScroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+
+.ticker-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-right: 2rem;
+  border-right: 1px dotted rgba(203, 213, 225, 0.8);
+}
+
+.ticker-item strong {
+  font-family: var(--font-mono);
+  color: var(--color-slate-900);
+}
+
+.ticker-change {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.ticker-change.positive { color: var(--color-accent-emerald); }
+.ticker-change.negative { color: var(--color-accent-rose); }
+
+/* ============================================================================
+   TABLES
+   Data tables for mock draft and comparisons
+   ========================================================================= */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+thead th {
+  padding: 0.5rem;
+  text-align: left;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.75rem;
+  border-bottom: 1px solid var(--color-slate-200);
+}
+
+tbody tr {
+  border-bottom: 1px solid var(--color-slate-200);
+  transition: background var(--transition-speed);
+}
+
+tbody tr:hover {
+  background: rgba(248, 250, 252, 0.7);
+}
+
+tbody td {
+  padding: 0.5rem;
+}
+
+.table-link {
+  color: var(--color-accent-indigo);
+  text-decoration: none;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.table-link:hover {
+  text-decoration: underline;
+}
+
+/* Change indicators in tables */
+.change-positive { color: #15803d; } /* emerald-700 */
+.change-negative { color: #be123c; } /* rose-700 */
+.change-neutral { color: var(--color-slate-500); }
+
+/* ============================================================================
+   PROSPECT CARDS
+   Grid of player prospect cards with hover effects
+   ========================================================================= */
+.prospects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.prospect-card {
+  position: relative;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  outline: 2px solid rgba(99, 102, 241, 0.6);
+  transition: transform var(--transition-speed);
+}
+
+.prospect-card:hover {
+  transform: translateY(-2px);
+}
+
+.prospect-image-wrapper {
+  position: relative;
+  overflow: hidden;
+}
+
+.prospect-image {
+  width: 100%;
+  height: 192px; /* 12rem */
+  object-fit: cover;
+  transition: filter var(--transition-speed);
+}
+
+.prospect-card:hover .prospect-image {
+  filter: brightness(1.05);
+}
+
+/* Badge for riser/faller status */
+.prospect-badge {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  font-size: 0.625rem;
+  font-weight: 600;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+}
+
+.prospect-badge.riser {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.prospect-badge.faller {
+  background: #ffe4e6;
+  color: #9f1239;
+}
+
+/* Pixel corner accents on hover */
+.prospect-card::before,
+.prospect-card::after {
+  content: "";
+  position: absolute;
+  width: 1rem;
+  height: 1rem;
+  opacity: 0;
+  transition: opacity var(--transition-speed);
+  z-index: 10;
+}
+
+.prospect-card::before {
+  top: -0.25rem;
+  left: -0.25rem;
+  background: linear-gradient(45deg, transparent 50%, var(--color-accent-indigo) 50%);
+}
+
+.prospect-card::after {
+  bottom: -0.25rem;
+  right: -0.25rem;
+  background: linear-gradient(225deg, transparent 50%, var(--color-accent-emerald) 50%);
+}
+
+.prospect-card:hover::before,
+.prospect-card:hover::after {
+  opacity: 1;
+}
+
+.prospect-info {
+  padding: 0.75rem;
+}
+
+.prospect-name {
+  font-weight: 600;
+  line-height: 1.25;
+  margin-bottom: 0.25rem;
+}
+
+.prospect-meta {
+  font-size: 0.75rem;
+  color: var(--color-slate-500);
+  margin-bottom: 0.5rem;
+}
+
+/* Stats grid for each prospect */
+.prospect-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  font-size: 0.6875rem;
+}
+
+.stat-pill {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--color-slate-200);
+  background: var(--color-slate-50);
+  color: var(--color-slate-700);
+  text-align: center;
+}
+
+.stat-pill .label {
+  font-size: 0.625rem;
+  color: var(--color-slate-500);
+  margin-right: 0.25rem;
+}
+
+.stat-pill .value {
+  font-weight: 500;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ============================================================================
+   VS ARENA / PLAYER COMPARISON
+   Interactive player comparison section with toggles
+   ========================================================================= */
+.vs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.vs-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.vs-toggles {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+/* Toggle button styles */
+.toggle-button {
+  height: 2rem;
+  padding: 0 0.75rem;
+  font-size: 0.75rem;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 0.375rem;
+  background: var(--color-white);
+  color: var(--color-slate-700);
+  border-color: var(--color-slate-300);
+  cursor: pointer;
+  transition: all var(--transition-speed);
+}
+
+.toggle-button.active {
+  background: #eef2ff;
+  color: #4338ca;
+  border-color: #a5b4fc;
+}
+
+.toggle-button:hover:not(.active) {
+  background: var(--color-slate-50);
+}
+
+/* VS Arena card */
+.vs-arena-card {
+  position: relative;
+}
+
+.vs-content {
+  position: relative;
+  padding: 1rem;
+}
+
+/* Player selectors */
+.vs-selectors {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 1rem;
+  align-items: end;
+  margin-bottom: 1.5rem;
+}
+
+.vs-select {
+  width: 100%;
+  background: var(--color-white);
+  border: 1px solid var(--color-slate-300);
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.vs-badge {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 0.25rem;
+  background: #eef2ff;
+  color: var(--color-accent-indigo);
+  border: 1px solid #c7d2fe;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* Comparison table styles */
+.comparison-table {
+  overflow-x: auto;
+  margin-bottom: 1rem;
+}
+
+.comparison-table thead th {
+  padding: 0.75rem;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.75rem;
+  color: var(--color-slate-600);
+}
+
+.comparison-table tbody td {
+  padding: 0.75rem;
+}
+
+.comparison-table tbody tr {
+  border-bottom: 1px solid var(--color-slate-200);
+}
+
+.comparison-table tbody tr:hover {
+  background: var(--color-slate-50);
+}
+
+.comparison-value {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 1rem;
+}
+
+.comparison-value.winner {
+  font-weight: 800;
+}
+
+.comparison-value.winner-a {
+  color: #15803d;
+  background: #d1fae5;
+}
+
+.comparison-value.winner-b {
+  color: #4338ca;
+  background: #eef2ff;
+}
+
+.comparison-value.loser {
+  color: var(--color-slate-500);
+}
+
+/* Winner declaration banner */
+.winner-banner {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  border-radius: 0.375rem;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-weight: 700;
+}
+
+.winner-banner.winner-a {
+  background: #d1fae5;
+  color: #15803d;
+}
+
+.winner-banner.winner-b {
+  background: #eef2ff;
+  color: #4338ca;
+}
+
+.winner-banner.tie {
+  background: var(--color-slate-100);
+  color: var(--color-slate-800);
+}
+
+/* ============================================================================
+   DRAFT POSITION SPECIALS
+   Betting odds and promotional content
+   ========================================================================= */
+.specials-container {
+  background: var(--color-white);
+  padding: 1rem;
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  outline: 1px solid rgba(245, 158, 11, 0.6);
+}
+
+.specials-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.special-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.special-odds {
+  color: var(--color-accent-indigo);
+  font-weight: 600;
+}
+
+.specials-cta {
+  width: 100%;
+  background: var(--color-accent-emerald);
+  color: var(--color-white);
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-speed);
+  margin-bottom: 0.5rem;
+}
+
+.specials-cta:hover {
+  background: #059669;
+}
+
+.specials-disclaimer {
+  font-size: 0.625rem;
+  color: var(--color-slate-500);
+  text-align: center;
+}
+
+/* ============================================================================
+   RESPONSIVE DESIGN - HOMEPAGE
+   Mobile-first breakpoints for homepage components
+   ========================================================================= */
+@media (max-width: 768px) {
+  .prospects-grid {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  }
+
+  .vs-selectors {
+    grid-template-columns: 1fr;
+  }
+
+  .vs-badge {
+    justify-self: center;
+  }
+}

--- a/app/static/css/player-detail.css
+++ b/app/static/css/player-detail.css
@@ -1,0 +1,1111 @@
+/* ============================================================================
+   PLAYER-DETAIL.CSS - Player Detail Page-specific styles
+   ========================================================================= */
+
+/* ============================================================================
+   PERSONAL INFO SECTION
+   Two-column layout with photo on left, bio + scoreboard stacked on right
+   ========================================================================= */
+.personal-info-grid {
+  display: grid;
+  grid-template-columns: 400px 1fr;
+  gap: 2rem;
+  align-items: start;
+}
+
+/* Left column: Photo only */
+.player-photo-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* Right column: Bio and scoreboard stacked */
+.player-info-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  height: 100%;
+}
+
+.player-photo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  outline: 2px solid rgba(99, 102, 241, 0.4);
+  outline-offset: -2px;
+}
+
+.player-bio {
+  background: var(--color-white);
+  padding: 1.25rem;
+  border-radius: var(--border-radius);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  flex-shrink: 0;
+}
+
+.bio-header {
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-slate-600);
+  font-weight: 600;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--color-slate-200);
+}
+
+.player-primary-meta {
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  color: var(--color-slate-600);
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--color-slate-200);
+}
+
+.player-secondary-meta {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+  font-size: 0.875rem;
+}
+
+.meta-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.meta-label {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-slate-500);
+  margin-bottom: 0.125rem;
+}
+
+.meta-value {
+  color: var(--color-slate-900);
+  font-weight: 500;
+}
+
+/* ============================================================================
+   SPORTS SCOREBOARD
+   Retro-styled metrics dashboard
+   ========================================================================= */
+.sports-scoreboard {
+  background: var(--color-white);
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  outline: 2px solid rgba(245, 158, 11, 0.6);
+  outline-offset: -2px;
+  position: relative;
+  overflow: hidden;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  /* Dot-matrix background pattern */
+  background-image:
+    linear-gradient(#ffffff, #ffffff),
+    radial-gradient(circle at 1px 1px, rgba(245, 158, 11, 0.08) 1px, transparent 1px);
+  background-size: 100% 100%, 12px 12px;
+}
+
+.scoreboard-header {
+  position: relative;
+  padding: 1rem 1.25rem;
+  background: linear-gradient(to right, #fef3c7, #fde68a);
+  border-bottom: 2px solid var(--color-accent-amber);
+}
+
+.scoreboard-title {
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-slate-900);
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.scoreboard-content {
+  position: relative;
+  padding: 1.5rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+/* Metric panels */
+.scoreboard-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.scoreboard-row:last-child {
+  margin-bottom: 0;
+}
+
+.metric-panel {
+  background: var(--color-slate-50);
+  border: 1px solid var(--color-slate-200);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  text-align: center;
+  transition: all var(--transition-speed);
+  position: relative;
+}
+
+.metric-panel:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Pixel corner accents on hover */
+.metric-panel::before,
+.metric-panel::after {
+  content: "";
+  position: absolute;
+  width: 0.75rem;
+  height: 0.75rem;
+  opacity: 0;
+  transition: opacity var(--transition-speed);
+}
+
+.metric-panel::before {
+  top: -0.25rem;
+  left: -0.25rem;
+  background: linear-gradient(45deg, transparent 50%, var(--color-accent-amber) 50%);
+}
+
+.metric-panel::after {
+  bottom: -0.25rem;
+  right: -0.25rem;
+  background: linear-gradient(225deg, transparent 50%, var(--color-accent-emerald) 50%);
+}
+
+.metric-panel:hover::before,
+.metric-panel:hover::after {
+  opacity: 1;
+}
+
+.metric-label {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-slate-500);
+  margin-bottom: 0.5rem;
+  display: block;
+}
+
+.metric-value {
+  font-family: var(--font-mono);
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--color-slate-900);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.metric-value.large {
+  font-size: 3rem;
+}
+
+.metric-subtext {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--color-slate-600);
+  margin-top: 0.25rem;
+}
+
+/* Change indicator */
+.change-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-family: var(--font-mono);
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-top: 0.25rem;
+}
+
+.change-indicator.positive {
+  color: var(--color-accent-emerald);
+}
+
+.change-indicator.negative {
+  color: var(--color-accent-rose);
+}
+
+.change-indicator.neutral {
+  color: var(--color-slate-500);
+}
+
+/* Buzz meter */
+.buzz-meter {
+  width: 100%;
+  height: 0.5rem;
+  background: var(--color-slate-200);
+  border-radius: 9999px;
+  overflow: hidden;
+  margin-top: 0.5rem;
+}
+
+.buzz-fill {
+  height: 100%;
+  background: linear-gradient(to right, var(--color-accent-emerald), var(--color-accent-cyan));
+  transition: width var(--transition-speed);
+}
+
+/* Wide panel for certain metrics */
+.metric-panel-wide {
+  grid-column: span 2;
+}
+
+/* ============================================================================
+   PERFORMANCE SECTION
+   Percentile bars showing player rankings across metrics
+   ========================================================================= */
+.perf-controls-row {
+  display: flex;
+  align-items: end;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.perf-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 200px;
+}
+
+.perf-control-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-top: 1.75rem;
+}
+
+.perf-label {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-slate-600);
+  font-weight: 600;
+}
+
+.perf-select {
+  width: 100%;
+  background: var(--color-white);
+  border: 1px solid var(--color-slate-300);
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all var(--transition-speed);
+}
+
+.perf-select:focus {
+  outline: none;
+  border-color: var(--color-accent-emerald);
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.2);
+}
+
+.perf-checkbox {
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 2px solid var(--color-slate-300);
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition: all var(--transition-speed);
+  appearance: none;
+  position: relative;
+}
+
+.perf-checkbox:checked {
+  background: var(--color-accent-emerald);
+  border-color: var(--color-accent-emerald);
+}
+
+.perf-checkbox:checked::after {
+  content: "";
+  position: absolute;
+  left: 0.25rem;
+  top: 0.0625rem;
+  width: 0.375rem;
+  height: 0.625rem;
+  border: solid white;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.perf-checkbox:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.2);
+}
+
+.perf-checkbox-label {
+  font-size: 0.875rem;
+  color: var(--color-slate-700);
+  cursor: pointer;
+  user-select: none;
+}
+
+/* Category tabs */
+.perf-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.perf-tab {
+  padding: 0.5rem 1rem;
+  background: var(--color-white);
+  border: 2px solid var(--color-slate-300);
+  border-radius: 0.375rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-slate-700);
+  cursor: pointer;
+  transition: all var(--transition-speed);
+  font-weight: 600;
+}
+
+.perf-tab:hover {
+  background: var(--color-slate-50);
+  border-color: var(--color-slate-400);
+}
+
+.perf-tab.active {
+  background: #d1fae5;
+  border-color: var(--color-accent-emerald);
+  color: #065f46;
+}
+
+/* Percentile card */
+.perf-card {
+  position: relative;
+  overflow: hidden;
+  /* Dot-matrix background pattern */
+  background-image:
+    linear-gradient(#ffffff, #ffffff),
+    radial-gradient(circle at 1px 1px, rgba(16, 185, 129, 0.08) 1px, transparent 1px);
+  background-size: 100% 100%, 12px 12px;
+}
+
+.perf-content {
+  position: relative;
+  padding: 1.5rem;
+}
+
+.perf-bars-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* Individual percentile bar row */
+.perf-bar-row {
+  display: grid;
+  grid-template-columns: 180px 1fr 120px;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.75rem;
+  background: var(--color-white);
+  border-radius: 0.5rem;
+  border: 1px solid var(--color-slate-200);
+  transition: all var(--transition-speed);
+}
+
+.perf-bar-row:hover {
+  background: var(--color-slate-50);
+  transform: translateX(4px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.perf-metric-label {
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-slate-700);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Bar container and fill */
+.perf-bar-track {
+  position: relative;
+  height: 1.5rem;
+  background: var(--color-slate-100);
+  border-radius: 9999px;
+  overflow: hidden;
+  border: 1px solid var(--color-slate-200);
+}
+
+.perf-bar-fill {
+  height: 100%;
+  background: linear-gradient(to right, var(--color-accent-emerald), var(--color-accent-cyan));
+  border-radius: 9999px;
+  transition: width 0.4s ease-out;
+  position: relative;
+}
+
+/* Percentile marker on bar */
+.perf-bar-fill::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: rgba(255, 255, 255, 0.8);
+}
+
+/* Color variations based on percentile */
+.perf-bar-fill.elite {
+  background: linear-gradient(to right, #059669, #10b981);
+}
+
+.perf-bar-fill.good {
+  background: linear-gradient(to right, #0ea5e9, #06b6d4);
+}
+
+.perf-bar-fill.average {
+  background: linear-gradient(to right, #f59e0b, #fbbf24);
+}
+
+.perf-bar-fill.below-average {
+  background: linear-gradient(to right, #ef4444, #f87171);
+}
+
+/* Value and percentile display */
+.perf-values {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.125rem;
+}
+
+.perf-actual-value {
+  font-family: var(--font-mono);
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--color-slate-900);
+  font-variant-numeric: tabular-nums;
+}
+
+.perf-percentile-value {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-slate-600);
+  font-variant-numeric: tabular-nums;
+}
+
+.perf-percentile-value.elite { color: #059669; }
+.perf-percentile-value.good { color: #0ea5e9; }
+.perf-percentile-value.average { color: #f59e0b; }
+.perf-percentile-value.below-average { color: #ef4444; }
+
+/* ============================================================================
+   HEAD-TO-HEAD COMPARISON SECTION
+   Player comparison with fuchsia theme (extends home.css h2h styles)
+   ========================================================================= */
+.h2h-control-button {
+  display: flex;
+  align-items: end;
+  padding-bottom: 0.125rem;
+}
+
+.h2h-swap-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--color-white);
+  border: 2px solid var(--color-slate-300);
+  border-radius: 0.375rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-slate-700);
+  cursor: pointer;
+  transition: all var(--transition-speed);
+  font-weight: 600;
+}
+
+.h2h-swap-btn:hover {
+  background: #fae8ff;
+  border-color: var(--color-accent-fuchsia);
+  color: #86198f;
+}
+
+/* ============================================================================
+   PLAYER COMPARISONS SECTION
+   Find similar players based on various criteria
+   ========================================================================= */
+.comp-controls-row {
+  display: flex;
+  align-items: end;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.comp-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 200px;
+}
+
+.comp-control-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-top: 1.75rem;
+}
+
+.comp-label {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-slate-600);
+  font-weight: 600;
+}
+
+/* Category tabs for comparisons */
+.comp-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.comp-tab {
+  padding: 0.5rem 1rem;
+  background: var(--color-white);
+  border: 2px solid var(--color-slate-300);
+  border-radius: 0.375rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-slate-700);
+  cursor: pointer;
+  transition: all var(--transition-speed);
+  font-weight: 600;
+}
+
+.comp-tab:hover {
+  background: var(--color-slate-50);
+  border-color: var(--color-slate-400);
+}
+
+.comp-tab.active {
+  background: #cffafe;
+  border-color: var(--color-accent-cyan);
+  color: #155e75;
+}
+
+.comp-select {
+  width: 100%;
+  background: var(--color-white);
+  border: 1px solid var(--color-slate-300);
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all var(--transition-speed);
+}
+
+.comp-select:focus {
+  outline: none;
+  border-color: var(--color-accent-indigo);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+}
+
+.comp-checkbox {
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 2px solid var(--color-slate-300);
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition: all var(--transition-speed);
+  appearance: none;
+  position: relative;
+}
+
+.comp-checkbox:checked {
+  background: var(--color-accent-indigo);
+  border-color: var(--color-accent-indigo);
+}
+
+.comp-checkbox:checked::after {
+  content: "";
+  position: absolute;
+  left: 0.25rem;
+  top: 0.0625rem;
+  width: 0.375rem;
+  height: 0.625rem;
+  border: solid white;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.comp-checkbox:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+}
+
+.comp-checkbox-label {
+  font-size: 0.875rem;
+  color: var(--color-slate-700);
+  cursor: pointer;
+  user-select: none;
+}
+
+/* Comparison results grid */
+.comp-results-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.5rem;
+}
+
+/* Similarity badge - positioned top-right on cards */
+.similarity-badge {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  padding: 0.375rem 0.625rem;
+  border-radius: 9999px;
+  z-index: 20;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.similarity-badge-high {
+  background: #d1fae5;
+  color: #065f46;
+  border: 1px solid #a7f3d0;
+}
+
+.similarity-badge-good {
+  background: #cffafe;
+  color: #155e75;
+  border: 1px solid #a5f3fc;
+}
+
+.similarity-badge-moderate {
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fde68a;
+}
+
+.similarity-badge-weak {
+  background: #f1f5f9;
+  color: #475569;
+  border: 1px solid #e2e8f0;
+}
+
+/* Compare button within cards */
+.comp-compare-btn {
+  width: 100%;
+  background: var(--color-accent-indigo);
+  color: var(--color-white);
+  border: none;
+  border-radius: 0.375rem;
+  padding: 0.625rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  transition: all var(--transition-speed);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  margin-top: 0.75rem;
+}
+
+.comp-compare-btn:hover {
+  background: #4f46e5;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px rgba(99, 102, 241, 0.3);
+}
+
+/* Comparison view modal/section */
+.comp-comparison-view {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  padding: 2rem;
+  overflow-y: auto;
+}
+
+.comp-comparison-view.active {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.comp-comparison-content {
+  background: var(--color-white);
+  border-radius: var(--border-radius);
+  max-width: 900px;
+  width: 100%;
+  position: relative;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.3);
+}
+
+.comp-comparison-header {
+  padding: 1.5rem;
+  border-bottom: 2px solid var(--color-accent-fuchsia);
+  background: linear-gradient(to right, #fae8ff, #f5d0fe);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.comp-comparison-title {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-slate-900);
+  font-weight: 700;
+}
+
+.comp-close-btn {
+  width: 2rem;
+  height: 2rem;
+  background: rgba(0, 0, 0, 0.1);
+  border: none;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: background var(--transition-speed);
+  display: grid;
+  place-items: center;
+}
+
+.comp-close-btn:hover {
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.comp-comparison-body {
+  padding: 2rem;
+  position: relative;
+  overflow: hidden;
+  /* Dot-matrix background pattern */
+  background-image:
+    linear-gradient(#ffffff, #ffffff),
+    radial-gradient(circle at 1px 1px, rgba(217, 70, 239, 0.08) 1px, transparent 1px);
+  background-size: 100% 100%, 12px 12px;
+}
+
+/* Scanlines for comparison view */
+.comp-comparison-body::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 1) 0,
+    rgba(0, 0, 0, 1) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  opacity: 0.05;
+  pointer-events: none;
+}
+
+/* Comparison table within modal */
+.comp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.comp-table thead th {
+  padding: 0.75rem;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.75rem;
+  color: var(--color-slate-600);
+  border-bottom: 2px solid var(--color-slate-200);
+}
+
+.comp-table tbody td {
+  padding: 0.875rem 0.75rem;
+  border-bottom: 1px solid var(--color-slate-200);
+}
+
+.comp-table tbody tr:hover {
+  background: var(--color-slate-50);
+}
+
+.comp-table-value {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.comp-table-value.winner {
+  color: var(--color-accent-fuchsia);
+  font-weight: 800;
+}
+
+/* Prospect card styles (for comparison cards) */
+.prospect-card {
+  position: relative;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  outline: 2px solid rgba(99, 102, 241, 0.6);
+  transition: transform var(--transition-speed);
+  background: var(--color-white);
+}
+
+.prospect-card:hover {
+  transform: translateY(-2px);
+}
+
+.prospect-image-wrapper {
+  position: relative;
+  overflow: hidden;
+}
+
+.prospect-image {
+  width: 100%;
+  height: 192px;
+  object-fit: cover;
+  transition: filter var(--transition-speed);
+}
+
+.prospect-card:hover .prospect-image {
+  filter: brightness(1.05);
+}
+
+/* Pixel corner accents on hover */
+.prospect-card::before,
+.prospect-card::after {
+  content: "";
+  position: absolute;
+  width: 1rem;
+  height: 1rem;
+  opacity: 0;
+  transition: opacity var(--transition-speed);
+  z-index: 10;
+}
+
+.prospect-card::before {
+  top: -0.25rem;
+  left: -0.25rem;
+  background: linear-gradient(45deg, transparent 50%, var(--color-accent-indigo) 50%);
+}
+
+.prospect-card::after {
+  bottom: -0.25rem;
+  right: -0.25rem;
+  background: linear-gradient(225deg, transparent 50%, var(--color-accent-emerald) 50%);
+}
+
+.prospect-card:hover::before,
+.prospect-card:hover::after {
+  opacity: 1;
+}
+
+.prospect-info {
+  padding: 0.75rem;
+}
+
+.prospect-name {
+  font-weight: 600;
+  line-height: 1.25;
+  margin-bottom: 0.25rem;
+}
+
+.prospect-meta {
+  font-size: 0.75rem;
+  color: var(--color-slate-500);
+  margin-bottom: 0.5rem;
+}
+
+.prospect-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  font-size: 0.6875rem;
+}
+
+.stat-pill {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--color-slate-200);
+  background: var(--color-slate-50);
+  color: var(--color-slate-700);
+  text-align: center;
+}
+
+.stat-pill .label {
+  font-size: 0.625rem;
+  color: var(--color-slate-500);
+  margin-right: 0.25rem;
+}
+
+.stat-pill .value {
+  font-weight: 500;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ============================================================================
+   PLAYER NEWS FEED
+   News feed with article snippets (extends home.css feed styles)
+   ========================================================================= */
+.feed-tag.analysis {
+  color: #1e40af;
+  border-color: #bfdbfe;
+  background: #dbeafe;
+}
+
+.feed-tag.highlight {
+  color: #92400e;
+  border-color: #fde68a;
+  background: #fef3c7;
+}
+
+/* ============================================================================
+   RESPONSIVE DESIGN - PLAYER DETAIL
+   Mobile-first breakpoints for player detail page
+   ========================================================================= */
+@media (max-width: 768px) {
+  .personal-info-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .player-photo {
+    max-width: 400px;
+    margin: 0 auto;
+  }
+
+  .scoreboard-row {
+    grid-template-columns: 1fr;
+  }
+
+  .metric-panel-wide {
+    grid-column: span 1;
+  }
+
+  .metric-value {
+    font-size: 2rem;
+  }
+
+  .metric-value.large {
+    font-size: 2.5rem;
+  }
+
+  .comp-controls-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .comp-control {
+    min-width: 100%;
+  }
+
+  .comp-control-checkbox {
+    padding-top: 0;
+  }
+
+  .comp-tabs {
+    gap: 0.375rem;
+  }
+
+  .comp-tab {
+    font-size: 0.6875rem;
+    padding: 0.375rem 0.75rem;
+  }
+
+  .comp-results-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+  }
+
+  .comp-comparison-view {
+    padding: 1rem;
+  }
+
+  .comp-comparison-body {
+    padding: 1rem;
+  }
+
+  .perf-controls-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .perf-control {
+    min-width: 100%;
+  }
+
+  .perf-control-checkbox {
+    padding-top: 0;
+  }
+
+  .perf-tabs {
+    gap: 0.375rem;
+  }
+
+  .perf-tab {
+    font-size: 0.6875rem;
+    padding: 0.375rem 0.75rem;
+  }
+
+  .perf-bar-row {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  .perf-values {
+    align-items: flex-start;
+  }
+
+  .h2h-control-button {
+    align-items: stretch;
+    padding-bottom: 0;
+  }
+
+  .h2h-swap-btn {
+    justify-content: center;
+  }
+}

--- a/app/static/js/home.js
+++ b/app/static/js/home.js
@@ -1,0 +1,525 @@
+/**
+ * ============================================================================
+ * HOME.JS - Homepage JavaScript Modules
+ * All interactive functionality and data rendering for the homepage
+ * ============================================================================
+ */
+
+/**
+ * ============================================================================
+ * TICKER MODULE
+ * Renders and animates the market moves ticker
+ * ============================================================================
+ */
+const TickerModule = {
+  /**
+   * Initialize the ticker with player change data
+   */
+  init() {
+    const tickerElement = document.getElementById('ticker');
+    if (!tickerElement || !window.MOCK_PICKS) return;
+
+    const tickerData = this.prepareTickerData();
+    tickerElement.innerHTML = this.renderTicker(tickerData);
+  },
+
+  /**
+   * Prepare ticker data by sorting players by change magnitude
+   * @returns {Array} Sorted ticker items
+   */
+  prepareTickerData() {
+    return [...window.MOCK_PICKS]
+      .map((player) => ({ name: player.name, change: player.change }))
+      .sort((a, b) => Math.abs(b.change) - Math.abs(a.change));
+  },
+
+  /**
+   * Render ticker HTML (duplicated for seamless infinite scroll)
+   * @param {Array} data - Ticker items
+   * @returns {string} HTML string
+   */
+  renderTicker(data) {
+    const chunk = data.map((item) => {
+      const changeClass = item.change > 0 ? 'positive' : 'negative';
+      const changeSymbol = item.change > 0 ? '▲' : '▼';
+
+      return `
+        <span class="ticker-item">
+          <strong>${item.name}</strong>
+          <span class="ticker-change ${changeClass}">
+            ${changeSymbol} ${Math.abs(item.change)}
+          </span>
+        </span>
+      `;
+    }).join('');
+
+    // Duplicate content for seamless loop
+    return chunk + chunk;
+  }
+};
+
+/**
+ * ============================================================================
+ * MOCK DRAFT TABLE MODULE
+ * Renders the consensus mock draft table
+ * ============================================================================
+ */
+const MockTableModule = {
+  /**
+   * Initialize the mock draft table
+   */
+  init() {
+    const tbody = document.getElementById('mockTableBody');
+    if (!tbody || !window.MOCK_PICKS) return;
+
+    tbody.innerHTML = this.renderTableRows();
+  },
+
+  /**
+   * Render table rows for each mock pick
+   * @returns {string} HTML string
+   */
+  renderTableRows() {
+    return window.MOCK_PICKS.map((pick) => {
+      const changeClass = pick.change > 0
+        ? 'change-positive'
+        : pick.change < 0
+        ? 'change-negative'
+        : 'change-neutral';
+
+      const changeSymbol = pick.change > 0
+        ? '▲'
+        : pick.change < 0
+        ? '▼'
+        : '=';
+
+      return `
+        <tr>
+          <td class="tabular-nums mono-font" style="font-weight: 500;">${pick.pick}</td>
+          <td><a href="/players/${pick.slug}" class="table-link">${pick.name}</a></td>
+          <td>${pick.position}</td>
+          <td>${pick.college}</td>
+          <td class="tabular-nums mono-font">${pick.avgRank.toFixed(1)}</td>
+          <td class="tabular-nums mono-font ${changeClass}">
+            ${changeSymbol} ${Math.abs(pick.change)}
+          </td>
+          <td>
+            <a href="#" class="table-link">Bet −110</a>
+          </td>
+        </tr>
+      `;
+    }).join('');
+  }
+};
+
+/**
+ * ============================================================================
+ * PROSPECTS GRID MODULE
+ * Renders the grid of top prospect cards
+ * ============================================================================
+ */
+const ProspectsModule = {
+  /**
+   * Initialize the prospects grid
+   */
+  init() {
+    const grid = document.getElementById('prospectsGrid');
+    if (!grid || !window.PLAYERS) return;
+
+    grid.innerHTML = this.renderProspects();
+  },
+
+  /**
+   * Render all prospect cards
+   * @returns {string} HTML string
+   */
+  renderProspects() {
+    return window.PLAYERS.map((player) => {
+      const badge = player.change !== 0
+        ? this.renderBadge(player.change)
+        : '';
+
+      return `
+        <a href="/players/${player.slug}" class="prospect-card" style="text-decoration: none; color: inherit;">
+          <div class="prospect-image-wrapper">
+            <img
+              src="${player.img}"
+              alt="${player.name}"
+              class="prospect-image"
+            />
+            ${badge}
+          </div>
+          <div class="prospect-info">
+            <h4 class="prospect-name">${player.name}</h4>
+            <p class="prospect-meta">${player.position} • ${player.college}</p>
+            <div class="prospect-stats">
+              ${this.renderStatPill('HT', `${player.measurables.ht}"`)}
+              ${this.renderStatPill('WS', `${player.measurables.ws}"`)}
+              ${this.renderStatPill('VRT', `${player.measurables.vert}"`)}
+            </div>
+          </div>
+        </a>
+      `;
+    }).join('');
+  },
+
+  /**
+   * Render riser/faller badge
+   * @param {number} change - Position change value
+   * @returns {string} HTML string
+   */
+  renderBadge(change) {
+    const badgeClass = change > 0 ? 'riser' : 'faller';
+    const badgeText = change > 0 ? 'Riser' : 'Faller';
+    return `<span class="prospect-badge ${badgeClass}">${badgeText}</span>`;
+  },
+
+  /**
+   * Render a single stat pill
+   * @param {string} label - Stat label
+   * @param {string} value - Stat value
+   * @returns {string} HTML string
+   */
+  renderStatPill(label, value) {
+    return `
+      <div class="stat-pill">
+        <span class="label">${label}</span>
+        <span class="value">${value}</span>
+      </div>
+    `;
+  }
+};
+
+/**
+ * ============================================================================
+ * HEAD-TO-HEAD COMPARISON MODULE (VS ARENA)
+ * Handles player comparison functionality with photos and category tabs
+ * ============================================================================
+ */
+const HeadToHeadModule = {
+  selectedPlayerA: null,
+  selectedPlayerB: null,
+  currentCategory: 'anthropometrics',
+
+  // Player data with full stats
+  playerData: {
+    'Cooper Flagg': {
+      img: 'https://placehold.co/200x200/d946ef/ffffff?text=Cooper+Flagg',
+      anthropometrics: { height: 81, weight: 205, wingspan: 86, standingReach: 108 },
+      combinePerformance: { verticalLeap: 38.5, lane: 10.8, shuttle: 2.9, bench: 12 },
+      advancedStats: { per: 28.4, ts: 61.2, orb: 12.8, drb: 18.5, ast: 23.1, stl: 3.2, blk: 5.8, tov: 12.4 }
+    },
+    'Ace Bailey': {
+      img: 'https://placehold.co/200x200/d946ef/ffffff?text=Ace+Bailey',
+      anthropometrics: { height: 79, weight: 196, wingspan: 83, standingReach: 104 },
+      combinePerformance: { verticalLeap: 41.0, lane: 10.5, shuttle: 2.8, bench: 10 },
+      advancedStats: { per: 26.8, ts: 58.7, orb: 8.4, drb: 15.2, ast: 18.6, stl: 2.8, blk: 3.1, tov: 14.2 }
+    },
+    'Zachary Rioux': {
+      img: 'https://placehold.co/200x200/d946ef/ffffff?text=Zachary+Rioux',
+      anthropometrics: { height: 84, weight: 245, wingspan: 89, standingReach: 112 },
+      combinePerformance: { verticalLeap: 32.5, lane: 11.8, shuttle: 3.2, bench: 15 },
+      advancedStats: { per: 24.2, ts: 64.5, orb: 18.2, drb: 22.4, ast: 8.5, stl: 1.4, blk: 8.9, tov: 9.8 }
+    },
+    'Matas Buzelis': {
+      img: 'https://placehold.co/200x200/d946ef/ffffff?text=Matas+Buzelis',
+      anthropometrics: { height: 82, weight: 210, wingspan: 87, standingReach: 109 },
+      combinePerformance: { verticalLeap: 36.0, lane: 11.0, shuttle: 3.0, bench: 11 },
+      advancedStats: { per: 25.6, ts: 59.8, orb: 10.2, drb: 16.8, ast: 20.4, stl: 2.5, blk: 4.2, tov: 11.6 }
+    },
+    'KJ Evans Jr.': {
+      img: 'https://placehold.co/200x200/d946ef/ffffff?text=KJ+Evans+Jr',
+      anthropometrics: { height: 80, weight: 215, wingspan: 84, standingReach: 106 },
+      combinePerformance: { verticalLeap: 35.0, lane: 11.2, shuttle: 3.1, bench: 13 },
+      advancedStats: { per: 23.8, ts: 56.4, orb: 14.6, drb: 19.2, ast: 14.8, stl: 2.1, blk: 3.8, tov: 10.2 }
+    }
+  },
+
+  // Category metrics definitions
+  categoryMetrics: {
+    anthropometrics: [
+      { key: 'height', label: 'Height', unit: '"', higherIsBetter: true },
+      { key: 'weight', label: 'Weight', unit: ' lbs', higherIsBetter: true },
+      { key: 'wingspan', label: 'Wingspan', unit: '"', higherIsBetter: true },
+      { key: 'standingReach', label: 'Standing Reach', unit: '"', higherIsBetter: true }
+    ],
+    combinePerformance: [
+      { key: 'verticalLeap', label: 'Vertical Leap', unit: '"', higherIsBetter: true },
+      { key: 'lane', label: 'Lane Agility', unit: 's', higherIsBetter: false },
+      { key: 'shuttle', label: '3/4 Shuttle', unit: 's', higherIsBetter: false },
+      { key: 'bench', label: 'Bench Press', unit: ' reps', higherIsBetter: true }
+    ],
+    advancedStats: [
+      { key: 'per', label: 'PER', unit: '', higherIsBetter: true },
+      { key: 'ts', label: 'TS%', unit: '%', higherIsBetter: true },
+      { key: 'orb', label: 'ORB%', unit: '%', higherIsBetter: true },
+      { key: 'drb', label: 'DRB%', unit: '%', higherIsBetter: true },
+      { key: 'ast', label: 'AST%', unit: '%', higherIsBetter: true },
+      { key: 'stl', label: 'STL%', unit: '%', higherIsBetter: true },
+      { key: 'blk', label: 'BLK%', unit: '%', higherIsBetter: true },
+      { key: 'tov', label: 'TOV%', unit: '%', higherIsBetter: false }
+    ]
+  },
+
+  /**
+   * Initialize Head-to-Head module
+   */
+  init() {
+    const playerASelect = document.getElementById('playerA');
+    if (!playerASelect) return;
+
+    this.populateSelectors();
+    this.setupEventListeners();
+    this.renderComparison();
+  },
+
+  /**
+   * Populate player dropdown selectors
+   */
+  populateSelectors() {
+    const playerASelect = document.getElementById('playerA');
+    const playerBSelect = document.getElementById('playerB');
+
+    Object.keys(this.playerData).forEach((playerName) => {
+      const optionA = document.createElement('option');
+      optionA.value = playerName;
+      optionA.textContent = playerName;
+      playerASelect.appendChild(optionA);
+
+      const optionB = document.createElement('option');
+      optionB.value = playerName;
+      optionB.textContent = playerName;
+      playerBSelect.appendChild(optionB);
+    });
+
+    // Set default selections
+    const playerNames = Object.keys(this.playerData);
+    playerASelect.value = playerNames[0];
+    playerBSelect.value = playerNames[1];
+    this.selectedPlayerA = playerNames[0];
+    this.selectedPlayerB = playerNames[1];
+  },
+
+  /**
+   * Setup event listeners
+   */
+  setupEventListeners() {
+    // Player selectors
+    document.getElementById('playerA').addEventListener('change', (e) => {
+      this.selectedPlayerA = e.target.value;
+      this.renderComparison();
+    });
+
+    document.getElementById('playerB').addEventListener('change', (e) => {
+      this.selectedPlayerB = e.target.value;
+      this.renderComparison();
+    });
+
+    // Category tabs
+    const tabs = document.querySelectorAll('.h2h-tab');
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        tabs.forEach((t) => t.classList.remove('active'));
+        tab.classList.add('active');
+        this.currentCategory = tab.dataset.category;
+        this.renderComparison();
+      });
+    });
+  },
+
+  /**
+   * Calculate similarity score between two players
+   */
+  calculateSimilarity(playerAData, playerBData) {
+    const metrics = this.categoryMetrics[this.currentCategory];
+    let totalDiff = 0;
+    let count = 0;
+
+    metrics.forEach((metric) => {
+      const valA = playerAData[metric.key];
+      const valB = playerBData[metric.key];
+      if (valA !== undefined && valB !== undefined) {
+        const diff = Math.abs(valA - valB);
+        const avg = (valA + valB) / 2;
+        const percentDiff = avg !== 0 ? (diff / avg) * 100 : 0;
+        totalDiff += percentDiff;
+        count++;
+      }
+    });
+
+    const avgDiff = count > 0 ? totalDiff / count : 0;
+    const similarity = Math.max(0, 100 - avgDiff);
+    return Math.round(similarity);
+  },
+
+  /**
+   * Render the complete comparison
+   */
+  renderComparison() {
+    if (!this.selectedPlayerA || !this.selectedPlayerB) return;
+
+    const playerAData = this.playerData[this.selectedPlayerA][this.currentCategory];
+    const playerBData = this.playerData[this.selectedPlayerB][this.currentCategory];
+
+    // Update photos
+    document.getElementById('h2hPhotoA').src = this.playerData[this.selectedPlayerA].img;
+    document.getElementById('h2hPhotoB').src = this.playerData[this.selectedPlayerB].img;
+    document.getElementById('h2hPhotoNameA').textContent = this.selectedPlayerA;
+    document.getElementById('h2hPhotoNameB').textContent = this.selectedPlayerB;
+
+    // Update similarity badge
+    const similarity = this.calculateSimilarity(playerAData, playerBData);
+    document.getElementById('h2hSimilarityBadge').textContent = `${similarity}% Similar`;
+
+    // Update table headers
+    document.getElementById('headerA').textContent = this.selectedPlayerA;
+    document.getElementById('headerB').textContent = this.selectedPlayerB;
+
+    // Render comparison table
+    const metrics = this.categoryMetrics[this.currentCategory];
+    let rowsHTML = '';
+    let winsA = 0;
+    let winsB = 0;
+
+    metrics.forEach((metric) => {
+      const valueA = playerAData[metric.key];
+      const valueB = playerBData[metric.key];
+
+      // Determine winner based on metric type
+      let isWinnerA, isWinnerB;
+      if (metric.higherIsBetter) {
+        isWinnerA = valueA > valueB;
+        isWinnerB = valueB > valueA;
+      } else {
+        isWinnerA = valueA < valueB;
+        isWinnerB = valueB < valueA;
+      }
+
+      if (isWinnerA) winsA++;
+      if (isWinnerB) winsB++;
+
+      // Build classes for styling with fuchsia winner theme
+      const classA = isWinnerA ? 'h2h-value winner' : 'h2h-value loser';
+      const classB = isWinnerB ? 'h2h-value winner' : 'h2h-value loser';
+
+      rowsHTML += `
+        <tr>
+          <td class="text-right ${classA}">${valueA}${metric.unit}</td>
+          <td class="text-center">${metric.label}</td>
+          <td class="text-left ${classB}">${valueB}${metric.unit}</td>
+        </tr>
+      `;
+    });
+
+    document.getElementById('comparisonBody').innerHTML = rowsHTML;
+
+    // Render winner banner
+    const totalMetrics = metrics.length;
+    let bannerText = '';
+    let bannerClass = '';
+
+    if (winsA > winsB) {
+      bannerText = `🏆 ${this.selectedPlayerA} wins — ${winsA}/${totalMetrics} categories`;
+      bannerClass = 'h2h-winner-banner winner-a';
+    } else if (winsB > winsA) {
+      bannerText = `🏆 ${this.selectedPlayerB} wins — ${winsB}/${totalMetrics} categories`;
+      bannerClass = 'h2h-winner-banner winner-b';
+    } else {
+      bannerText = `⚔️ Tie — ${winsA}/${totalMetrics} categories each`;
+      bannerClass = 'h2h-winner-banner tie';
+    }
+
+    document.getElementById('winnerDeclaration').innerHTML = `<div class="${bannerClass}">${bannerText}</div>`;
+  }
+};
+
+/**
+ * ============================================================================
+ * FEED MODULE
+ * Renders the live draft buzz news feed
+ * ============================================================================
+ */
+const FeedModule = {
+  /**
+   * Initialize the feed
+   */
+  init() {
+    const feedContainer = document.getElementById('feedContainer');
+    if (!feedContainer || !window.FEED_ITEMS) return;
+
+    feedContainer.innerHTML = this.renderFeed();
+  },
+
+  /**
+   * Render all feed items
+   * @returns {string} HTML string
+   */
+  renderFeed() {
+    return window.FEED_ITEMS.map((item) => {
+      const tagClass = item.tag === 'Riser' ? 'riser' : 'faller';
+
+      return `
+        <div class="feed-item">
+          <p class="feed-title">${item.title}</p>
+          <div class="feed-meta">
+            ${item.source}
+            <svg class="icon" viewBox="0 0 24 24" style="width: 0.75rem; height: 0.75rem;">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+            ${item.time}
+            <span class="feed-tag ${tagClass}">${item.tag}</span>
+          </div>
+        </div>
+      `;
+    }).join('');
+  }
+};
+
+/**
+ * ============================================================================
+ * SPECIALS MODULE
+ * Renders draft position betting specials
+ * ============================================================================
+ */
+const SpecialsModule = {
+  /**
+   * Initialize the specials section
+   */
+  init() {
+    const specialsList = document.getElementById('specialsList');
+    if (!specialsList || !window.MOCK_PICKS) return;
+
+    specialsList.innerHTML = this.renderSpecials();
+  },
+
+  /**
+   * Render special betting items
+   * @returns {string} HTML string
+   */
+  renderSpecials() {
+    return window.MOCK_PICKS.slice(0, 4).map((pick) => {
+      const odds = (pick.pick + 50) * 10;
+      return `
+        <div class="special-item">
+          <span>${pick.name} Top ${pick.pick}</span>
+          <span class="special-odds">+${odds}</span>
+        </div>
+      `;
+    }).join('');
+  }
+};
+
+/**
+ * ============================================================================
+ * APPLICATION INITIALIZATION
+ * Initialize all modules when DOM is ready
+ * ============================================================================
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  TickerModule.init();
+  MockTableModule.init();
+  ProspectsModule.init();
+  HeadToHeadModule.init();
+  FeedModule.init();
+  SpecialsModule.init();
+});

--- a/app/static/js/player-detail.js
+++ b/app/static/js/player-detail.js
@@ -1,0 +1,718 @@
+/**
+ * ============================================================================
+ * PLAYER-DETAIL.JS - Player Detail Page JavaScript Modules
+ * All interactive functionality and data rendering for the player detail page
+ * ============================================================================
+ */
+
+/**
+ * ============================================================================
+ * SCOREBOARD MODULE
+ * Populates the sports scoreboard metrics from player data
+ * ============================================================================
+ */
+const ScoreboardModule = {
+  /**
+   * Initialize the scoreboard with player data
+   */
+  init() {
+    if (!window.PLAYER_DATA) return;
+    this.populatePlayerData();
+  },
+
+  /**
+   * Populate all scoreboard elements from player data
+   */
+  populatePlayerData() {
+    const player = window.PLAYER_DATA;
+    const metrics = player.metrics;
+
+    // Update page header
+    const pageHeader = document.getElementById('pageHeader');
+    if (pageHeader) {
+      pageHeader.textContent = `${player.name} — Player Profile`;
+    }
+
+    // Update player photo
+    const playerPhoto = document.getElementById('playerPhoto');
+    if (playerPhoto) {
+      playerPhoto.src = player.photo_url;
+      playerPhoto.alt = player.name;
+    }
+
+    // Update primary meta
+    const playerPrimaryMeta = document.getElementById('playerPrimaryMeta');
+    if (playerPrimaryMeta) {
+      playerPrimaryMeta.textContent = `${player.position} • ${player.college} • ${player.height} • ${player.weight}`;
+    }
+
+    // Update secondary meta
+    const updates = {
+      'playerAge': player.age,
+      'playerClass': player.class,
+      'playerHometown': player.hometown,
+      'playerWingspan': player.wingspan
+    };
+
+    Object.keys(updates).forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) el.textContent = updates[id];
+    });
+
+    // Update scoreboard metrics
+    const consensusRank = document.getElementById('consensusRank');
+    if (consensusRank) consensusRank.textContent = metrics.consensusRank;
+
+    const consensusChange = document.getElementById('consensusChange');
+    if (consensusChange && metrics.consensusChange !== undefined) {
+      const isPositive = metrics.consensusChange > 0;
+      consensusChange.className = `change-indicator ${isPositive ? 'positive' : metrics.consensusChange < 0 ? 'negative' : 'neutral'}`;
+      consensusChange.innerHTML = `
+        <span>${isPositive ? '▲' : metrics.consensusChange < 0 ? '▼' : '='}</span>
+        <span>${Math.abs(metrics.consensusChange)}</span>
+      `;
+    }
+
+    const buzzScore = document.getElementById('buzzScore');
+    if (buzzScore) buzzScore.textContent = metrics.buzzScore;
+
+    const buzzFill = document.getElementById('buzzFill');
+    if (buzzFill) buzzFill.style.width = `${metrics.buzzScore}%`;
+
+    const truePosition = document.getElementById('truePosition');
+    if (truePosition) truePosition.textContent = metrics.truePosition;
+
+    const trueRange = document.getElementById('trueRange');
+    if (trueRange) trueRange.textContent = `± ${metrics.trueRange}`;
+
+    const winsAdded = document.getElementById('winsAdded');
+    if (winsAdded) winsAdded.textContent = `+${metrics.winsAdded}`;
+
+    const trendIndicator = document.getElementById('trendIndicator');
+    if (trendIndicator) {
+      const isRising = metrics.trendDirection === 'rising';
+      trendIndicator.className = `change-indicator ${isRising ? 'positive' : 'negative'}`;
+    }
+  }
+};
+
+/**
+ * ============================================================================
+ * PERFORMANCE MODULE
+ * Renders percentile bars with cohort/category filtering
+ * ============================================================================
+ */
+const PerformanceModule = {
+  currentCategory: 'anthropometrics',
+  currentCohort: 'currentDraft',
+  positionAdjusted: true,
+
+  /**
+   * Initialize performance module
+   */
+  init() {
+    const perfContainer = document.getElementById('perfBarsContainer');
+    if (!perfContainer || !window.PERCENTILE_DATA) return;
+
+    this.setupEventListeners();
+    this.renderPercentiles();
+  },
+
+  /**
+   * Setup event listeners for controls
+   */
+  setupEventListeners() {
+    // Cohort selector
+    const cohortSelect = document.getElementById('perfCohort');
+    if (cohortSelect) {
+      cohortSelect.addEventListener('change', (e) => {
+        this.currentCohort = e.target.value;
+        this.renderPercentiles();
+      });
+    }
+
+    // Position checkbox
+    const positionCheckbox = document.getElementById('perfPositionAdjusted');
+    if (positionCheckbox) {
+      positionCheckbox.addEventListener('change', (e) => {
+        this.positionAdjusted = e.target.checked;
+        this.renderPercentiles();
+      });
+    }
+
+    // Category tabs
+    const tabs = document.querySelectorAll('.perf-tab');
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        tabs.forEach((t) => t.classList.remove('active'));
+        tab.classList.add('active');
+        this.currentCategory = tab.dataset.category;
+        this.renderPercentiles();
+      });
+    });
+  },
+
+  /**
+   * Get percentile class based on value
+   */
+  getPercentileClass(value) {
+    if (value >= 90) return 'elite';
+    if (value >= 70) return 'good';
+    if (value >= 40) return 'average';
+    return 'below-average';
+  },
+
+  /**
+   * Render percentile bars
+   */
+  renderPercentiles() {
+    const container = document.getElementById('perfBarsContainer');
+    if (!container) return;
+
+    const data = window.PERCENTILE_DATA[this.currentCategory] || [];
+
+    const html = data.map((item) => {
+      const percentileClass = this.getPercentileClass(item.percentile);
+
+      return `
+        <div class="perf-bar-row">
+          <div class="perf-metric-label">${item.metric}</div>
+          <div class="perf-bar-track">
+            <div class="perf-bar-fill ${percentileClass}" style="width: ${item.percentile}%;"></div>
+          </div>
+          <div class="perf-values">
+            <span class="perf-actual-value">${item.value}${item.unit}</span>
+            <span class="perf-percentile-value ${percentileClass}">${item.percentile}th</span>
+          </div>
+        </div>
+      `;
+    }).join('');
+
+    container.innerHTML = html;
+  }
+};
+
+/**
+ * ============================================================================
+ * PLAYER COMPARISONS MODULE
+ * Comparison grid with modal overlay for detailed comparisons
+ * ============================================================================
+ */
+const PlayerComparisonsModule = {
+  currentType: 'anthropometrics',
+  currentPool: 'currentDraft',
+  positionFilter: false,
+  selectedCompPlayer: null,
+
+  /**
+   * Initialize comparisons module
+   */
+  init() {
+    const grid = document.getElementById('compResultsGrid');
+    if (!grid || !window.COMPARISON_DATA) return;
+
+    this.setupEventListeners();
+    this.renderResults();
+  },
+
+  /**
+   * Setup event listeners
+   */
+  setupEventListeners() {
+    // Category tabs
+    const tabs = document.querySelectorAll('.comp-tab');
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        tabs.forEach((t) => t.classList.remove('active'));
+        tab.classList.add('active');
+        this.currentType = tab.dataset.category;
+        this.renderResults();
+      });
+    });
+
+    // Pool dropdown
+    const poolSelect = document.getElementById('compPool');
+    if (poolSelect) {
+      poolSelect.addEventListener('change', (e) => {
+        this.currentPool = e.target.value;
+        this.renderResults();
+      });
+    }
+
+    // Position checkbox
+    const posCheckbox = document.getElementById('compPositionFilter');
+    if (posCheckbox) {
+      posCheckbox.addEventListener('change', (e) => {
+        this.positionFilter = e.target.checked;
+        this.renderResults();
+      });
+    }
+
+    // Modal close button
+    const closeBtn = document.getElementById('compCloseBtn');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', () => this.closeComparison());
+    }
+
+    // Close on backdrop click
+    const modal = document.getElementById('compComparisonView');
+    if (modal) {
+      modal.addEventListener('click', (e) => {
+        if (e.target === modal) this.closeComparison();
+      });
+    }
+
+    // Close on escape key
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') this.closeComparison();
+    });
+  },
+
+  /**
+   * Get similarity badge class
+   */
+  getSimilarityBadgeClass(similarity) {
+    if (similarity >= 90) return 'similarity-badge-high';
+    if (similarity >= 80) return 'similarity-badge-good';
+    if (similarity >= 70) return 'similarity-badge-moderate';
+    return 'similarity-badge-weak';
+  },
+
+  /**
+   * Render comparison card
+   */
+  renderCompCard(player) {
+    const badgeClass = this.getSimilarityBadgeClass(player.similarity);
+
+    return `
+      <div class="prospect-card" data-player="${player.name}">
+        <div class="prospect-image-wrapper">
+          <img src="${player.img}" alt="${player.name}" class="prospect-image" />
+          <span class="similarity-badge ${badgeClass}">${player.similarity}%</span>
+        </div>
+        <div class="prospect-info">
+          <h4 class="prospect-name">${player.name}</h4>
+          <p class="prospect-meta">${player.position} • ${player.school}</p>
+          <div class="prospect-stats">
+            <div class="stat-pill">
+              <span class="label">HT</span>
+              <span class="value">${player.stats.ht}"</span>
+            </div>
+            <div class="stat-pill">
+              <span class="label">WS</span>
+              <span class="value">${player.stats.ws}"</span>
+            </div>
+            <div class="stat-pill">
+              <span class="label">VRT</span>
+              <span class="value">${player.stats.vert}"</span>
+            </div>
+          </div>
+          <button class="comp-compare-btn" onclick="PlayerComparisonsModule.showComparison('${player.name}')">
+            <svg class="icon" viewBox="0 0 24 24">
+              <path d="M14.5 17.5L3 6l3-3 11.5 11.5"></path>
+              <path d="M13 19l2 2 6-6-2-2-6 6z"></path>
+            </svg>
+            Compare
+          </button>
+        </div>
+      </div>
+    `;
+  },
+
+  /**
+   * Render all comparison results
+   */
+  renderResults() {
+    const grid = document.getElementById('compResultsGrid');
+    if (!grid) return;
+
+    const html = window.COMPARISON_DATA.map((player) => this.renderCompCard(player)).join('');
+    grid.innerHTML = html;
+  },
+
+  /**
+   * Show detailed comparison modal
+   */
+  showComparison(playerName) {
+    this.selectedCompPlayer = window.COMPARISON_DATA.find((p) => p.name === playerName);
+    if (!this.selectedCompPlayer) return;
+
+    const modal = document.getElementById('compComparisonView');
+    const title = document.getElementById('compComparisonTitle');
+    const body = document.getElementById('compComparisonBody');
+
+    if (title) {
+      title.textContent = `${window.PLAYER_DATA.name} vs ${this.selectedCompPlayer.name}`;
+    }
+
+    if (body) {
+      body.innerHTML = this.renderComparisonTable();
+    }
+
+    if (modal) {
+      modal.classList.add('active');
+      document.body.style.overflow = 'hidden';
+    }
+  },
+
+  /**
+   * Close comparison modal
+   */
+  closeComparison() {
+    const modal = document.getElementById('compComparisonView');
+    if (modal) {
+      modal.classList.remove('active');
+      document.body.style.overflow = '';
+    }
+    this.selectedCompPlayer = null;
+  },
+
+  /**
+   * Render comparison table for modal
+   */
+  renderComparisonTable() {
+    if (!this.selectedCompPlayer) return '';
+
+    const player = window.PLAYER_DATA;
+    const comp = this.selectedCompPlayer;
+
+    // Sample metrics for comparison
+    const metrics = [
+      { label: 'Height', playerA: player.height, playerB: `${comp.stats.ht}"` },
+      { label: 'Wingspan', playerA: player.wingspan, playerB: `${comp.stats.ws}"` },
+      { label: 'Vertical', playerA: '36"', playerB: `${comp.stats.vert}"` }
+    ];
+
+    const rows = metrics.map((m) => `
+      <tr>
+        <td class="text-right comp-table-value">${m.playerA}</td>
+        <td class="text-center">${m.label}</td>
+        <td class="text-left comp-table-value">${m.playerB}</td>
+      </tr>
+    `).join('');
+
+    return `
+      <div class="scanlines"></div>
+      <table class="comp-table" style="position: relative;">
+        <thead>
+          <tr>
+            <th class="text-right">${player.name}</th>
+            <th class="text-center">Metric</th>
+            <th class="text-left">${comp.name}</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${rows}
+        </tbody>
+      </table>
+    `;
+  }
+};
+
+/**
+ * ============================================================================
+ * HEAD-TO-HEAD MODULE (PLAYER DETAIL VERSION)
+ * H2H comparison with swap functionality and fixed Player A
+ * ============================================================================
+ */
+const HeadToHeadModule = {
+  selectedPlayerA: null,
+  selectedPlayerB: null,
+  currentCategory: 'anthropometrics',
+
+  // Player data with full stats (reuses data from homepage)
+  playerData: {},
+
+  // Category metrics definitions
+  categoryMetrics: {
+    anthropometrics: [
+      { key: 'height', label: 'Height', unit: '"', higherIsBetter: true },
+      { key: 'weight', label: 'Weight', unit: ' lbs', higherIsBetter: true },
+      { key: 'wingspan', label: 'Wingspan', unit: '"', higherIsBetter: true },
+      { key: 'standingReach', label: 'Standing Reach', unit: '"', higherIsBetter: true }
+    ],
+    combinePerformance: [
+      { key: 'verticalLeap', label: 'Vertical Leap', unit: '"', higherIsBetter: true },
+      { key: 'lane', label: 'Lane Agility', unit: 's', higherIsBetter: false },
+      { key: 'shuttle', label: '3/4 Shuttle', unit: 's', higherIsBetter: false },
+      { key: 'bench', label: 'Bench Press', unit: ' reps', higherIsBetter: true }
+    ],
+    advancedStats: [
+      { key: 'per', label: 'PER', unit: '', higherIsBetter: true },
+      { key: 'ts', label: 'TS%', unit: '%', higherIsBetter: true },
+      { key: 'ast', label: 'AST%', unit: '%', higherIsBetter: true },
+      { key: 'blk', label: 'BLK%', unit: '%', higherIsBetter: true }
+    ]
+  },
+
+  /**
+   * Initialize the H2H module
+   */
+  init() {
+    const playerBSelect = document.getElementById('h2hPlayerB');
+    if (!playerBSelect) return;
+
+    // Build player data from comparison data
+    this.buildPlayerData();
+    this.populateSelector();
+    this.setupEventListeners();
+    this.renderComparison();
+  },
+
+  /**
+   * Build player data from various sources
+   */
+  buildPlayerData() {
+    // Add current player
+    if (window.PLAYER_DATA) {
+      const p = window.PLAYER_DATA;
+      this.playerData[p.name] = {
+        img: p.photo_url,
+        anthropometrics: { height: 81, weight: 205, wingspan: 86, standingReach: 108 },
+        combinePerformance: { verticalLeap: 38.5, lane: 10.8, shuttle: 2.9, bench: 12 },
+        advancedStats: { per: 28.4, ts: 61.2, ast: 23.1, blk: 5.8 }
+      };
+      this.selectedPlayerA = p.name;
+    }
+
+    // Add comparison players
+    if (window.COMPARISON_DATA) {
+      window.COMPARISON_DATA.forEach((comp) => {
+        this.playerData[comp.name] = {
+          img: comp.img,
+          anthropometrics: {
+            height: parseInt(comp.stats.ht) || 80,
+            weight: 210,
+            wingspan: parseInt(comp.stats.ws) || 84,
+            standingReach: 106
+          },
+          combinePerformance: {
+            verticalLeap: parseInt(comp.stats.vert) || 34,
+            lane: 11.0,
+            shuttle: 3.0,
+            bench: 10
+          },
+          advancedStats: { per: 24.0, ts: 58.0, ast: 18.0, blk: 4.0 }
+        };
+      });
+    }
+  },
+
+  /**
+   * Populate player B selector
+   */
+  populateSelector() {
+    const select = document.getElementById('h2hPlayerB');
+    if (!select) return;
+
+    select.innerHTML = '';
+    Object.keys(this.playerData).forEach((name) => {
+      if (name !== this.selectedPlayerA) {
+        const option = document.createElement('option');
+        option.value = name;
+        option.textContent = name;
+        select.appendChild(option);
+      }
+    });
+
+    if (select.options.length > 0) {
+      this.selectedPlayerB = select.options[0].value;
+    }
+  },
+
+  /**
+   * Setup event listeners
+   */
+  setupEventListeners() {
+    // Player B selector
+    const select = document.getElementById('h2hPlayerB');
+    if (select) {
+      select.addEventListener('change', (e) => {
+        this.selectedPlayerB = e.target.value;
+        this.renderComparison();
+      });
+    }
+
+    // Swap button
+    const swapBtn = document.getElementById('h2hSwapBtn');
+    if (swapBtn) {
+      swapBtn.addEventListener('click', () => {
+        const temp = this.selectedPlayerA;
+        this.selectedPlayerA = this.selectedPlayerB;
+        this.selectedPlayerB = temp;
+        this.populateSelector();
+        document.getElementById('h2hPlayerB').value = this.selectedPlayerB;
+        this.renderComparison();
+      });
+    }
+
+    // Category tabs
+    const tabs = document.querySelectorAll('.h2h-tab');
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        tabs.forEach((t) => t.classList.remove('active'));
+        tab.classList.add('active');
+        this.currentCategory = tab.dataset.category;
+        this.renderComparison();
+      });
+    });
+  },
+
+  /**
+   * Calculate similarity score
+   */
+  calculateSimilarity(playerAData, playerBData) {
+    const metrics = this.categoryMetrics[this.currentCategory];
+    let totalDiff = 0;
+    let count = 0;
+
+    metrics.forEach((metric) => {
+      const valA = playerAData[metric.key];
+      const valB = playerBData[metric.key];
+      if (valA !== undefined && valB !== undefined) {
+        const diff = Math.abs(valA - valB);
+        const avg = (valA + valB) / 2;
+        const percentDiff = avg !== 0 ? (diff / avg) * 100 : 0;
+        totalDiff += percentDiff;
+        count++;
+      }
+    });
+
+    const avgDiff = count > 0 ? totalDiff / count : 0;
+    return Math.max(0, Math.round(100 - avgDiff));
+  },
+
+  /**
+   * Render comparison
+   */
+  renderComparison() {
+    if (!this.selectedPlayerA || !this.selectedPlayerB) return;
+    if (!this.playerData[this.selectedPlayerA] || !this.playerData[this.selectedPlayerB]) return;
+
+    const playerAData = this.playerData[this.selectedPlayerA][this.currentCategory];
+    const playerBData = this.playerData[this.selectedPlayerB][this.currentCategory];
+
+    // Update photos
+    document.getElementById('h2hPhotoA').src = this.playerData[this.selectedPlayerA].img;
+    document.getElementById('h2hPhotoB').src = this.playerData[this.selectedPlayerB].img;
+    document.getElementById('h2hPhotoNameA').textContent = this.selectedPlayerA;
+    document.getElementById('h2hPhotoNameB').textContent = this.selectedPlayerB;
+
+    // Update similarity badge
+    const similarity = this.calculateSimilarity(playerAData, playerBData);
+    document.getElementById('h2hSimilarityBadge').textContent = `${similarity}% Similar`;
+
+    // Update table headers
+    document.getElementById('h2hHeaderA').textContent = this.selectedPlayerA;
+    document.getElementById('h2hHeaderB').textContent = this.selectedPlayerB;
+
+    // Render comparison table
+    const metrics = this.categoryMetrics[this.currentCategory];
+    let rowsHTML = '';
+    let winsA = 0;
+    let winsB = 0;
+
+    metrics.forEach((metric) => {
+      const valueA = playerAData[metric.key];
+      const valueB = playerBData[metric.key];
+
+      let isWinnerA, isWinnerB;
+      if (metric.higherIsBetter) {
+        isWinnerA = valueA > valueB;
+        isWinnerB = valueB > valueA;
+      } else {
+        isWinnerA = valueA < valueB;
+        isWinnerB = valueB < valueA;
+      }
+
+      if (isWinnerA) winsA++;
+      if (isWinnerB) winsB++;
+
+      const classA = isWinnerA ? 'h2h-value winner' : 'h2h-value loser';
+      const classB = isWinnerB ? 'h2h-value winner' : 'h2h-value loser';
+
+      rowsHTML += `
+        <tr>
+          <td class="text-right ${classA}">${valueA}${metric.unit}</td>
+          <td class="text-center">${metric.label}</td>
+          <td class="text-left ${classB}">${valueB}${metric.unit}</td>
+        </tr>
+      `;
+    });
+
+    document.getElementById('h2hComparisonBody').innerHTML = rowsHTML;
+
+    // Render winner banner
+    const totalMetrics = metrics.length;
+    let bannerText = '';
+    let bannerClass = '';
+
+    if (winsA > winsB) {
+      bannerText = `🏆 ${this.selectedPlayerA} wins — ${winsA}/${totalMetrics} categories`;
+      bannerClass = 'h2h-winner-banner winner-a';
+    } else if (winsB > winsA) {
+      bannerText = `🏆 ${this.selectedPlayerB} wins — ${winsB}/${totalMetrics} categories`;
+      bannerClass = 'h2h-winner-banner winner-b';
+    } else {
+      bannerText = `⚔️ Tie — ${winsA}/${totalMetrics} categories each`;
+      bannerClass = 'h2h-winner-banner tie';
+    }
+
+    document.getElementById('h2hWinnerDeclaration').innerHTML = `<div class="${bannerClass}">${bannerText}</div>`;
+  }
+};
+
+/**
+ * ============================================================================
+ * PLAYER FEED MODULE
+ * Renders player-specific news feed
+ * ============================================================================
+ */
+const PlayerFeedModule = {
+  /**
+   * Initialize the feed
+   */
+  init() {
+    const feedContainer = document.getElementById('playerFeedContainer');
+    if (!feedContainer || !window.PLAYER_FEED) return;
+
+    feedContainer.innerHTML = this.renderFeed();
+  },
+
+  /**
+   * Render all feed items
+   */
+  renderFeed() {
+    return window.PLAYER_FEED.map((item) => {
+      const tagClass = item.tag.toLowerCase().replace(' ', '-');
+
+      return `
+        <div class="feed-item">
+          <p class="feed-title">${item.title}</p>
+          <div class="feed-meta">
+            ${item.source}
+            <svg class="icon" viewBox="0 0 24 24" style="width: 0.75rem; height: 0.75rem;">
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+            ${item.time}
+            <span class="feed-tag ${tagClass}">${item.tag}</span>
+          </div>
+        </div>
+      `;
+    }).join('');
+  }
+};
+
+/**
+ * ============================================================================
+ * APPLICATION INITIALIZATION
+ * Initialize all modules when DOM is ready
+ * ============================================================================
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  ScoreboardModule.init();
+  PerformanceModule.init();
+  PlayerComparisonsModule.init();
+  HeadToHeadModule.init();
+  PlayerFeedModule.init();
+});

--- a/app/static/main.css
+++ b/app/static/main.css
@@ -1,10 +1,732 @@
+/* ============================================================================
+   CSS CUSTOM PROPERTIES
+   Centralized color palette and typography for easy theming
+   ========================================================================= */
 :root {
+  /* Typography */
   --font-heading: 'Russo One', system-ui, sans-serif;
   --font-mono: 'Azeret Mono', ui-monospace, monospace;
   --font-body: system-ui, -apple-system, sans-serif;
+
+  /* Primary Colors */
+  --color-primary: #4A7FB8;        /* Blue navbar */
+  --color-secondary: #E8B4A8;      /* Peach footer */
+  --color-accent-emerald: #10b981; /* Success/positive */
+  --color-accent-rose: #f43f5e;    /* Error/negative */
+  --color-accent-indigo: #6366f1;  /* Interactive elements */
+  --color-accent-cyan: #06b6d4;    /* Info sections */
+  --color-accent-amber: #f59e0b;   /* Warnings/highlights */
+  --color-accent-fuchsia: #d946ef; /* Special features */
+
+  /* Neutral Colors */
+  --color-white: #ffffff;
+  --color-slate-50: #f8fafc;
+  --color-slate-100: #f1f5f9;
+  --color-slate-200: #e2e8f0;
+  --color-slate-300: #cbd5e1;
+  --color-slate-500: #64748b;
+  --color-slate-600: #475569;
+  --color-slate-700: #334155;
+  --color-slate-800: #1e293b;
+  --color-slate-900: #0f172a;
+
+  /* Layout */
+  --max-width: 1280px;
+  --content-width: 80%;
+  --spacing-unit: 1rem;
+  --border-radius: 0.75rem;
+  --transition-speed: 0.2s;
+}
+
+/* ============================================================================
+   RESET & BASE STYLES
+   Normalize browser defaults and set foundational styles
+   ========================================================================= */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 body {
-  margin: 0;
   font-family: var(--font-body);
+  color: var(--color-slate-900);
+  background: linear-gradient(to bottom, var(--color-white), var(--color-slate-50));
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+/* ============================================================================
+   TYPOGRAPHY
+   Font styles, sizes, and text utilities
+   ========================================================================= */
+.heading-font {
+  font-family: var(--font-heading);
+  letter-spacing: 0.02em;
+}
+
+.mono-font {
+  font-family: var(--font-mono);
+}
+
+.uppercase {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* Tabular numbers for consistent width (great for tables and metrics) */
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
+}
+
+/* ============================================================================
+   LAYOUT UTILITIES
+   Grid, flex, spacing, and container utilities
+   ========================================================================= */
+.container {
+  max-width: 1152px; /* 72rem */
+  width: var(--content-width);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.section {
+  margin-bottom: 4rem;
+}
+
+.section-header {
+  font-size: 1.5rem;
+  font-weight: 600;
+  padding-left: 0.5rem;
+  border-left: 4px solid;
+  margin-bottom: 1rem;
+}
+
+.section-subtitle {
+  font-size: 0.875rem;
+  color: var(--color-slate-500);
+  margin-bottom: 1rem;
+  padding-left: 0.5rem;
+}
+
+/* Decorative divider between sections */
+.section-divider {
+  height: 1px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    rgba(148, 163, 184, 0.3) 20%,
+    rgba(148, 163, 184, 0.3) 80%,
+    transparent
+  );
+  margin: 3rem 0;
+}
+
+/* ============================================================================
+   NAVIGATION BAR
+   Fixed top navigation with search functionality
+   ========================================================================= */
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background: var(--color-primary);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.navbar-content {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.navbar-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+}
+
+.navbar-brand h1 {
+  font-size: 1.875rem;
+  color: var(--color-white);
+  font-family: var(--font-heading);
+  letter-spacing: 0.02em;
+}
+
+.navbar-search {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.search-input {
+  width: 288px; /* 18rem */
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #93c5fd;
+  color: var(--color-slate-900);
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  outline: none;
+  transition: all var(--transition-speed);
+}
+
+.search-input:focus {
+  border-color: var(--color-white);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.4);
+}
+
+.search-input::placeholder {
+  color: var(--color-slate-500);
+}
+
+.search-button {
+  width: 2.5rem;
+  height: 2.5rem;
+  background: #fbbf24;
+  color: #1e3a8a;
+  border: none;
+  border-radius: 0.375rem;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background var(--transition-speed);
+}
+
+.search-button:hover {
+  background: #fcd34d;
+}
+
+/* ============================================================================
+   FOOTER
+   Bottom footer with links and copyright
+   ========================================================================= */
+.footer {
+  background: var(--color-secondary);
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.08);
+  margin-top: 4rem;
+}
+
+.footer-content {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.footer-column h4 {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-slate-800);
+  margin-bottom: 0.75rem;
+}
+
+.footer-column ul {
+  list-style: none;
+}
+
+.footer-column ul li {
+  margin-bottom: 0.5rem;
+}
+
+.footer-column a {
+  color: var(--color-slate-700);
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color var(--transition-speed);
+}
+
+.footer-column a:hover {
+  color: var(--color-slate-900);
+}
+
+.footer-copyright {
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  padding-top: 1.5rem;
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--color-slate-700);
+}
+
+/* ============================================================================
+   CARDS
+   Reusable card component for content sections
+   ========================================================================= */
+.card {
+  background: var(--color-white);
+  border-radius: var(--border-radius);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.card-header {
+  padding: 1rem 1.25rem 0.25rem;
+  border-bottom: 1px solid var(--color-slate-200);
+}
+
+.card-content {
+  padding: 1rem;
+}
+
+/* Enhanced card with colored ring outline */
+.card-ring {
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  outline: 2px solid;
+  outline-offset: -2px;
+}
+
+.card-ring-emerald { outline-color: rgba(16, 185, 129, 0.6); }
+.card-ring-indigo { outline-color: rgba(99, 102, 241, 0.6); }
+.card-ring-fuchsia { outline-color: rgba(217, 70, 239, 0.6); }
+.card-ring-cyan { outline-color: rgba(6, 182, 212, 0.5); }
+.card-ring-amber { outline-color: rgba(245, 158, 11, 0.6); }
+
+/* ============================================================================
+   ICONS (SVG)
+   Inline SVG icon utilities
+   ========================================================================= */
+.icon {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.icon-lg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.icon-xl {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+/* ============================================================================
+   UTILITY CLASSES
+   Spacing, alignment, and other helpers
+   ========================================================================= */
+.mt-28 {
+  margin-top: 7rem; /* Account for fixed navbar */
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-right {
+  text-align: right;
+}
+
+.text-left {
+  text-align: left;
+}
+
+/* ============================================================================
+   SCANLINES OVERLAY
+   Retro CRT effect for cards
+   ========================================================================= */
+.scanlines {
+  position: absolute;
+  inset: 0;
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 1) 0,
+    rgba(0, 0, 0, 1) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  opacity: 0.05;
+  pointer-events: none;
+}
+
+/* ============================================================================
+   HEAD-TO-HEAD COMPARISON (SHARED STYLES)
+   Integrated player comparison with fuchsia theme
+   Used on both homepage and player-detail pages
+   ========================================================================= */
+.h2h-controls-row {
+  display: flex;
+  align-items: end;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.h2h-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 250px;
+}
+
+.h2h-label {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-slate-600);
+  font-weight: 600;
+}
+
+.h2h-select {
+  width: 100%;
+  background: var(--color-white);
+  border: 1px solid var(--color-slate-300);
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all var(--transition-speed);
+}
+
+.h2h-select:focus {
+  outline: none;
+  border-color: var(--color-accent-fuchsia);
+  box-shadow: 0 0 0 2px rgba(217, 70, 239, 0.2);
+}
+
+/* Category tabs */
+.h2h-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.h2h-tab {
+  padding: 0.5rem 1rem;
+  background: var(--color-white);
+  border: 2px solid var(--color-slate-300);
+  border-radius: 0.375rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-slate-700);
+  cursor: pointer;
+  transition: all var(--transition-speed);
+  font-weight: 600;
+}
+
+.h2h-tab:hover {
+  background: var(--color-slate-50);
+  border-color: var(--color-slate-400);
+}
+
+.h2h-tab.active {
+  background: #fae8ff;
+  border-color: var(--color-accent-fuchsia);
+  color: #86198f;
+}
+
+/* Comparison card */
+.h2h-card {
+  position: relative;
+  overflow: hidden;
+  /* Dot-matrix background pattern */
+  background-image:
+    linear-gradient(#ffffff, #ffffff),
+    radial-gradient(circle at 1px 1px, rgba(217, 70, 239, 0.08) 1px, transparent 1px);
+  background-size: 100% 100%, 12px 12px;
+}
+
+.h2h-content {
+  position: relative;
+  padding: 1.5rem;
+}
+
+/* Similarity badge */
+.h2h-similarity-badge {
+  position: absolute;
+  top: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  background: #fae8ff;
+  color: #86198f;
+  border: 2px solid var(--color-accent-fuchsia);
+  z-index: 10;
+  box-shadow: 0 2px 4px rgba(217, 70, 239, 0.2);
+}
+
+/* Comparison container with photos */
+.h2h-comparison-container {
+  display: flex;
+  flex-direction: column;
+  margin-top: 3.5rem;
+  margin-bottom: 1rem;
+}
+
+/* Photos row above table */
+.h2h-photos-row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+/* Spacer to separate photos */
+.h2h-photos-spacer {
+  width: 2rem;
+}
+
+/* Player photos */
+.h2h-player-photo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.h2h-player-photo img {
+  width: 150px;
+  height: 150px;
+  border-radius: 0.75rem;
+  object-fit: cover;
+  border: 3px solid var(--color-accent-fuchsia);
+  box-shadow: 0 4px 8px rgba(217, 70, 239, 0.2);
+  transition: transform var(--transition-speed);
+}
+
+.h2h-player-photo img:hover {
+  transform: scale(1.05);
+}
+
+.h2h-photo-name {
+  margin-top: 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-slate-700);
+}
+
+/* Comparison table */
+.h2h-comparison-table {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.h2h-comparison-table table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.h2h-comparison-table thead th {
+  padding: 0.75rem;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.75rem;
+  color: var(--color-slate-600);
+  border-bottom: 2px solid var(--color-slate-200);
+  font-weight: 600;
+}
+
+.h2h-comparison-table tbody td {
+  padding: 0.875rem 0.75rem;
+  border-bottom: 1px solid var(--color-slate-200);
+}
+
+.h2h-comparison-table tbody tr:hover {
+  background: var(--color-slate-50);
+}
+
+.h2h-value {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.h2h-value.winner {
+  color: var(--color-accent-fuchsia);
+  font-weight: 800;
+  background: #fae8ff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+}
+
+.h2h-value.loser {
+  color: var(--color-slate-500);
+}
+
+/* Winner banner */
+.h2h-winner-banner {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  border-radius: 0.375rem;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 0.875rem;
+}
+
+.h2h-winner-banner.winner-a {
+  background: #fae8ff;
+  color: #86198f;
+  border: 2px solid var(--color-accent-fuchsia);
+}
+
+.h2h-winner-banner.winner-b {
+  background: #cffafe;
+  color: #155e75;
+  border: 2px solid var(--color-accent-cyan);
+}
+
+.h2h-winner-banner.tie {
+  background: var(--color-slate-100);
+  color: var(--color-slate-800);
+  border: 2px solid var(--color-slate-300);
+}
+
+/* ============================================================================
+   NEWS FEED (SHARED STYLES)
+   Used on both homepage and player-detail pages
+   ========================================================================= */
+.feed-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 520px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.feed-item {
+  background: var(--color-white);
+  padding: 0.75rem;
+  border-radius: var(--border-radius);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  outline: 1px solid rgba(6, 182, 212, 0.5);
+  transition: background var(--transition-speed);
+}
+
+.feed-item:hover {
+  background: var(--color-slate-50);
+}
+
+.feed-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.25;
+  margin-bottom: 0.25rem;
+}
+
+.feed-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.6875rem;
+  color: var(--color-slate-500);
+}
+
+.feed-tag {
+  margin-left: auto;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  border: 1px solid;
+  font-size: 0.6875rem;
+}
+
+.feed-tag.riser {
+  color: #15803d;
+  border-color: #a7f3d0;
+  background: #d1fae5;
+}
+
+.feed-tag.faller {
+  color: #be123c;
+  border-color: #fecdd3;
+  background: #ffe4e6;
+}
+
+/* ============================================================================
+   RESPONSIVE DESIGN - BASE
+   Mobile-first breakpoints for shared components
+   ========================================================================= */
+@media (max-width: 768px) {
+  .h2h-controls-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .h2h-control {
+    min-width: 100%;
+  }
+
+  .h2h-tabs {
+    gap: 0.375rem;
+  }
+
+  .h2h-tab {
+    font-size: 0.6875rem;
+    padding: 0.375rem 0.75rem;
+  }
+
+  .h2h-similarity-badge {
+    font-size: 0.75rem;
+    padding: 0.375rem 0.75rem;
+  }
+
+  .h2h-comparison-container {
+    margin-top: 3rem;
+  }
+
+  .h2h-photos-row {
+    grid-template-columns: 1fr auto 1fr;
+    margin-bottom: 1rem;
+  }
+
+  .h2h-player-photo img {
+    width: 120px;
+    height: 120px;
+  }
+
+  .h2h-photo-name {
+    font-size: 0.75rem;
+  }
+  .navbar-brand h1 {
+    font-size: 1.5rem;
+  }
+
+  .search-input {
+    width: 200px;
+  }
+
+  .section-header {
+    font-size: 1.25rem;
+  }
+
+  .footer-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,1 +1,40 @@
-// Placeholder for shared behaviors; add page-specific scripts via template blocks.
+/**
+ * DraftGuru Shared Utilities
+ * Common functionality used across all pages
+ */
+const DraftGuru = {
+  /**
+   * Initialize search functionality
+   */
+  initSearch() {
+    const searchInput = document.getElementById('search');
+    const searchButton = document.querySelector('.search-button');
+
+    if (searchInput && searchButton) {
+      searchButton.addEventListener('click', () => this.performSearch(searchInput.value));
+      searchInput.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          this.performSearch(searchInput.value);
+        }
+      });
+    }
+  },
+
+  /**
+   * Perform search action
+   * @param {string} query - Search query
+   */
+  performSearch(query) {
+    if (query.trim()) {
+      // TODO: Wire to search API or redirect to search results
+      console.log('Searching for:', query);
+      window.location.href = `/search?q=${encodeURIComponent(query)}`;
+    }
+  }
+};
+
+// Initialize on DOM ready
+document.addEventListener('DOMContentLoaded', () => {
+  DraftGuru.initSearch();
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,84 +1,29 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Mini DraftGuru</title>
-    <link rel="stylesheet" href="/static/main.css">
-    {% block extra_css %}{% endblock %}
-  </head>
-  <body>
-    <header>
-      <h1>DraftGuru: Demo Change</h1>
-    </header>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}DraftGuru — NBA Draft Analytics{% endblock %}</title>
 
-    <main>
-      <section>
-        <h2>Add a Player</h2>
-        <form id="player-form">
-          <label>
-            Name
-            <input id="name" name="name" required placeholder="Cooper Example">
-          </label>
+  <!-- Google Fonts: Russo One (headings) and Azeret Mono (monospace) -->
+  <link href="https://fonts.googleapis.com/css2?family=Russo+One&family=Azeret+Mono:wght@400;600&display=swap" rel="stylesheet">
 
-          <label>
-            Position
-            <select id="position" name="position" required>
-              <option value="">Select…</option>
-              <option value="forward">Forward</option>
-              <option value="center">Center</option>
-              <option value="guard">Guard</option>
-            </select>
-          </label>
+  <!-- Global Styles -->
+  <link rel="stylesheet" href="{{ url_for('static', path='main.css') }}">
 
-          <label>
-            School
-            <input id="school" name="school" required placeholder="Duke">
-          </label>
+  {% block extra_css %}{% endblock %}
+</head>
+<body>
 
-          <label>
-            Birth date
-            <input id="birth_date" name="birth_date" type="date" min="1980-01-01" required>
-          </label>
+  {% include 'partials/navbar.html' %}
 
-          <button type="submit">Save Player</button>
-        </form>
-      </section>
+  {% block content %}{% endblock %}
 
-      <section>
-        <h2>Players</h2>
-        <table aria-label="Players">
-          <thead>
-            <tr>
-              <th>ID</th>
-              <th>Name</th>
-              <th>Pos</th>
-              <th>School</th>
-              <th>Age</th>
-              <th>Birth date</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody id="players-tbody">
-            {% if players %}
-              {% for p in players %}
-              <tr id="row-{{ p.id }}">
-                <td>{{ p.id }}</td>
-                <td>{{ p.name }}</td>
-                <td>{{ p.position }}</td>
-                <td>{{ p.school }}</td>
-                <td>{{ p.age if p.age is defined else "" }}</td>
-                <td>{{ p.birth_date }}</td>
-                <td><button type="button" data-id="{{ p.id }}" class="btn-delete">Delete</button></td>
-              </tr>
-              {% endfor %}
-            {% endif %}
-          </tbody>
-        </table>
-      </section>
-    </main>
+  {% include 'partials/footer.html' %}
 
-    <script src="/static/main.js"></script>
-    {% block extra_js %}{% endblock %}
-  </body>
+  <!-- Global Scripts -->
+  <script src="{{ url_for('static', path='main.js') }}"></script>
+
+  {% block extra_js %}{% endblock %}
+</body>
 </html>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,0 +1,219 @@
+{% extends "base.html" %}
+
+{% block title %}DraftGuru — NBA Draft Analytics{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/home.css') }}">
+{% endblock %}
+
+{% block content %}
+<!-- Main Content Container -->
+<main class="container mt-28">
+
+  <!-- ==========================================================================
+       MARKET MOVES TICKER
+       Scrolling ticker showing player stock changes (risers/fallers)
+       ========================================================================== -->
+  <section class="section">
+    <div class="ticker-container">
+      <!-- Ticker header with icon and label -->
+      <div class="ticker-header">
+        <!-- Activity icon -->
+        <svg class="icon" style="color: var(--color-accent-emerald);" viewBox="0 0 24 24">
+          <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+        </svg>
+        <span>Market Moves</span>
+        <span>(Risers &amp; Fallers)</span>
+      </div>
+
+      <!-- Ticker content - populated by JavaScript -->
+      <div class="ticker-wrapper">
+        <div id="ticker" class="ticker-content"></div>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ==========================================================================
+       CONSENSUS MOCK DRAFT
+       Aggregated mock draft picks from multiple expert sources
+       ========================================================================== -->
+  <section class="section">
+    <h2 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-emerald);">
+      Consensus Mock Draft
+    </h2>
+    <p class="section-subtitle">Averaged from 15 expert boards • updated hourly</p>
+
+    <div class="card card-ring card-ring-emerald">
+      <div class="card-content">
+        <!-- Mock draft table - populated by JavaScript -->
+        <div style="overflow-x: auto;">
+          <table id="mockTable">
+            <thead>
+              <tr>
+                <th>Pick</th>
+                <th>Player</th>
+                <th>Pos</th>
+                <th>Team</th>
+                <th>Avg</th>
+                <th>Δ</th>
+                <th>Odds</th>
+              </tr>
+            </thead>
+            <tbody id="mockTableBody"></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ==========================================================================
+       TOP PROSPECTS
+       Grid of top prospect player cards with stats
+       ========================================================================== -->
+  <section class="section">
+    <h3 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-indigo);">
+      Top Prospects
+    </h3>
+
+    <!-- Prospects grid - populated by JavaScript -->
+    <div id="prospectsGrid" class="prospects-grid"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ==========================================================================
+       VS ARENA (PLAYER COMPARISON)
+       Interactive head-to-head player comparison tool
+       ========================================================================== -->
+  <section class="section">
+    <h2 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-fuchsia);">
+      <!-- Swords icon -->
+      <svg class="icon icon-lg" style="color: var(--color-accent-fuchsia); margin-right: 0.5rem; display: inline-block;" viewBox="0 0 24 24">
+        <path d="M14.5 17.5L3 6l3-3 11.5 11.5"></path>
+        <path d="M13 19l2 2 6-6-2-2-6 6z"></path>
+        <path d="M3 6l7 7"></path>
+      </svg>
+      VS Arena
+    </h2>
+    <p class="section-subtitle">Compare top draft prospects head-to-head across key metrics</p>
+
+    <!-- Player Selectors Row -->
+    <div class="h2h-controls-row">
+      <!-- Player A Selector -->
+      <div class="h2h-control">
+        <label class="h2h-label" for="playerA">Player A</label>
+        <select id="playerA" class="h2h-select"></select>
+      </div>
+
+      <!-- Player B Selector -->
+      <div class="h2h-control">
+        <label class="h2h-label" for="playerB">Player B</label>
+        <select id="playerB" class="h2h-select"></select>
+      </div>
+    </div>
+
+    <!-- Category Tabs -->
+    <div class="h2h-tabs">
+      <button class="h2h-tab active" data-category="anthropometrics">Anthropometrics</button>
+      <button class="h2h-tab" data-category="combinePerformance">Combine Performance</button>
+      <button class="h2h-tab" data-category="advancedStats">Advanced Stats</button>
+    </div>
+
+    <!-- VS Arena card -->
+    <div class="card card-ring card-ring-fuchsia h2h-card">
+      <div class="scanlines"></div>
+
+      <div class="h2h-content">
+        <!-- Similarity Score Badge -->
+        <div id="h2hSimilarityBadge" class="h2h-similarity-badge">
+          Select Players
+        </div>
+
+        <!-- Player Photos and Comparison -->
+        <div class="h2h-comparison-container">
+          <!-- Player Photos Row -->
+          <div class="h2h-photos-row">
+            <div class="h2h-player-photo">
+              <img id="h2hPhotoA" src="https://placehold.co/200x200/edf2f7/1f2937?text=Player+A" alt="Player A" />
+              <div class="h2h-photo-name" id="h2hPhotoNameA">Player A</div>
+            </div>
+            <div class="h2h-photos-spacer"></div>
+            <div class="h2h-player-photo">
+              <img id="h2hPhotoB" src="https://placehold.co/200x200/edf2f7/1f2937?text=Player+B" alt="Player B" />
+              <div class="h2h-photo-name" id="h2hPhotoNameB">Player B</div>
+            </div>
+          </div>
+
+          <!-- Comparison Table -->
+          <div class="h2h-comparison-table">
+            <table>
+              <thead>
+                <tr>
+                  <th id="headerA" class="text-right"></th>
+                  <th class="text-center">Metric</th>
+                  <th id="headerB" class="text-left"></th>
+                </tr>
+              </thead>
+              <tbody id="comparisonBody"></tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Winner Declaration -->
+        <div id="winnerDeclaration"></div>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ==========================================================================
+       LIVE DRAFT BUZZ
+       Real-time news feed with draft-related articles and updates
+       ========================================================================== -->
+  <section class="section">
+    <h3 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-cyan);">
+      Live Draft Buzz
+    </h3>
+
+    <!-- Feed container - populated by JavaScript -->
+    <div id="feedContainer" class="feed-container"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ==========================================================================
+       DRAFT POSITION SPECIALS
+       Betting odds and promotional content (for entertainment purposes)
+       ========================================================================== -->
+  <section class="section">
+    <h3 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-amber);">
+      Draft Position Specials
+    </h3>
+    <p class="section-subtitle">Powered by FanDuel • 21+</p>
+
+    <div class="specials-container">
+      <!-- Specials list - populated by JavaScript -->
+      <div id="specialsList" class="specials-list"></div>
+
+      <button class="specials-cta">Claim Bonus</button>
+      <p class="specials-disclaimer">Gambling Problem? Call 1-800-GAMBLER</p>
+    </div>
+  </section>
+
+</main>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  // Server-side data injection
+  window.MOCK_PICKS = {{ mock_picks | tojson | safe }};
+  window.PLAYERS = {{ players | tojson | safe }};
+  window.FEED_ITEMS = {{ feed_items | tojson | safe }};
+</script>
+<script src="{{ url_for('static', path='js/home.js') }}"></script>
+{% endblock %}

--- a/app/templates/partials/footer.html
+++ b/app/templates/partials/footer.html
@@ -1,0 +1,23 @@
+{# Site Footer with link columns and copyright #}
+<footer class="footer">
+  <div class="footer-content">
+    <!-- Footer navigation grid -->
+    <div class="footer-grid">
+      {% for column in footer_columns %}
+      <div class="footer-column">
+        <h4>{{ column.title }}</h4>
+        <ul>
+          {% for link in column.links %}
+          <li><a href="{{ link.url }}">{{ link.text }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endfor %}
+    </div>
+
+    <!-- Copyright -->
+    <div class="footer-copyright">
+      <p>&copy; {{ current_year }} DraftGuru. All rights reserved. Stay informed, draft smarter.</p>
+    </div>
+  </div>
+</footer>

--- a/app/templates/partials/icons.html
+++ b/app/templates/partials/icons.html
@@ -1,0 +1,59 @@
+{# SVG Icon Macros - import with {% from 'partials/icons.html' import icon_sparkles, icon_search %} #}
+
+{% macro icon_sparkles(size='xl') %}
+<svg class="icon icon-{{ size }}" style="color: #fbbf24;" viewBox="0 0 24 24" stroke-width="2.5">
+  <path d="M12 3l1.5 3.5L17 8l-3.5 1.5L12 13l-1.5-3.5L7 8l3.5-1.5L12 3z"/>
+  <path d="M5 16l.7 1.6L7.3 18l-1.6.7L5 20l-.7-1.3L3 18l1.3-.4L5 16zM19 16l.7 1.6L21.3 18l-1.6.7L19 20l-.7-1.3L17 18l1.3-.4L19 16z"/>
+</svg>
+{% endmacro %}
+
+{% macro icon_search() %}
+<svg class="icon" viewBox="0 0 24 24" stroke-width="2.5">
+  <circle cx="11" cy="11" r="8"></circle>
+  <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+</svg>
+{% endmacro %}
+
+{% macro icon_activity() %}
+<svg class="icon" style="color: var(--color-accent-emerald);" viewBox="0 0 24 24">
+  <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+</svg>
+{% endmacro %}
+
+{% macro icon_swords() %}
+<svg class="icon icon-lg" style="color: var(--color-accent-fuchsia); display: inline-block;" viewBox="0 0 24 24">
+  <path d="M14.5 17.5L3 6l3-3 11.5 11.5"></path>
+  <path d="M13 19l2 2 6-6-2-2-6 6z"></path>
+  <path d="M3 6l7 7"></path>
+</svg>
+{% endmacro %}
+
+{% macro icon_bar_chart() %}
+<svg class="icon icon-lg" viewBox="0 0 24 24">
+  <line x1="12" y1="20" x2="12" y2="10"></line>
+  <line x1="18" y1="20" x2="18" y2="4"></line>
+  <line x1="6" y1="20" x2="6" y2="16"></line>
+</svg>
+{% endmacro %}
+
+{% macro icon_chevron_right() %}
+<svg class="icon" viewBox="0 0 24 24" style="width: 0.75rem; height: 0.75rem;">
+  <polyline points="9 18 15 12 9 6"></polyline>
+</svg>
+{% endmacro %}
+
+{% macro icon_close() %}
+<svg class="icon" viewBox="0 0 24 24">
+  <line x1="18" y1="6" x2="6" y2="18"></line>
+  <line x1="6" y1="6" x2="18" y2="18"></line>
+</svg>
+{% endmacro %}
+
+{% macro icon_swap() %}
+<svg class="icon" viewBox="0 0 24 24">
+  <polyline points="17 1 21 5 17 9"></polyline>
+  <path d="M3 11V9a4 4 0 0 1 4-4h14"></path>
+  <polyline points="7 23 3 19 7 15"></polyline>
+  <path d="M21 13v2a4 4 0 0 1-4 4H3"></path>
+</svg>
+{% endmacro %}

--- a/app/templates/partials/navbar.html
+++ b/app/templates/partials/navbar.html
@@ -1,0 +1,32 @@
+{# Navigation Bar - Fixed top with branding and search #}
+<nav class="navbar">
+  <div class="navbar-content">
+    <!-- Brand / Logo -->
+    <a href="/" class="navbar-brand">
+      <!-- Sparkles icon -->
+      <svg class="icon icon-xl" style="color: #fbbf24;" viewBox="0 0 24 24" stroke-width="2.5">
+        <path d="M12 3l1.5 3.5L17 8l-3.5 1.5L12 13l-1.5-3.5L7 8l3.5-1.5L12 3z"/>
+        <path d="M5 16l.7 1.6L7.3 18l-1.6.7L5 20l-.7-1.3L3 18l1.3-.4L5 16zM19 16l.7 1.6L21.3 18l-1.6.7L19 20l-.7-1.3L17 18l1.3-.4L19 16z"/>
+      </svg>
+      <h1>DraftGuru</h1>
+    </a>
+
+    <!-- Search bar -->
+    <div class="navbar-search">
+      <input
+        type="text"
+        id="search"
+        class="search-input"
+        placeholder="Search prospects…"
+        aria-label="Search prospects"
+      />
+      <button class="search-button" aria-label="Search">
+        <!-- Search icon -->
+        <svg class="icon" viewBox="0 0 24 24" stroke-width="2.5">
+          <circle cx="11" cy="11" r="8"></circle>
+          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+        </svg>
+      </button>
+    </div>
+  </div>
+</nav>

--- a/app/templates/player-detail.html
+++ b/app/templates/player-detail.html
@@ -1,0 +1,396 @@
+{% extends "base.html" %}
+
+{% block title %}{{ player.name }} — Player Profile | DraftGuru{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/player-detail.css') }}">
+{% endblock %}
+
+{% block content %}
+<!-- Main Content Container -->
+<main class="container mt-28">
+
+  <!-- ==========================================================================
+       PERSONAL INFO SECTION
+       Player photograph, biography, and sports scoreboard
+       ========================================================================== -->
+  <section class="section">
+    <h2 id="pageHeader" class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-indigo);">
+      {{ player.name }} — Player Profile
+    </h2>
+
+    <div class="personal-info-grid">
+
+      <!-- LEFT COLUMN: Photo Only -->
+      <div class="player-photo-wrapper">
+        <img
+          id="playerPhoto"
+          class="player-photo"
+          src="{{ player.photo_url }}"
+          alt="{{ player.name }}"
+        />
+      </div>
+
+      <!-- RIGHT COLUMN: Bio + Scoreboard Stacked -->
+      <div class="player-info-stack">
+
+        <!-- Biographical information -->
+        <div class="player-bio">
+          <h3 class="bio-header">Bio</h3>
+
+          <div id="playerPrimaryMeta" class="player-primary-meta">
+            {{ player.position }} • {{ player.college }} • {{ player.height }} • {{ player.weight }}
+          </div>
+
+          <div class="player-secondary-meta">
+            <div class="meta-item">
+              <span class="meta-label">Age</span>
+              <span id="playerAge" class="meta-value">{{ player.age }}</span>
+            </div>
+            <div class="meta-item">
+              <span class="meta-label">Class</span>
+              <span id="playerClass" class="meta-value">{{ player.class }}</span>
+            </div>
+            <div class="meta-item">
+              <span class="meta-label">Hometown</span>
+              <span id="playerHometown" class="meta-value">{{ player.hometown }}</span>
+            </div>
+            <div class="meta-item">
+              <span class="meta-label">Wingspan</span>
+              <span id="playerWingspan" class="meta-value">{{ player.wingspan }}</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Sports Scoreboard -->
+        <div class="sports-scoreboard">
+          <!-- Scanlines overlay -->
+          <div class="scanlines"></div>
+
+          <!-- Scoreboard header -->
+          <div class="scoreboard-header">
+            <div class="scoreboard-title">
+              <!-- Activity icon -->
+              <svg class="icon" viewBox="0 0 24 24">
+                <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+              </svg>
+              Draft Analytics Dashboard
+            </div>
+          </div>
+
+          <!-- Scoreboard content -->
+          <div class="scoreboard-content">
+
+            <!-- Top row: Primary metrics -->
+            <div class="scoreboard-row">
+
+              <!-- Consensus Mock Position -->
+              <div class="metric-panel">
+                <span class="metric-label">Consensus Mock</span>
+                <div class="metric-value large" id="consensusRank">{{ player.metrics.consensusRank }}</div>
+                <div class="change-indicator {{ 'positive' if player.metrics.consensusChange > 0 else 'negative' if player.metrics.consensusChange < 0 else 'neutral' }}" id="consensusChange">
+                  <span>{{ '▲' if player.metrics.consensusChange > 0 else '▼' if player.metrics.consensusChange < 0 else '=' }}</span>
+                  <span>{{ player.metrics.consensusChange | abs }}</span>
+                </div>
+              </div>
+
+              <!-- Draft Buzz Score -->
+              <div class="metric-panel metric-panel-wide">
+                <span class="metric-label">Draft Buzz Score</span>
+                <div class="metric-value" id="buzzScore">{{ player.metrics.buzzScore }}</div>
+                <div class="metric-subtext">Volume Index</div>
+                <div class="buzz-meter">
+                  <div class="buzz-fill" id="buzzFill" style="width: {{ player.metrics.buzzScore }}%;"></div>
+                </div>
+              </div>
+
+            </div>
+
+            <!-- Bottom row: Supporting metrics -->
+            <div class="scoreboard-row">
+
+              <!-- True Draft Position -->
+              <div class="metric-panel">
+                <span class="metric-label">True Position</span>
+                <div class="metric-value" id="truePosition">{{ player.metrics.truePosition }}</div>
+                <div class="metric-subtext" id="trueRange">± {{ player.metrics.trueRange }}</div>
+              </div>
+
+              <!-- Expected Wins Added -->
+              <div class="metric-panel">
+                <span class="metric-label">Exp. Wins Added</span>
+                <div class="metric-value" id="winsAdded">+{{ player.metrics.winsAdded }}</div>
+                <div class="metric-subtext">Year 1 Impact</div>
+              </div>
+
+              <!-- Stock Trend -->
+              <div class="metric-panel">
+                <span class="metric-label">7-Day Trend</span>
+                <div class="change-indicator {{ 'positive' if player.metrics.trendDirection == 'rising' else 'negative' }}" id="trendIndicator">
+                  <svg class="icon-lg" viewBox="0 0 24 24" style="width: 2rem; height: 2rem;">
+                    {% if player.metrics.trendDirection == 'rising' %}
+                    <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline>
+                    <polyline points="17 6 23 6 23 12"></polyline>
+                    {% else %}
+                    <polyline points="23 18 13.5 8.5 8.5 13.5 1 6"></polyline>
+                    <polyline points="17 18 23 18 23 12"></polyline>
+                    {% endif %}
+                  </svg>
+                </div>
+                <div class="metric-subtext">{{ 'Rising' if player.metrics.trendDirection == 'rising' else 'Falling' }}</div>
+              </div>
+
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ==========================================================================
+       PERFORMANCE SECTION
+       Percentile bars showing player rankings
+       ========================================================================== -->
+  <section class="section">
+    <h2 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-emerald);">
+      <!-- Bar chart icon -->
+      <svg class="icon icon-lg" style="color: var(--color-accent-emerald); margin-right: 0.5rem; display: inline-block;" viewBox="0 0 24 24">
+        <line x1="12" y1="20" x2="12" y2="10"></line>
+        <line x1="18" y1="20" x2="18" y2="4"></line>
+        <line x1="6" y1="20" x2="6" y2="16"></line>
+      </svg>
+      Performance Metrics
+    </h2>
+    <p class="section-subtitle">Percentile rankings vs current draft class</p>
+
+    <!-- Controls row -->
+    <div class="perf-controls-row">
+      <div class="perf-control">
+        <label class="perf-label" for="perfCohort">Compare Against</label>
+        <select id="perfCohort" class="perf-select">
+          <option value="currentDraft">Current Draft Class</option>
+          <option value="historical">Historical Prospects</option>
+          <option value="nbaPlayers">Active NBA Players</option>
+        </select>
+      </div>
+      <div class="perf-control-checkbox">
+        <input type="checkbox" id="perfPositionAdjusted" class="perf-checkbox" checked />
+        <label for="perfPositionAdjusted" class="perf-checkbox-label">Position Adjusted</label>
+      </div>
+    </div>
+
+    <!-- Category tabs -->
+    <div class="perf-tabs">
+      <button class="perf-tab active" data-category="anthropometrics">Anthropometrics</button>
+      <button class="perf-tab" data-category="combinePerformance">Combine Performance</button>
+      <button class="perf-tab" data-category="advancedStats">Advanced Stats</button>
+    </div>
+
+    <!-- Percentile card -->
+    <div class="card card-ring card-ring-emerald perf-card">
+      <div class="scanlines"></div>
+      <div class="perf-content">
+        <div id="perfBarsContainer" class="perf-bars-container">
+          <!-- Populated by JavaScript -->
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ==========================================================================
+       HEAD-TO-HEAD COMPARISON
+       Compare this player against another prospect
+       ========================================================================== -->
+  <section class="section">
+    <h2 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-fuchsia);">
+      <!-- Swords icon -->
+      <svg class="icon icon-lg" style="color: var(--color-accent-fuchsia); margin-right: 0.5rem; display: inline-block;" viewBox="0 0 24 24">
+        <path d="M14.5 17.5L3 6l3-3 11.5 11.5"></path>
+        <path d="M13 19l2 2 6-6-2-2-6 6z"></path>
+        <path d="M3 6l7 7"></path>
+      </svg>
+      Head-to-Head Comparison
+    </h2>
+    <p class="section-subtitle">Compare {{ player.name }} against other prospects</p>
+
+    <!-- Controls row -->
+    <div class="h2h-controls-row">
+      <!-- Player A (fixed) -->
+      <div class="h2h-control">
+        <label class="h2h-label">Player A</label>
+        <div class="h2h-select" style="background: var(--color-slate-100); cursor: not-allowed;">
+          {{ player.name }}
+        </div>
+      </div>
+
+      <!-- Swap button -->
+      <div class="h2h-control-button">
+        <button id="h2hSwapBtn" class="h2h-swap-btn">
+          <svg class="icon" viewBox="0 0 24 24">
+            <polyline points="17 1 21 5 17 9"></polyline>
+            <path d="M3 11V9a4 4 0 0 1 4-4h14"></path>
+            <polyline points="7 23 3 19 7 15"></polyline>
+            <path d="M21 13v2a4 4 0 0 1-4 4H3"></path>
+          </svg>
+          Swap
+        </button>
+      </div>
+
+      <!-- Player B selector -->
+      <div class="h2h-control">
+        <label class="h2h-label" for="h2hPlayerB">Player B</label>
+        <select id="h2hPlayerB" class="h2h-select">
+          <!-- Populated by JavaScript -->
+        </select>
+      </div>
+    </div>
+
+    <!-- Category tabs -->
+    <div class="h2h-tabs">
+      <button class="h2h-tab active" data-category="anthropometrics">Anthropometrics</button>
+      <button class="h2h-tab" data-category="combinePerformance">Combine Performance</button>
+      <button class="h2h-tab" data-category="advancedStats">Advanced Stats</button>
+    </div>
+
+    <!-- H2H Card -->
+    <div class="card card-ring card-ring-fuchsia h2h-card">
+      <div class="scanlines"></div>
+
+      <div class="h2h-content">
+        <!-- Similarity Score Badge -->
+        <div id="h2hSimilarityBadge" class="h2h-similarity-badge">
+          Select Players
+        </div>
+
+        <!-- Player Photos and Comparison -->
+        <div class="h2h-comparison-container">
+          <!-- Player Photos Row -->
+          <div class="h2h-photos-row">
+            <div class="h2h-player-photo">
+              <img id="h2hPhotoA" src="{{ player.photo_url }}" alt="{{ player.name }}" />
+              <div class="h2h-photo-name" id="h2hPhotoNameA">{{ player.name }}</div>
+            </div>
+            <div class="h2h-photos-spacer"></div>
+            <div class="h2h-player-photo">
+              <img id="h2hPhotoB" src="https://placehold.co/200x200/edf2f7/1f2937?text=Player+B" alt="Player B" />
+              <div class="h2h-photo-name" id="h2hPhotoNameB">Player B</div>
+            </div>
+          </div>
+
+          <!-- Comparison Table -->
+          <div class="h2h-comparison-table">
+            <table>
+              <thead>
+                <tr>
+                  <th id="h2hHeaderA" class="text-right">{{ player.name }}</th>
+                  <th class="text-center">Metric</th>
+                  <th id="h2hHeaderB" class="text-left">Player B</th>
+                </tr>
+              </thead>
+              <tbody id="h2hComparisonBody">
+                <!-- Populated by JavaScript -->
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Winner Declaration -->
+        <div id="h2hWinnerDeclaration"></div>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ==========================================================================
+       PLAYER COMPARISONS
+       Find similar players based on various criteria
+       ========================================================================== -->
+  <section class="section">
+    <h2 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-cyan);">
+      Player Comparisons
+    </h2>
+    <p class="section-subtitle">Similar players based on physical and statistical profiles</p>
+
+    <!-- Controls row -->
+    <div class="comp-controls-row">
+      <div class="comp-control">
+        <label class="comp-label" for="compPool">Similarity Pool</label>
+        <select id="compPool" class="comp-select">
+          <option value="currentDraft">Current Draft Class</option>
+          <option value="historical">Historical Prospects</option>
+          <option value="nbaPlayers">Active NBA Players</option>
+        </select>
+      </div>
+      <div class="comp-control-checkbox">
+        <input type="checkbox" id="compPositionFilter" class="comp-checkbox" />
+        <label for="compPositionFilter" class="comp-checkbox-label">Same Position Only</label>
+      </div>
+    </div>
+
+    <!-- Category tabs -->
+    <div class="comp-tabs">
+      <button class="comp-tab active" data-category="anthropometrics">Anthropometrics</button>
+      <button class="comp-tab" data-category="combinePerformance">Combine Performance</button>
+      <button class="comp-tab" data-category="advancedStats">Advanced Stats</button>
+    </div>
+
+    <!-- Results grid -->
+    <div id="compResultsGrid" class="comp-results-grid">
+      <!-- Populated by JavaScript -->
+    </div>
+  </section>
+
+  <!-- Comparison Modal -->
+  <div id="compComparisonView" class="comp-comparison-view">
+    <div class="comp-comparison-content">
+      <div class="comp-comparison-header">
+        <h3 id="compComparisonTitle" class="comp-comparison-title">Comparison</h3>
+        <button id="compCloseBtn" class="comp-close-btn">
+          <svg class="icon" viewBox="0 0 24 24">
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </button>
+      </div>
+      <div id="compComparisonBody" class="comp-comparison-body">
+        <!-- Populated by JavaScript -->
+      </div>
+    </div>
+  </div>
+
+  <div class="section-divider"></div>
+
+  <!-- ==========================================================================
+       PLAYER NEWS FEED
+       Player-specific news and updates
+       ========================================================================== -->
+  <section class="section">
+    <h3 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-cyan);">
+      {{ player.name }} News
+    </h3>
+
+    <!-- Feed container -->
+    <div id="playerFeedContainer" class="feed-container">
+      <!-- Populated by JavaScript -->
+    </div>
+  </section>
+
+</main>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  // Server-side data injection
+  window.PLAYER_DATA = {{ player | tojson | safe }};
+  window.PERCENTILE_DATA = {{ percentile_data | tojson | safe }};
+  window.COMPARISON_DATA = {{ comparison_data | tojson | safe }};
+  window.PLAYER_FEED = {{ player_feed | tojson | safe }};
+</script>
+<script src="{{ url_for('static', path='js/player-detail.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
- Add homepage template with ticker, mock draft table, prospects grid, VS Arena comparison, news feed, and betting specials sections
- Add player-detail template with bio, scoreboard, performance metrics, head-to-head comparison, player comparisons, and news feed sections
- Create reusable partials for navbar, footer, and SVG icons
- Split CSS into main.css (shared) + page-specific stylesheets
- Implement vanilla JS modules for interactive components
- Add slug-based routing for player detail pages (/players/{slug})
- Use placeholder data for all sections (backend connection later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)