### PR TITLE
feat: add docstring linting via ruff and lint-docstrings skill

### DIFF
--- a/.claude/skills/lint-docstrings/SKILL.md
+++ b/.claude/skills/lint-docstrings/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: lint-docstrings
+description: Review and fix docstrings to follow Google-style conventions. Use when asked to check docstrings, format docstrings, or lint docstrings.
+allowed-tools: Read, Grep, Glob, Edit
+---
+
+# Docstring Linting
+
+Review files for docstring compliance and fix any issues.
+
+## Instructions
+
+1. Find the target files (specified by user, or recently modified files)
+2. Check each public function, class, and method for proper docstrings
+3. Report issues and fix them
+
+## Google-Style Docstring Format
+
+### Functions
+
+```python
+def calculate_percentile(value: float, distribution: list[float]) -> int:
+    """Calculate the percentile rank of a value within a distribution.
+
+    Args:
+        value: The value to rank.
+        distribution: Sorted list of values forming the reference distribution.
+
+    Returns:
+        Percentile rank from 0-100.
+
+    Raises:
+        ValueError: If distribution is empty.
+    """
+```
+
+Rules:
+- First line: imperative summary ending with period
+- Blank line before Args/Returns/Raises sections
+- Args: one line per param, name followed by colon and description
+- Returns: describe the return value (omit if None)
+- Raises: list exceptions that may be raised
+
+### Classes
+
+```python
+class PlayerMetrics:
+    """Container for computed player statistics.
+
+    Holds percentile rankings and z-scores for a player across
+    multiple statistical categories.
+
+    Attributes:
+        player_id: Unique identifier for the player.
+        percentiles: Dict mapping metric names to percentile values.
+        computed_at: Timestamp when metrics were calculated.
+    """
+```
+
+### Simple Functions (no args)
+
+```python
+def get_current_timestamp() -> datetime:
+    """Return the current UTC timestamp."""
+```
+
+One-liner docstrings: opening and closing quotes on same line.
+
+## Test Docstring Format
+
+Tests use a custom format with Fixtures, Scenario, and Expected sections:
+
+```python
+def test_player_slug_generation(db_session):
+    """Slug is generated from player name on create.
+
+    Fixtures:
+        db_session: Clean database session.
+
+    Scenario:
+        Create player with name "LeBron James".
+
+    Expected:
+        Player.slug equals "lebron-james".
+    """
+```
+
+```python
+def test_percentile_edge_case_empty_distribution():
+    """Percentile calculation handles empty distribution.
+
+    Scenario:
+        Call calculate_percentile with empty list.
+
+    Expected:
+        Raises ValueError with message about empty distribution.
+    """
+```
+
+Rules for tests:
+- First line: concise description of what's being tested
+- Fixtures: list test fixtures/dependencies used (if any)
+- Scenario: describe the setup and action
+- Expected: describe the expected outcome
+
+## Checklist
+
+When reviewing, check:
+- [ ] All public functions have docstrings
+- [ ] First line is imperative mood ("Return", "Calculate", not "Returns", "Calculates")
+- [ ] First line ends with period
+- [ ] Args section documents all parameters
+- [ ] Returns section present (unless function returns None)
+- [ ] One-liners fit on single line with quotes
+- [ ] Test docstrings follow Fixtures/Scenario/Expected format

--- a/app/cli/compute_similarity.py
+++ b/app/cli/compute_similarity.py
@@ -173,9 +173,10 @@ def compute_dimension_similarity(
     Dict[Tuple[int, int], float],
     Dict[Tuple[int, int], float],
 ]:
-    """
-    Returns distance_map, similarity_map, overlap_map keyed by (anchor, neighbor).
-    Anthro/Combine: standardized Euclidean (variance-weighted). Shooting: keep the same distance logic for now.
+    """Return distance_map, similarity_map, overlap_map keyed by (anchor, neighbor).
+
+    Anthro/Combine: standardized Euclidean (variance-weighted).
+    Shooting: keep the same distance logic for now.
     Pairs below overlap threshold are skipped.
     """
     distance_map: Dict[Tuple[int, int], float] = {}

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,4 @@
-"""
-Main entry point for FastAPI application.
-"""
+"""Main entry point for FastAPI application."""
 
 from contextlib import asynccontextmanager
 import os
@@ -98,7 +96,7 @@ async def handle_dbapi_errors(request, exc: DBAPIError):  # type: ignore[no-unty
 
 @app.get("/health")
 async def health_check():
-    """Health Check Endpoint"""
+    """Health check endpoint."""
     return {"status": "ok"}
 
 

--- a/app/models/fields.py
+++ b/app/models/fields.py
@@ -1,6 +1,4 @@
-"""
-Contains PyDantic fields to be used in various models.
-"""
+"""Contains Pydantic fields to be used in various models."""
 
 from enum import Enum
 from datetime import date

--- a/app/models/players.py
+++ b/app/models/players.py
@@ -76,7 +76,7 @@ class PlayerProfileRead(SQLModel):
     @computed_field  # type: ignore[misc]
     @property
     def height_formatted(self) -> Optional[str]:
-        """Format height as feet'inches\" (e.g., 6'9\")."""
+        r"""Format height as feet'inches" (e.g., 6'9")."""
         if not self.height_in:
             return None
         feet = self.height_in // 12
@@ -94,7 +94,7 @@ class PlayerProfileRead(SQLModel):
     @computed_field  # type: ignore[misc]
     @property
     def wingspan_formatted(self) -> Optional[str]:
-        """Format wingspan as feet'inches\" with half-inch precision."""
+        r"""Format wingspan as feet'inches" with half-inch precision."""
         if not self.wingspan_in:
             return None
         # Round to nearest half inch for display

--- a/app/schemas/base.py
+++ b/app/schemas/base.py
@@ -1,4 +1,4 @@
-"""Base Classes to Use as MixIns Elsewhere in App"""
+"""Base classes to use as mixins elsewhere in app."""
 
 from sqlmodel import SQLModel, Field
 from typing import Optional

--- a/app/services/metrics_service.py
+++ b/app/services/metrics_service.py
@@ -232,7 +232,6 @@ async def get_player_metrics(
 
     async def _metric_population_size(metric_key: str) -> Optional[int]:
         """Return the baseline population size used for the metric's distribution."""
-
         if snapshot is None:
             return None
 
@@ -448,7 +447,7 @@ def _format_number(value: float, decimals: int = 2) -> str:
 
 
 def _format_inches_to_feet(raw_inches: float) -> str:
-    """Convert inches to feet'inches\" with half-inch precision."""
+    r"""Convert inches to feet'inches" with half-inch precision."""
     rounded = round(raw_inches * 2) / 2
     feet = int(rounded) // 12
     inches = rounded % 12

--- a/app/services/news_ingestion_service.py
+++ b/app/services/news_ingestion_service.py
@@ -243,7 +243,6 @@ async def _fetch_existing_external_ids(
     external_ids: list[str],
 ) -> set[str]:
     """Fetch IDs that already exist for a source."""
-
     if not external_ids:
         return set()
 
@@ -257,7 +256,6 @@ async def _fetch_existing_external_ids(
 
 def _is_transient_db_error(exc: BaseException) -> bool:
     """Return True when the DB exception is likely fixed by retrying once."""
-
     if isinstance(exc, DBAPIError) and exc.connection_invalidated:
         return True
     text = str(exc)

--- a/app/utils/db_async.py
+++ b/app/utils/db_async.py
@@ -16,7 +16,6 @@ from app import schemas as schemas_pkg
 
 def load_schema_modules() -> None:
     """Ensure every app.schemas module is imported so metadata is current."""
-
     package_path = getattr(schemas_pkg, "__path__", [])
     package_prefix = schemas_pkg.__name__ + "."
     for _, module_name, _ in pkgutil.walk_packages(package_path, package_prefix):
@@ -45,7 +44,6 @@ def _normalize_db_url(url: str) -> URL:
 
 def _prepare_asyncpg_connection(url: str) -> Tuple[str, Dict[str, Any]]:
     """Strip unsupported query args and derive asyncpg connect kwargs."""
-
     normalized_url = _normalize_db_url(url)
     rendered_url = normalized_url.render_as_string(hide_password=False)
     split = urlsplit(rendered_url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,14 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "app.cli.compute_metrics"
 disable_error_code = "attr-defined,arg-type,call-overload,misc"
+
+[tool.ruff]
+exclude = ["alembic", "tests"]
+
+[tool.ruff.lint]
+extend-select = ["D"]
+# Ignore missing docstring rules - only enforce formatting on existing docstrings
+ignore = ["D100", "D101", "D102", "D103", "D104", "D105", "D106", "D107"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"


### PR DESCRIPTION
- Configure ruff D rules for Google-style docstring formatting
- Exclude tests/ and alembic/ from docstring checks
- Ignore missing docstring rules (D100-D107) to avoid noise on existing code
- Fix 16 existing docstring formatting issues
- Add /lint-docstrings skill for on-demand full Google-style enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)