### PR TITLE
feat: add X share buttons next to image export actions

### DIFF
--- a/app/static/css/export-modal.css
+++ b/app/static/css/export-modal.css
@@ -265,6 +265,14 @@
   height: 18px;
 }
 
+.share-btn {
+  color: #0f172a;
+}
+
+.share-btn:hover {
+  color: #0b1120;
+}
+
 /* Tooltip for export button */
 .export-btn[title] {
   position: relative;

--- a/app/static/js/h2h-comparison.js
+++ b/app/static/js/h2h-comparison.js
@@ -15,7 +15,8 @@ const H2HComparison = {
     defaultPlayerA: null,       // Default slug when not fixed (vs-arena mode)
     defaultPlayerB: null,       // Default Player B slug
     exportComponent: 'h2h',     // 'vs_arena' or 'h2h'
-    exportBtnId: 'h2hExportBtn' // Export button element ID
+    exportBtnId: 'h2hExportBtn', // Export button element ID
+    shareBtnId: 'h2hShareBtn'    // Share button element ID
   },
 
   // State
@@ -364,16 +365,15 @@ const H2HComparison = {
    */
   updateExportButtonState() {
     const exportBtn = document.getElementById(this.config.exportBtnId);
-    if (!exportBtn) return;
+    const shareBtn = document.getElementById(this.config.shareBtnId);
 
     const playerA = this.players?.[this.selectedPlayerA];
     const playerB = this.players?.[this.selectedPlayerB];
 
-    if (playerA?.id && playerB?.id) {
-      exportBtn.disabled = false;
-    } else {
-      exportBtn.disabled = true;
-    }
+    const enabled = Boolean(playerA?.id && playerB?.id);
+
+    if (exportBtn) exportBtn.disabled = !enabled;
+    if (shareBtn) shareBtn.disabled = !enabled;
   },
 
   /**
@@ -513,6 +513,37 @@ const H2HComparison = {
     if (typeof ExportModal !== 'undefined') {
       ExportModal.export(this.config.exportComponent, [playerA.id, playerB.id], context);
     }
+  },
+
+  /**
+   * Build share text for the current comparison
+   * @returns {string|null} Share text
+   */
+  buildShareText() {
+    const playerA = this.players[this.selectedPlayerA];
+    const playerB = this.players[this.selectedPlayerB];
+    if (!playerA?.name || !playerB?.name) return null;
+
+    const categoryLabels = {
+      anthropometrics: 'Anthropometrics',
+      combinePerformance: 'Combine Performance',
+      shooting: 'Shooting'
+    };
+
+    const categoryLabel = categoryLabels[this.currentCategory] || 'Anthropometrics';
+    return `DraftGuru: ${playerA.name} vs ${playerB.name} — ${categoryLabel} matchup`;
+  },
+
+  /**
+   * Share the current comparison via X/Twitter
+   */
+  share() {
+    if (typeof TweetShare === 'undefined') return;
+
+    const text = this.buildShareText();
+    if (!text) return;
+
+    TweetShare.open({ text, url: window.location.href });
   }
 };
 

--- a/app/static/js/home.js
+++ b/app/static/js/home.js
@@ -395,6 +395,13 @@ function exportVSArena() {
 }
 
 /**
+ * Share VS Arena comparison via X/Twitter
+ */
+function shareVSArena() {
+  H2HComparison.share();
+}
+
+/**
  * ============================================================================
  * APPLICATION INITIALIZATION
  * Initialize all modules when DOM is ready
@@ -409,7 +416,8 @@ document.addEventListener('DOMContentLoaded', () => {
     defaultPlayerA: 'cooper-flagg',
     defaultPlayerB: 'ace-bailey',
     exportComponent: 'vs_arena',
-    exportBtnId: 'vsArenaExportBtn'
+    exportBtnId: 'vsArenaExportBtn',
+    shareBtnId: 'vsArenaShareBtn'
   });
 
   FeedModule.init();

--- a/app/static/js/player-detail.js
+++ b/app/static/js/player-detail.js
@@ -1178,6 +1178,33 @@ function getPerformanceContext() {
 }
 
 /**
+ * Build a share text summary for performance metrics
+ */
+function buildPerformanceShareText() {
+  const player = window.PLAYER_DATA;
+  if (!player?.name) return null;
+
+  const context = getPerformanceContext();
+  const cohortLabels = {
+    current_draft: 'Current Draft Class',
+    all_time_draft: 'Historical Prospects',
+    current_nba: 'Active NBA Players',
+    all_time_nba: 'All-Time NBA'
+  };
+  const metricLabels = {
+    anthropometrics: 'Anthropometrics',
+    combine: 'Combine Performance',
+    shooting: 'Shooting'
+  };
+
+  const cohortLabel = cohortLabels[context.comparisonGroup] || 'Current Draft Class';
+  const metricLabel = metricLabels[context.metricGroup] || 'Anthropometrics';
+  const positionLabel = context.samePosition ? ' (position adjusted)' : '';
+
+  return `DraftGuru: ${player.name} performance — ${metricLabel}, ${cohortLabel}${positionLabel}`;
+}
+
+/**
  * Export performance metrics share card
  */
 function exportPerformance() {
@@ -1189,10 +1216,29 @@ function exportPerformance() {
 }
 
 /**
+ * Share performance metrics via X/Twitter
+ */
+function sharePerformance() {
+  if (typeof TweetShare === 'undefined') return;
+
+  const text = buildPerformanceShareText();
+  if (!text) return;
+
+  TweetShare.open({ text, url: window.location.href });
+}
+
+/**
  * Export head-to-head comparison share card
  */
 function exportH2H() {
   H2HComparison.export();
+}
+
+/**
+ * Share head-to-head comparison via X/Twitter
+ */
+function shareH2H() {
+  H2HComparison.share();
 }
 
 /**
@@ -1223,6 +1269,32 @@ function getCompsContext() {
 }
 
 /**
+ * Build a share text summary for comps
+ */
+function buildCompsShareText() {
+  const player = window.PLAYER_DATA;
+  if (!player?.name) return null;
+
+  const context = getCompsContext();
+  const cohortLabels = {
+    current_draft: 'Current Draft Class',
+    all_time_draft: 'Historical Prospects',
+    current_nba: 'Active NBA Players'
+  };
+  const metricLabels = {
+    anthropometrics: 'Anthropometrics',
+    combine: 'Combine Performance',
+    shooting: 'Shooting'
+  };
+
+  const cohortLabel = cohortLabels[context.comparisonGroup] || 'Current Draft Class';
+  const metricLabel = metricLabels[context.metricGroup] || 'Anthropometrics';
+  const positionLabel = context.samePosition ? ' (same position only)' : '';
+
+  return `DraftGuru: ${player.name} comps — ${metricLabel}, ${cohortLabel}${positionLabel}`;
+}
+
+/**
  * Export player comparisons share card
  */
 function exportComps() {
@@ -1231,6 +1303,18 @@ function exportComps() {
 
   const context = getCompsContext();
   ExportModal.export('comps', [player.id], context);
+}
+
+/**
+ * Share player comparisons via X/Twitter
+ */
+function shareComps() {
+  if (typeof TweetShare === 'undefined') return;
+
+  const text = buildCompsShareText();
+  if (!text) return;
+
+  TweetShare.open({ text, url: window.location.href });
 }
 
 /**
@@ -1253,7 +1337,8 @@ document.addEventListener('DOMContentLoaded', () => {
       playerAId: window.PLAYER_DATA.id,
       playerAPhoto: window.PLAYER_DATA.photo_url,
       exportComponent: 'h2h',
-      exportBtnId: 'h2hExportBtn'
+      exportBtnId: 'h2hExportBtn',
+      shareBtnId: 'h2hShareBtn'
     });
   }
 

--- a/app/static/js/tweet-share.js
+++ b/app/static/js/tweet-share.js
@@ -1,0 +1,23 @@
+/**
+ * Tweet Share - open an X/Twitter share window with prefilled text
+ */
+const TweetShare = {
+  /**
+   * Open the X/Twitter intent with text and URL.
+   * @param {Object} options - Share options
+   * @param {string} options.text - Tweet text
+   * @param {string} options.url - URL to share
+   */
+  open({ text, url }) {
+    const base = 'https://twitter.com/intent/tweet';
+    const params = new URLSearchParams();
+
+    if (text) params.set('text', text);
+    if (url) params.set('url', url);
+
+    const shareUrl = `${base}?${params.toString()}`;
+    window.open(shareUrl, '_blank', 'noopener,noreferrer');
+  }
+};
+
+window.TweetShare = TweetShare;

--- a/app/static/main.css
+++ b/app/static/main.css
@@ -106,6 +106,12 @@ body {
   margin-bottom: 0;
 }
 
+.section-header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .section-header {
   font-size: 1.5rem;
   font-weight: 600;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -25,6 +25,7 @@
   <!-- Global Scripts -->
   <script src="{{ url_for('static', path='main.js') }}"></script>
   <script src="{{ url_for('static', path='js/export-modal.js') }}"></script>
+  <script src="{{ url_for('static', path='js/tweet-share.js') }}"></script>
   <script src="{{ url_for('static', path='js/h2h-comparison.js') }}"></script>
 
   {% block extra_js %}{% endblock %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -41,13 +41,20 @@
         </svg>
         VS Arena
       </h2>
-      <button class="export-btn" title="Save as Image" onclick="exportVSArena()" id="vsArenaExportBtn" disabled>
-        <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
-          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-          <polyline points="7 10 12 15 17 10"/>
-          <line x1="12" y1="15" x2="12" y2="3"/>
-        </svg>
-      </button>
+      <div class="section-header-actions">
+        <button class="export-btn" title="Save as Image" onclick="exportVSArena()" id="vsArenaExportBtn" disabled>
+          <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+            <polyline points="7 10 12 15 17 10"/>
+            <line x1="12" y1="15" x2="12" y2="3"/>
+          </svg>
+        </button>
+        <button class="export-btn share-btn" title="Share on X" onclick="shareVSArena()" id="vsArenaShareBtn" disabled>
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M18.87 2H22l-7.33 8.38L23 22h-6.87l-5.37-7.03L4.6 22H1.46l7.9-9.03L1 2h7.03l4.86 6.38L18.87 2Zm-1.2 18.02h1.9L7.46 3.88H5.48l12.19 16.14Z"/>
+          </svg>
+        </button>
+      </div>
     </div>
     <p class="section-subtitle">Compare top draft prospects head-to-head across key metrics</p>
 

--- a/app/templates/player-detail.html
+++ b/app/templates/player-detail.html
@@ -187,13 +187,20 @@
         </svg>
         Performance Metrics
       </h2>
-      <button class="export-btn" title="Save as Image" onclick="exportPerformance()">
-        <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
-          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-          <polyline points="7 10 12 15 17 10"/>
-          <line x1="12" y1="15" x2="12" y2="3"/>
-        </svg>
-      </button>
+      <div class="section-header-actions">
+        <button class="export-btn" title="Save as Image" onclick="exportPerformance()">
+          <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+            <polyline points="7 10 12 15 17 10"/>
+            <line x1="12" y1="15" x2="12" y2="3"/>
+          </svg>
+        </button>
+        <button class="export-btn share-btn" title="Share on X" onclick="sharePerformance()">
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M18.87 2H22l-7.33 8.38L23 22h-6.87l-5.37-7.03L4.6 22H1.46l7.9-9.03L1 2h7.03l4.86 6.38L18.87 2Zm-1.2 18.02h1.9L7.46 3.88H5.48l12.19 16.14Z"/>
+          </svg>
+        </button>
+      </div>
     </div>
     <p class="section-subtitle">Percentile rankings vs current draft class</p>
 
@@ -249,13 +256,20 @@
         </svg>
         Head-to-Head Comparison
       </h2>
-      <button class="export-btn" title="Save as Image" onclick="exportH2H()" id="h2hExportBtn" disabled>
-        <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
-          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-          <polyline points="7 10 12 15 17 10"/>
-          <line x1="12" y1="15" x2="12" y2="3"/>
-        </svg>
-      </button>
+      <div class="section-header-actions">
+        <button class="export-btn" title="Save as Image" onclick="exportH2H()" id="h2hExportBtn" disabled>
+          <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+            <polyline points="7 10 12 15 17 10"/>
+            <line x1="12" y1="15" x2="12" y2="3"/>
+          </svg>
+        </button>
+        <button class="export-btn share-btn" title="Share on X" onclick="shareH2H()" id="h2hShareBtn" disabled>
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M18.87 2H22l-7.33 8.38L23 22h-6.87l-5.37-7.03L4.6 22H1.46l7.9-9.03L1 2h7.03l4.86 6.38L18.87 2Zm-1.2 18.02h1.9L7.46 3.88H5.48l12.19 16.14Z"/>
+          </svg>
+        </button>
+      </div>
     </div>
     <p class="section-subtitle">Compare {{ player.name }} against other prospects</p>
 
@@ -351,13 +365,20 @@
       <h2 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-cyan);">
         Player Comparisons
       </h2>
-      <button class="export-btn" title="Save as Image" onclick="exportComps()">
-        <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
-          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-          <polyline points="7 10 12 15 17 10"/>
-          <line x1="12" y1="15" x2="12" y2="3"/>
-        </svg>
-      </button>
+      <div class="section-header-actions">
+        <button class="export-btn" title="Save as Image" onclick="exportComps()">
+          <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+            <polyline points="7 10 12 15 17 10"/>
+            <line x1="12" y1="15" x2="12" y2="3"/>
+          </svg>
+        </button>
+        <button class="export-btn share-btn" title="Share on X" onclick="shareComps()">
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M18.87 2H22l-7.33 8.38L23 22h-6.87l-5.37-7.03L4.6 22H1.46l7.9-9.03L1 2h7.03l4.86 6.38L18.87 2Zm-1.2 18.02h1.9L7.46 3.88H5.48l12.19 16.14Z"/>
+          </svg>
+        </button>
+      </div>
     </div>
     <p class="section-subtitle">Similar players based on physical and statistical profiles</p>
 


### PR DESCRIPTION
### Motivation
- Provide a lightweight way for users to share app content on X/Twitter from the same UI where they download share-card images. 
- Buttons should appear alongside existing image-download icons and include the same contextual information as the image exports. 
- Keep the implementation small and frontend-only so it fits the app's low-JS, no-build philosophy.

### Description
- Added share buttons in the section header action areas for VS Arena, Performance, H2H, and Comps by updating `app/templates/home.html` and `app/templates/player-detail.html` and grouping actions with a new `.section-header-actions` wrapper. 
- Implemented a small `app/static/js/tweet-share.js` helper that opens the X/Twitter intent URL and wired share actions (`shareVSArena`, `sharePerformance`, `shareH2H`, `shareComps`) in `app/static/js/home.js` and `app/static/js/player-detail.js`. 
- Extended `H2HComparison` (`app/static/js/h2h-comparison.js`) to accept a `shareBtnId`, build a contextual share message via `buildShareText()`, and expose `share()` that calls the tweet helper; also added enable/disable sync between export and share buttons. 
- Added minimal styling for the share variant (`.share-btn`) and header action layout in `app/static/css/export-modal.css` and `app/static/main.css`, and included the new script via `app/templates/base.html`.

### Testing
- Ran `mypy app --ignore-missing-imports` which completed successfully with no reported issues. 
- Ran unit tests with `pytest tests/unit -q` which failed during collection due to missing runtime dependencies (`pydantic`, `sqlalchemy`, `httpx`) in the environment. 
- Attempted `make precommit` which could not run because `pre-commit` is not installed in the environment and network access prevented installing it. 
- Attempted to start dev server with `make dev` which failed because `uvicorn` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69643e6bf2248326938d2f25c892acc0)