### PR TITLE
feat: add tweet sharing for share cards

### DIFF
--- a/app/static/css/export-modal.css
+++ b/app/static/css/export-modal.css
@@ -260,6 +260,42 @@
   color: #64748b;
 }
 
+.tweet-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid rgba(6, 182, 212, 0.4);
+  border-radius: 8px;
+  color: var(--color-accent-cyan);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.tweet-btn:hover {
+  background: rgba(6, 182, 212, 0.08);
+  border-color: rgba(6, 182, 212, 0.7);
+  color: #0891b2;
+}
+
+.tweet-btn:active {
+  background: rgba(6, 182, 212, 0.16);
+}
+
+.tweet-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.tweet-btn:disabled:hover {
+  background: transparent;
+  border-color: rgba(6, 182, 212, 0.4);
+  color: var(--color-accent-cyan);
+}
+
 .export-btn svg {
   width: 18px;
   height: 18px;

--- a/app/static/js/home.js
+++ b/app/static/js/home.js
@@ -395,6 +395,13 @@ function exportVSArena() {
 }
 
 /**
+ * Share VS Arena comparison as a tweet
+ */
+function tweetVSArena() {
+  H2HComparison.shareTweet();
+}
+
+/**
  * ============================================================================
  * APPLICATION INITIALIZATION
  * Initialize all modules when DOM is ready
@@ -409,7 +416,8 @@ document.addEventListener('DOMContentLoaded', () => {
     defaultPlayerA: 'cooper-flagg',
     defaultPlayerB: 'ace-bailey',
     exportComponent: 'vs_arena',
-    exportBtnId: 'vsArenaExportBtn'
+    exportBtnId: 'vsArenaExportBtn',
+    tweetBtnId: 'vsArenaTweetBtn'
   });
 
   FeedModule.init();

--- a/app/static/js/player-detail.js
+++ b/app/static/js/player-detail.js
@@ -1189,10 +1189,39 @@ function exportPerformance() {
 }
 
 /**
+ * Share performance metrics as a tweet
+ */
+function tweetPerformance() {
+  const player = window.PLAYER_DATA;
+  if (!player?.id || typeof TweetShare === 'undefined') return;
+
+  const context = getPerformanceContext();
+  const summary = TweetShare.formatContextSummary(context);
+  const text = summary
+    ? `${player.name} — Performance • ${summary}`
+    : `${player.name} — Performance`;
+
+  TweetShare.share({
+    component: 'performance',
+    playerIds: [player.id],
+    context,
+    text,
+    pageUrl: window.location.href
+  });
+}
+
+/**
  * Export head-to-head comparison share card
  */
 function exportH2H() {
   H2HComparison.export();
+}
+
+/**
+ * Share head-to-head comparison as a tweet
+ */
+function tweetH2H() {
+  H2HComparison.shareTweet();
 }
 
 /**
@@ -1234,6 +1263,28 @@ function exportComps() {
 }
 
 /**
+ * Share comparisons as a tweet
+ */
+function tweetComps() {
+  const player = window.PLAYER_DATA;
+  if (!player?.id || typeof TweetShare === 'undefined') return;
+
+  const context = getCompsContext();
+  const summary = TweetShare.formatContextSummary(context);
+  const text = summary
+    ? `${player.name} — Comparisons • ${summary}`
+    : `${player.name} — Comparisons`;
+
+  TweetShare.share({
+    component: 'comps',
+    playerIds: [player.id],
+    context,
+    text,
+    pageUrl: window.location.href
+  });
+}
+
+/**
  * ============================================================================
  * APPLICATION INITIALIZATION
  * Initialize all modules when DOM is ready
@@ -1253,7 +1304,8 @@ document.addEventListener('DOMContentLoaded', () => {
       playerAId: window.PLAYER_DATA.id,
       playerAPhoto: window.PLAYER_DATA.photo_url,
       exportComponent: 'h2h',
-      exportBtnId: 'h2hExportBtn'
+      exportBtnId: 'h2hExportBtn',
+      tweetBtnId: 'h2hTweetBtn'
     });
   }
 

--- a/app/static/js/tweet-share.js
+++ b/app/static/js/tweet-share.js
@@ -1,0 +1,115 @@
+/**
+ * Tweet Share - Generate shareable tweet links with exported images
+ */
+
+const TweetShare = {
+  /**
+   * Format comparison group for display
+   * @param {string} group
+   * @returns {string}
+   */
+  formatComparisonGroup(group) {
+    const map = {
+      current_draft: 'Current Draft Class',
+      all_time_draft: 'Historical Prospects',
+      current_nba: 'Active NBA Players',
+      all_time_nba: 'All-Time NBA'
+    };
+    return map[group] || 'Draft Prospects';
+  },
+
+  /**
+   * Format metric group for display
+   * @param {string} metric
+   * @returns {string}
+   */
+  formatMetricGroup(metric) {
+    const map = {
+      anthropometrics: 'Anthropometrics',
+      combine: 'Combine Performance',
+      shooting: 'Shooting'
+    };
+    return map[metric] || 'Metrics';
+  },
+
+  /**
+   * Format position filter for display
+   * @param {boolean} samePosition
+   * @returns {string}
+   */
+  formatPositionScope(samePosition) {
+    return samePosition ? 'Same Position' : 'All Positions';
+  },
+
+  /**
+   * Build context summary for tweet text
+   * @param {Object} context
+   * @returns {string}
+   */
+  formatContextSummary(context) {
+    if (!context) return 'Draft Prospects';
+    const group = this.formatComparisonGroup(context.comparisonGroup);
+    const metric = this.formatMetricGroup(context.metricGroup);
+    const position = this.formatPositionScope(context.samePosition);
+    return `${group} • ${metric} • ${position}`;
+  },
+
+  /**
+   * Open a tweet intent URL in a new window
+   * @param {string} text
+   * @param {string} url
+   */
+  openTweetIntent(text, url) {
+    const tweetUrl = new URL('https://twitter.com/intent/tweet');
+    if (text) {
+      tweetUrl.searchParams.set('text', text);
+    }
+    if (url) {
+      tweetUrl.searchParams.set('url', url);
+    }
+    window.open(tweetUrl.toString(), '_blank', 'noopener');
+  },
+
+  /**
+   * Generate an export image and open a tweet intent with it
+   * @param {Object} options
+   * @param {string} options.component
+   * @param {number[]} options.playerIds
+   * @param {Object} options.context
+   * @param {string} options.text
+   * @param {string} [options.pageUrl]
+   */
+  async share({ component, playerIds, context, text, pageUrl }) {
+    const pageLink = pageUrl || window.location.href;
+    const tweetText = `${text || 'DraftGuru'} ${pageLink}`.trim();
+
+    try {
+      const response = await fetch('/api/export/image', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          component,
+          player_ids: playerIds,
+          context: {
+            comparison_group: context?.comparisonGroup || 'current_draft',
+            same_position: context?.samePosition || false,
+            metric_group: context?.metricGroup || 'anthropometrics'
+          }
+        })
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.detail || `HTTP ${response.status}`);
+      }
+
+      const data = await response.json();
+      this.openTweetIntent(tweetText, data.url);
+    } catch (err) {
+      console.error('Tweet share failed:', err);
+      this.openTweetIntent(tweetText, pageLink);
+    }
+  }
+};
+
+window.TweetShare = TweetShare;

--- a/app/static/main.css
+++ b/app/static/main.css
@@ -102,6 +102,12 @@ body {
   gap: 1rem;
 }
 
+.section-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .section-header-row .section-header {
   margin-bottom: 0;
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -25,6 +25,7 @@
   <!-- Global Scripts -->
   <script src="{{ url_for('static', path='main.js') }}"></script>
   <script src="{{ url_for('static', path='js/export-modal.js') }}"></script>
+  <script src="{{ url_for('static', path='js/tweet-share.js') }}"></script>
   <script src="{{ url_for('static', path='js/h2h-comparison.js') }}"></script>
 
   {% block extra_js %}{% endblock %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -41,13 +41,21 @@
         </svg>
         VS Arena
       </h2>
-      <button class="export-btn" title="Save as Image" onclick="exportVSArena()" id="vsArenaExportBtn" disabled>
-        <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
-          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-          <polyline points="7 10 12 15 17 10"/>
-          <line x1="12" y1="15" x2="12" y2="3"/>
-        </svg>
-      </button>
+      <div class="section-actions">
+        <button class="export-btn" title="Save as Image" onclick="exportVSArena()" id="vsArenaExportBtn" disabled>
+          <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+            <polyline points="7 10 12 15 17 10"/>
+            <line x1="12" y1="15" x2="12" y2="3"/>
+          </svg>
+        </button>
+        <button class="tweet-btn" title="Share on X" onclick="tweetVSArena()" id="vsArenaTweetBtn" disabled>
+          <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
+            <line x1="5" y1="5" x2="19" y2="19"></line>
+            <line x1="19" y1="5" x2="5" y2="19"></line>
+          </svg>
+        </button>
+      </div>
     </div>
     <p class="section-subtitle">Compare top draft prospects head-to-head across key metrics</p>
 

--- a/app/templates/player-detail.html
+++ b/app/templates/player-detail.html
@@ -187,13 +187,21 @@
         </svg>
         Performance Metrics
       </h2>
-      <button class="export-btn" title="Save as Image" onclick="exportPerformance()">
-        <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
-          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-          <polyline points="7 10 12 15 17 10"/>
-          <line x1="12" y1="15" x2="12" y2="3"/>
-        </svg>
-      </button>
+      <div class="section-actions">
+        <button class="export-btn" title="Save as Image" onclick="exportPerformance()">
+          <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+            <polyline points="7 10 12 15 17 10"/>
+            <line x1="12" y1="15" x2="12" y2="3"/>
+          </svg>
+        </button>
+        <button class="tweet-btn" title="Share on X" onclick="tweetPerformance()">
+          <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
+            <line x1="5" y1="5" x2="19" y2="19"></line>
+            <line x1="19" y1="5" x2="5" y2="19"></line>
+          </svg>
+        </button>
+      </div>
     </div>
     <p class="section-subtitle">Percentile rankings vs current draft class</p>
 
@@ -249,13 +257,21 @@
         </svg>
         Head-to-Head Comparison
       </h2>
-      <button class="export-btn" title="Save as Image" onclick="exportH2H()" id="h2hExportBtn" disabled>
-        <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
-          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-          <polyline points="7 10 12 15 17 10"/>
-          <line x1="12" y1="15" x2="12" y2="3"/>
-        </svg>
-      </button>
+      <div class="section-actions">
+        <button class="export-btn" title="Save as Image" onclick="exportH2H()" id="h2hExportBtn" disabled>
+          <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+            <polyline points="7 10 12 15 17 10"/>
+            <line x1="12" y1="15" x2="12" y2="3"/>
+          </svg>
+        </button>
+        <button class="tweet-btn" title="Share on X" onclick="tweetH2H()" id="h2hTweetBtn" disabled>
+          <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
+            <line x1="5" y1="5" x2="19" y2="19"></line>
+            <line x1="19" y1="5" x2="5" y2="19"></line>
+          </svg>
+        </button>
+      </div>
     </div>
     <p class="section-subtitle">Compare {{ player.name }} against other prospects</p>
 
@@ -351,13 +367,21 @@
       <h2 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-cyan);">
         Player Comparisons
       </h2>
-      <button class="export-btn" title="Save as Image" onclick="exportComps()">
-        <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
-          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-          <polyline points="7 10 12 15 17 10"/>
-          <line x1="12" y1="15" x2="12" y2="3"/>
-        </svg>
-      </button>
+      <div class="section-actions">
+        <button class="export-btn" title="Save as Image" onclick="exportComps()">
+          <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+            <polyline points="7 10 12 15 17 10"/>
+            <line x1="12" y1="15" x2="12" y2="3"/>
+          </svg>
+        </button>
+        <button class="tweet-btn" title="Share on X" onclick="tweetComps()">
+          <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none">
+            <line x1="5" y1="5" x2="19" y2="19"></line>
+            <line x1="19" y1="5" x2="5" y2="19"></line>
+          </svg>
+        </button>
+      </div>
     </div>
     <p class="section-subtitle">Similar players based on physical and statistical profiles</p>
 


### PR DESCRIPTION
### Motivation
- Provide a one-click way for users to share app content to X (Twitter) alongside the existing image download flow.
- Tweet actions should surface in the same places as current image export controls and include the same export/context metadata. 
- Keep the frontend approach minimal and JS-driven to match the app's lightweight, no-build frontend philosophy.

### Description
- Added a new client-side helper `app/static/js/tweet-share.js` that requests an export image via the existing export API and opens a tweet intent with the generated image URL. 
- Placed tweet buttons next to export buttons in `player-detail.html` and `home.html` and wired new `tweet*()` functions in `app/static/js/player-detail.js` and `app/static/js/home.js`. 
- Extended `H2HComparison` (`app/static/js/h2h-comparison.js`) to manage tweet button state and surface a `shareTweet()` flow that builds contextual text and delegates to `TweetShare.share()`. 
- Added UI styling and layout tweaks in `app/static/css/export-modal.css` and `app/static/main.css`, and included the tweet-share script in `app/templates/base.html`.

### Testing
- Ran `mypy app --ignore-missing-imports` and it completed without type errors for the checked files. 
- Ran `pytest tests/unit -q` but test collection failed due to missing external test dependencies (`httpx`, `pydantic`, `sqlalchemy`). 
- Attempted `make precommit` which failed in this environment because `pre-commit` is not installed, so repo-level precommit hooks were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69643e6bf2248326938d2f25c892acc0)