### PR TITLE
fix: link H2H comparison photos to player pages

### DIFF
--- a/app/static/js/h2h-comparison.js
+++ b/app/static/js/h2h-comparison.js
@@ -403,11 +403,21 @@ const H2HComparison = {
     const photoNameB = document.getElementById('h2hPhotoNameB');
     const headerA = document.getElementById('h2hHeaderA');
     const headerB = document.getElementById('h2hHeaderB');
+    const photoLinkA = document.getElementById('h2hPhotoLinkA');
+    const photoLinkB = document.getElementById('h2hPhotoLinkB');
 
     if (photoNameA) photoNameA.textContent = nameA;
     if (photoNameB) photoNameB.textContent = nameB;
     if (headerA) headerA.textContent = nameA;
     if (headerB) headerB.textContent = nameB;
+    if (photoLinkA) {
+      photoLinkA.href = `/players/${this.selectedPlayerA}`;
+      photoLinkA.setAttribute('aria-label', `View ${nameA} details`);
+    }
+    if (photoLinkB) {
+      photoLinkB.href = `/players/${this.selectedPlayerB}`;
+      photoLinkB.setAttribute('aria-label', `View ${nameB} details`);
+    }
 
     // Update similarity badge
     const badge = document.getElementById('h2hSimilarityBadge');

--- a/app/static/main.css
+++ b/app/static/main.css
@@ -584,6 +584,14 @@ body {
   text-align: center;
 }
 
+.h2h-photo-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  color: inherit;
+}
+
 .h2h-player-photo img {
   width: 150px;
   height: 150px;

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -180,12 +180,16 @@
           <!-- Player Photos Row -->
           <div class="h2h-photos-row">
             <div class="h2h-player-photo">
-              <img id="h2hPhotoA" src="https://placehold.co/200x200/edf2f7/1f2937?text=Player+A" alt="Player A" />
+              <a id="h2hPhotoLinkA" class="h2h-photo-link" href="#" aria-label="View Player A details">
+                <img id="h2hPhotoA" src="https://placehold.co/200x200/edf2f7/1f2937?text=Player+A" alt="Player A" />
+              </a>
               <div class="h2h-photo-name" id="h2hPhotoNameA">Player A</div>
             </div>
             <div class="h2h-photos-spacer"></div>
             <div class="h2h-player-photo">
-              <img id="h2hPhotoB" src="https://placehold.co/200x200/edf2f7/1f2937?text=Player+B" alt="Player B" />
+              <a id="h2hPhotoLinkB" class="h2h-photo-link" href="#" aria-label="View Player B details">
+                <img id="h2hPhotoB" src="https://placehold.co/200x200/edf2f7/1f2937?text=Player+B" alt="Player B" />
+              </a>
               <div class="h2h-photo-name" id="h2hPhotoNameB">Player B</div>
             </div>
           </div>

--- a/app/templates/player-detail.html
+++ b/app/templates/player-detail.html
@@ -321,12 +321,16 @@
           <!-- Player Photos Row -->
           <div class="h2h-photos-row">
             <div class="h2h-player-photo">
-              <img id="h2hPhotoA" src="{{ player.photo_url }}" alt="{{ player.name }}" />
+              <a id="h2hPhotoLinkA" class="h2h-photo-link" href="/players/{{ player.slug }}" aria-label="View {{ player.name }} details">
+                <img id="h2hPhotoA" src="{{ player.photo_url }}" alt="{{ player.name }}" />
+              </a>
               <div class="h2h-photo-name" id="h2hPhotoNameA">{{ player.name }}</div>
             </div>
             <div class="h2h-photos-spacer"></div>
             <div class="h2h-player-photo">
-              <img id="h2hPhotoB" src="https://placehold.co/200x200/edf2f7/1f2937?text=Player+B" alt="Player B" />
+              <a id="h2hPhotoLinkB" class="h2h-photo-link" href="#" aria-label="View Player B details">
+                <img id="h2hPhotoB" src="https://placehold.co/200x200/edf2f7/1f2937?text=Player+B" alt="Player B" />
+              </a>
               <div class="h2h-photo-name" id="h2hPhotoNameB">Player B</div>
             </div>
           </div>


### PR DESCRIPTION
### Motivation

- Make head-to-head player photos in the VS Arena (home) and the Player Detail H2H card clickable so users can navigate to the referenced player detail page without changing the visual layout.

### Description

- Wrap H2H player images in anchors in `app/templates/home.html` and `app/templates/player-detail.html` and add `id`s (`h2hPhotoLinkA`/`h2hPhotoLinkB`) for runtime updates.
- Update `app/static/js/h2h-comparison.js` to set the photo link `href` and `aria-label` dynamically during `renderComparison()` so links point to `/players/{slug}` for the selected players.
- Add a neutral anchor style `.h2h-photo-link` in `app/static/main.css` to ensure the new anchors do not alter the existing image layout or visual styling.

### Testing

- Ran `make precommit` which failed locally because the `pre-commit` tool is not installed in the environment. 
- Ran `mypy app --ignore-missing-imports` which completed successfully with no issues reported. 
- Ran `pytest tests/unit -q` which failed during collection due to missing runtime test dependencies (`httpx`, `pydantic`, `sqlalchemy`) in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d21df7ec4832697fd812d0b55317c)