### PR TITLE
feat: add recency-weighted trending scores, sparklines, thumbnails, a…

### DIFF
--- a/alembic/versions/h7i8j9k0l1m2_add_player_mentions.py
+++ b/alembic/versions/h7i8j9k0l1m2_add_player_mentions.py
@@ -1,0 +1,52 @@
+"""Add player mentions junction table and is_stub column.
+
+Revision ID: h7i8j9k0l1m2
+Revises: g6h7i8j9k0l1
+Create Date: 2026-02-08
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op  # type: ignore[attr-defined]
+
+# revision identifiers, used by Alembic.
+revision: str = "h7i8j9k0l1m2"
+down_revision: Union[str, None] = "g6h7i8j9k0l1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add is_stub column to players_master
+    op.add_column(
+        "players_master",
+        sa.Column("is_stub", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+
+    # Create news_item_player_mentions junction table
+    op.create_table(
+        "news_item_player_mentions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("news_item_id", sa.Integer(), nullable=False),
+        sa.Column("player_id", sa.Integer(), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["news_item_id"], ["news_items.id"], name="fk_mentions_news_item"),
+        sa.ForeignKeyConstraint(["player_id"], ["players_master.id"], name="fk_mentions_player"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("news_item_id", "player_id", name="uq_news_item_player_mention"),
+    )
+
+    # Create indexes
+    op.create_index("ix_news_item_player_mentions_news_item_id", "news_item_player_mentions", ["news_item_id"])
+    op.create_index("ix_news_item_player_mentions_player_id", "news_item_player_mentions", ["player_id"])
+    op.create_index("ix_mentions_player_created", "news_item_player_mentions", ["player_id", "created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_mentions_player_created", table_name="news_item_player_mentions")
+    op.drop_index("ix_news_item_player_mentions_player_id", table_name="news_item_player_mentions")
+    op.drop_index("ix_news_item_player_mentions_news_item_id", table_name="news_item_player_mentions")
+    op.drop_table("news_item_player_mentions")
+    op.drop_column("players_master", "is_stub")

--- a/app/models/news.py
+++ b/app/models/news.py
@@ -21,6 +21,7 @@ class NewsItemRead(SQLModel):
     time: str  # Relative time "2h", "1d"
     tag: str  # "Riser", "Faller", etc.
     read_more_text: str  # "Read at Floor and Ceiling"
+    is_player_specific: bool = False  # True when article mentions this player
 
 
 class NewsFeedResponse(SQLModel):
@@ -61,4 +62,5 @@ class IngestionResult(SQLModel):
     sources_processed: int
     items_added: int
     items_skipped: int
+    mentions_added: int = 0
     errors: list[str]

--- a/app/routes/news.py
+++ b/app/routes/news.py
@@ -21,7 +21,7 @@ from app.models.news import (
 )
 from app.schemas.news_sources import FeedType, NewsSource
 from app.services.news_ingestion_service import run_ingestion_cycle
-from app.services.news_service import get_news_feed
+from app.services.news_service import get_news_feed, get_player_news_feed
 from app.services.staff_authz import require_dataset_permission
 from app.utils.db_async import SessionLocal, dispose_engine, get_session
 
@@ -38,13 +38,20 @@ async def list_news(
     """Fetch paginated news feed.
 
     Returns news items with AI-generated summaries, sorted by published date.
-    Optionally filter by player ID for player-specific news.
+    When player_id is provided, returns player-specific feed (mentions + direct
+    association) with general feed backfill.
     """
+    if player_id is not None:
+        return await get_player_news_feed(
+            db=db,
+            player_id=player_id,
+            limit=limit,
+            offset=offset,
+        )
     return await get_news_feed(
         db=db,
         limit=limit,
         offset=offset,
-        player_id=player_id,
     )
 
 

--- a/app/schemas/news_item_player_mentions.py
+++ b/app/schemas/news_item_player_mentions.py
@@ -1,0 +1,42 @@
+"""Junction table for news item ↔ player mention associations."""
+
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import Index, UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+
+class MentionSource(str, Enum):
+    """How a player mention was detected."""
+
+    AI = "ai"
+    BACKFILL = "backfill"
+    MANUAL = "manual"
+
+
+class NewsItemPlayerMention(SQLModel, table=True):  # type: ignore[call-arg]
+    """Tracks which players are mentioned in which news articles."""
+
+    __tablename__ = "news_item_player_mentions"
+    __table_args__ = (
+        UniqueConstraint(
+            "news_item_id",
+            "player_id",
+            name="uq_news_item_player_mention",
+        ),
+        Index(
+            "ix_mentions_player_created",
+            "player_id",
+            "created_at",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    news_item_id: int = Field(foreign_key="news_items.id", index=True)
+    player_id: int = Field(foreign_key="players_master.id", index=True)
+    source: MentionSource = Field(description="Detection method")
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC).replace(tzinfo=None)
+    )

--- a/app/schemas/players_master.py
+++ b/app/schemas/players_master.py
@@ -40,6 +40,9 @@ class PlayerMaster(SQLModel, table=True):  # type: ignore[call-arg]
     nba_debut_date: Optional[date] = Field(default=None)
     nba_debut_season: Optional[str] = Field(default=None, index=True)
 
+    # Stub flag: auto-created players with just a name, pending enrichment
+    is_stub: bool = Field(default=False)
+
     # Image generation
     reference_image_url: Optional[str] = Field(
         default=None,

--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -3,15 +3,32 @@
 Handles fetching and formatting news items for display.
 """
 
-from datetime import datetime, timezone
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from sqlalchemy import func, select
+from sqlalchemy import Float, cast, func, literal, select, union
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.news import NewsFeedResponse, NewsItemRead
+from app.schemas.news_item_player_mentions import NewsItemPlayerMention
 from app.schemas.news_items import NewsItem
 from app.schemas.news_sources import NewsSource
+from app.schemas.players_master import PlayerMaster
+
+# Shared column list for all news feed queries (general, hero, player-specific).
+# Keep in sync with _row_to_news_item_read() which maps these columns.
+_NEWS_FEED_COLUMNS = [
+    NewsItem.id,
+    NewsItem.title,
+    NewsItem.summary,
+    NewsItem.url,
+    NewsItem.image_url,
+    NewsItem.author,
+    NewsItem.tag,
+    NewsItem.published_at,
+    NewsSource.display_name.label("source_name"),  # type: ignore[attr-defined]
+]
 
 
 def format_relative_time(dt: datetime) -> str:
@@ -66,7 +83,6 @@ async def get_news_feed(
     db: AsyncSession,
     limit: int = 20,
     offset: int = 0,
-    player_id: Optional[int] = None,
 ) -> NewsFeedResponse:
     """Fetch paginated news feed with joined source info.
 
@@ -74,40 +90,19 @@ async def get_news_feed(
         db: Async database session
         limit: Maximum items to return
         offset: Number of items to skip
-        player_id: Optional filter by player ID
 
     Returns:
         NewsFeedResponse with items and pagination info
     """
     # Build base query with JOIN
     base_query = (
-        select(
-            NewsItem.id,
-            NewsItem.title,
-            NewsItem.summary,
-            NewsItem.url,
-            NewsItem.image_url,
-            NewsItem.author,
-            NewsItem.tag,
-            NewsItem.published_at,
-            NewsSource.display_name.label("source_name"),  # type: ignore[attr-defined]
-        )  # type: ignore[call-overload]
+        select(*_NEWS_FEED_COLUMNS)  # type: ignore[call-overload]
         .select_from(NewsItem)
-        .join(NewsSource, NewsSource.id == NewsItem.source_id)
+        .join(NewsSource, NewsSource.id == NewsItem.source_id)  # type: ignore[arg-type]
     )
-
-    # Apply player filter if provided
-    if player_id is not None:
-        base_query = base_query.where(
-            NewsItem.player_id == player_id  # type: ignore[arg-type]
-        )
 
     # Count total items
     count_query = select(func.count()).select_from(NewsItem)
-    if player_id is not None:
-        count_query = count_query.where(
-            NewsItem.player_id == player_id  # type: ignore[arg-type]
-        )
     count_result = await db.execute(count_query)
     total = count_result.scalar() or 0
 
@@ -121,25 +116,7 @@ async def get_news_feed(
     rows = result.mappings().all()
 
     # Transform to response models
-    items: list[NewsItemRead] = []
-    for row in rows:
-        source_name = row["source_name"]
-        summary = row["summary"] or ""
-
-        items.append(
-            NewsItemRead(
-                id=row["id"],
-                source_name=source_name,
-                title=row["title"],
-                summary=summary,
-                url=row["url"],
-                image_url=row["image_url"],
-                author=row["author"],
-                time=format_relative_time(row["published_at"]),
-                tag=row["tag"].value,
-                read_more_text=build_read_more_text(source_name),
-            )
-        )
+    items: list[NewsItemRead] = [_row_to_news_item_read(row) for row in rows]  # type: ignore[arg-type]
 
     return NewsFeedResponse(
         items=items,
@@ -175,19 +152,9 @@ async def get_hero_article(db: AsyncSession) -> Optional[NewsItemRead]:
         Most recent NewsItemRead with image_url, or None if no articles have images
     """
     stmt = (
-        select(
-            NewsItem.id,
-            NewsItem.title,
-            NewsItem.summary,
-            NewsItem.url,
-            NewsItem.image_url,
-            NewsItem.author,
-            NewsItem.tag,
-            NewsItem.published_at,
-            NewsSource.display_name.label("source_name"),  # type: ignore[attr-defined]
-        )  # type: ignore[call-overload]
+        select(*_NEWS_FEED_COLUMNS)  # type: ignore[call-overload]
         .select_from(NewsItem)
-        .join(NewsSource, NewsSource.id == NewsItem.source_id)
+        .join(NewsSource, NewsSource.id == NewsItem.source_id)  # type: ignore[arg-type]
         .where(NewsItem.image_url.isnot(None))  # type: ignore[union-attr]
         .where(NewsItem.image_url != "")  # type: ignore[arg-type]
         .order_by(NewsItem.published_at.desc())  # type: ignore[attr-defined]
@@ -200,74 +167,295 @@ async def get_hero_article(db: AsyncSession) -> Optional[NewsItemRead]:
     if not row:
         return None
 
-    source_name = row["source_name"]
-    summary = row["summary"] or ""
+    return _row_to_news_item_read(row)  # type: ignore[arg-type]
 
+
+@dataclass(frozen=True, slots=True)
+class TrendingPlayer:
+    """A player trending in the news based on recency-weighted mention volume."""
+
+    player_id: int
+    display_name: str
+    slug: str
+    school: Optional[str]
+    mention_count: int
+    trending_score: float
+    daily_counts: list[int] = field(default_factory=list)
+    latest_mention_at: Optional[datetime] = None
+
+
+async def get_trending_players(
+    db: AsyncSession,
+    days: int = 7,
+    limit: int = 10,
+) -> list[TrendingPlayer]:
+    """Get players with the most news mentions, ranked by recency-weighted score.
+
+    Uses linear decay: a mention from today has weight 1.0, a mention from
+    ``days`` ago has weight ~0.0.  The trending score is SUM(weights).
+    Raw ``mention_count`` is still returned for badge display.
+
+    Uses ``NewsItem.published_at`` (article publication date) rather than
+    ``NewsItemPlayerMention.created_at`` so back-filled data is bucketed
+    correctly.
+
+    Args:
+        db: Async database session
+        days: Number of days to look back for mentions
+        limit: Maximum number of players to return
+
+    Returns:
+        List of TrendingPlayer sorted by trending_score desc
+    """
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    cutoff = now - timedelta(days=days)
+
+    # Age in fractional days (using published_at from the article)
+    age_seconds = func.extract(
+        "epoch",
+        literal(now) - NewsItem.published_at,
+    )
+    age_days = age_seconds / 86400.0
+    weight = func.greatest(1.0 - age_days / days, 0.0)
+
+    stmt = (
+        select(
+            NewsItemPlayerMention.player_id,
+            PlayerMaster.display_name,
+            PlayerMaster.slug,
+            PlayerMaster.school,
+            func.count().label("mention_count"),  # type: ignore[call-overload]
+            cast(func.sum(weight), Float).label("trending_score"),
+            func.max(NewsItem.published_at).label("latest_mention_at"),  # type: ignore[call-overload]
+        )
+        .join(
+            NewsItem,
+            NewsItem.id == NewsItemPlayerMention.news_item_id,  # type: ignore[arg-type]
+        )
+        .join(
+            PlayerMaster,
+            PlayerMaster.id == NewsItemPlayerMention.player_id,  # type: ignore[arg-type]
+        )
+        .where(NewsItemPlayerMention.created_at >= cutoff)  # type: ignore[arg-type]
+        .group_by(
+            NewsItemPlayerMention.player_id,
+            PlayerMaster.display_name,
+            PlayerMaster.slug,
+            PlayerMaster.school,
+        )
+        .order_by(
+            cast(func.sum(weight), Float).desc(),
+            func.count().desc(),  # type: ignore[call-overload]
+        )
+        .limit(limit)
+    )
+
+    result = await db.execute(stmt)
+    rows = result.mappings().all()
+
+    if not rows:
+        return []
+
+    player_ids = [row["player_id"] for row in rows]
+    daily_map = await _get_daily_mention_counts(db, player_ids, days)
+
+    return [
+        TrendingPlayer(
+            player_id=row["player_id"],
+            display_name=row["display_name"] or "Unknown",
+            slug=row["slug"] or "",
+            school=row["school"],
+            mention_count=row["mention_count"],
+            trending_score=round(float(row["trending_score"] or 0), 3),
+            daily_counts=daily_map.get(row["player_id"], [0] * days),
+            latest_mention_at=row["latest_mention_at"],
+        )
+        for row in rows
+    ]
+
+
+async def _get_daily_mention_counts(
+    db: AsyncSession,
+    player_ids: list[int],
+    days: int = 7,
+) -> dict[int, list[int]]:
+    """Fetch per-day mention counts for a set of players.
+
+    Buckets by ``date_trunc('day', news_items.published_at)`` and fills
+    zeros for days with no mentions.
+
+    Args:
+        db: Async database session
+        player_ids: Player IDs to fetch counts for
+        days: Number of days to look back
+
+    Returns:
+        Mapping of player_id → list of daily counts (oldest-first, length=days)
+    """
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    cutoff = now - timedelta(days=days)
+
+    day_col = func.date_trunc("day", NewsItem.published_at).label("mention_day")
+
+    stmt = (
+        select(
+            NewsItemPlayerMention.player_id,
+            day_col,
+            func.count().label("cnt"),  # type: ignore[call-overload]
+        )
+        .join(
+            NewsItem,
+            NewsItem.id == NewsItemPlayerMention.news_item_id,  # type: ignore[arg-type]
+        )
+        .where(NewsItemPlayerMention.created_at >= cutoff)  # type: ignore[arg-type]
+        .where(
+            NewsItemPlayerMention.player_id.in_(player_ids)  # type: ignore[attr-defined]
+        )
+        .group_by(NewsItemPlayerMention.player_id, day_col)
+    )
+
+    result = await db.execute(stmt)
+    rows = result.mappings().all()
+
+    # Build date labels for the window (oldest first)
+    date_labels = [(now - timedelta(days=days - 1 - i)).date() for i in range(days)]
+
+    # Organise raw rows into pid → {date: count}
+    raw: dict[int, dict] = {}
+    for row in rows:
+        pid = row["player_id"]
+        day = row["mention_day"]
+        # date_trunc returns a datetime; normalise to date
+        if isinstance(day, datetime):
+            day = day.date()
+        raw.setdefault(pid, {})[day] = row["cnt"]
+
+    # Fill zeros for missing days
+    result_map: dict[int, list[int]] = {}
+    for pid in player_ids:
+        counts = raw.get(pid, {})
+        result_map[pid] = [counts.get(d, 0) for d in date_labels]
+
+    return result_map
+
+
+async def get_player_news_feed(
+    db: AsyncSession,
+    player_id: int,
+    limit: int = 20,
+    offset: int = 0,
+    min_items: int = 5,
+) -> NewsFeedResponse:
+    """Fetch news feed for a specific player.
+
+    Queries articles where the player has a mention row OR where
+    NewsItem.player_id matches. If results are below min_items,
+    backfills with general feed items (excluding already-included IDs).
+
+    Args:
+        db: Async database session
+        player_id: Player to get news for
+        limit: Maximum items to return
+        offset: Number of items to skip
+        min_items: Minimum items before backfilling with general feed
+
+    Returns:
+        NewsFeedResponse with items marked with is_player_specific
+    """
+    # Subquery: news_item IDs that mention this player (via junction table)
+    mention_subq = select(  # type: ignore[call-overload]
+        NewsItemPlayerMention.news_item_id.label("item_id")  # type: ignore[attr-defined]
+    ).where(
+        NewsItemPlayerMention.player_id == player_id  # type: ignore[arg-type]
+    )
+
+    # Subquery: news_item IDs where player_id is set directly
+    direct_subq = select(  # type: ignore[call-overload]
+        NewsItem.id.label("item_id")  # type: ignore[union-attr]
+    ).where(
+        NewsItem.player_id == player_id  # type: ignore[arg-type]
+    )
+
+    # Union of both sources (union deduplicates IDs that appear in both)
+    combined = union(mention_subq, direct_subq).subquery()
+
+    # Player-specific query
+    player_query = (
+        select(*_NEWS_FEED_COLUMNS)  # type: ignore[call-overload]
+        .select_from(NewsItem)
+        .join(NewsSource, NewsSource.id == NewsItem.source_id)  # type: ignore[arg-type]
+        .where(NewsItem.id.in_(select(combined.c.item_id)))  # type: ignore[union-attr]
+        .order_by(NewsItem.published_at.desc())  # type: ignore[attr-defined]
+        .limit(limit)
+        .offset(offset)
+    )
+
+    result = await _execute_mappings(db, player_query)
+    player_item_ids: set[int] = set()
+    items: list[NewsItemRead] = []
+
+    for row in result:
+        player_item_ids.add(row["id"])
+        items.append(_row_to_news_item_read(row, is_player_specific=True))
+
+    # Backfill with general feed if insufficient player-specific articles
+    if len(items) < min_items and offset == 0:
+        backfill_needed = min_items - len(items)
+        backfill_query = (
+            select(*_NEWS_FEED_COLUMNS)  # type: ignore[call-overload]
+            .select_from(NewsItem)
+            .join(NewsSource, NewsSource.id == NewsItem.source_id)  # type: ignore[arg-type]
+            .order_by(NewsItem.published_at.desc())  # type: ignore[attr-defined]
+            .limit(backfill_needed)
+        )
+
+        if player_item_ids:
+            backfill_query = backfill_query.where(
+                NewsItem.id.notin_(list(player_item_ids))  # type: ignore[union-attr]
+            )
+
+        backfill_result = await _execute_mappings(db, backfill_query)
+        for row in backfill_result:
+            if len(items) >= limit:
+                break
+            items.append(_row_to_news_item_read(row, is_player_specific=False))
+
+    # Count total player-specific items
+    count_query = (
+        select(func.count())
+        .select_from(NewsItem)
+        .where(NewsItem.id.in_(select(combined.c.item_id)))  # type: ignore[union-attr]
+    )
+    count_result = await db.execute(count_query)
+    total = count_result.scalar() or 0
+
+    return NewsFeedResponse(
+        items=items,
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+async def _execute_mappings(db: AsyncSession, query: object) -> list[dict]:
+    """Execute a SELECT query and return rows as mapping dicts."""
+    result = await db.execute(query)  # type: ignore[arg-type,call-overload]
+    return list(result.mappings().all())  # type: ignore[union-attr]
+
+
+def _row_to_news_item_read(row: dict, is_player_specific: bool = False) -> NewsItemRead:
+    """Convert a database row mapping to a NewsItemRead response model."""
+    source_name = row["source_name"]
     return NewsItemRead(
         id=row["id"],
         source_name=source_name,
         title=row["title"],
-        summary=summary,
+        summary=row["summary"] or "",
         url=row["url"],
         image_url=row["image_url"],
         author=row["author"],
         time=format_relative_time(row["published_at"]),
         tag=row["tag"].value,
         read_more_text=build_read_more_text(source_name),
+        is_player_specific=is_player_specific,
     )
-
-
-async def get_author_counts(db: AsyncSession, limit: int = 10) -> list[dict]:
-    """Get distinct authors with article counts.
-
-    Args:
-        db: Async database session
-        limit: Maximum number of authors to return
-
-    Returns:
-        List of dicts with 'author' and 'count' keys, sorted by count desc
-    """
-    stmt = (
-        select(
-            NewsItem.author,
-            func.count().label("count"),  # type: ignore[call-overload]
-        )
-        .where(NewsItem.author.isnot(None))  # type: ignore[union-attr]
-        .where(NewsItem.author != "")  # type: ignore[arg-type]
-        .group_by(NewsItem.author)
-        .order_by(func.count().desc())  # type: ignore[call-overload]
-        .limit(limit)
-    )
-
-    result = await db.execute(stmt)
-    rows = result.mappings().all()
-
-    return [{"author": row["author"], "count": row["count"]} for row in rows]
-
-
-async def get_source_counts(db: AsyncSession, limit: int = 10) -> list[dict]:
-    """Get sources with article counts for sidebar.
-
-    Args:
-        db: Async database session
-        limit: Maximum number of sources to return
-
-    Returns:
-        List of dicts with 'source_name' and 'count' keys, sorted by count desc
-    """
-    stmt = (
-        select(
-            NewsSource.display_name.label("source_name"),  # type: ignore[attr-defined]
-            func.count().label("count"),  # type: ignore[call-overload]
-        )
-        .select_from(NewsItem)
-        .join(NewsSource, NewsSource.id == NewsItem.source_id)  # type: ignore[arg-type]
-        .group_by(NewsSource.display_name)
-        .order_by(func.count().desc())  # type: ignore[call-overload]
-        .limit(limit)
-    )
-
-    result = await db.execute(stmt)
-    rows = result.mappings().all()
-
-    return [{"source_name": row["source_name"], "count": row["count"]} for row in rows]

--- a/app/services/player_mention_service.py
+++ b/app/services/player_mention_service.py
@@ -1,0 +1,199 @@
+"""Player mention resolution service.
+
+Resolves player name strings to database IDs by checking display_name,
+aliases, and optionally creating stub records for unknown players.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.player_aliases import PlayerAlias
+from app.schemas.players_master import PlayerMaster
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class PlayerMatch:
+    """Result of resolving a player name to a database record."""
+
+    player_id: int
+    display_name: str
+    matched_via: str  # "display_name", "alias", or "stub_created"
+
+
+def split_name(full_name: str) -> tuple[str, Optional[str]]:
+    """Split a full name into (first_name, last_name).
+
+    Args:
+        full_name: Full player name string (e.g. "Cooper Flagg")
+
+    Returns:
+        Tuple of (first_name, last_name). last_name is None for single-word names.
+    """
+    parts = full_name.strip().split()
+    if len(parts) == 0:
+        return ("", None)
+    if len(parts) == 1:
+        return (parts[0], None)
+    return (parts[0], " ".join(parts[1:]))
+
+
+async def _resolve_iter(
+    db: AsyncSession,
+    names: list[str],
+    draft_year: Optional[int],
+    create_stubs: bool,
+) -> list[tuple[str, PlayerMatch]]:
+    """Core matching loop shared by the public resolve functions.
+
+    Returns:
+        List of (input_name, PlayerMatch) tuples, deduplicated by player_id.
+    """
+    results: list[tuple[str, PlayerMatch]] = []
+    seen_ids: set[int] = set()
+
+    for raw_name in names:
+        name = raw_name.strip()
+        if not name:
+            continue
+
+        match = await _match_display_name(db, name)
+        if match is None:
+            match = await _match_alias(db, name)
+        if match is None and create_stubs:
+            match = await _create_stub_player(db, name, draft_year=draft_year)
+
+        if match is not None and match.player_id not in seen_ids:
+            seen_ids.add(match.player_id)
+            results.append((name, match))
+
+    return results
+
+
+async def resolve_player_names(
+    db: AsyncSession,
+    names: list[str],
+    draft_year: Optional[int] = None,
+    create_stubs: bool = True,
+) -> list[PlayerMatch]:
+    """Resolve a list of player name strings to database records.
+
+    For each name, checks in order:
+      1. PlayerMaster.display_name (case-insensitive exact match)
+      2. PlayerAlias.full_name (case-insensitive exact match)
+      3. Creates a stub PlayerMaster if create_stubs=True
+
+    Args:
+        db: Async database session (caller manages transaction)
+        names: List of player name strings to resolve
+        draft_year: Optional draft year to set on created stubs
+        create_stubs: Whether to create stub records for unmatched names
+
+    Returns:
+        List of PlayerMatch results (one per successfully resolved name)
+    """
+    if not names:
+        return []
+    pairs = await _resolve_iter(db, names, draft_year, create_stubs)
+    return [match for _, match in pairs]
+
+
+async def resolve_player_names_as_map(
+    db: AsyncSession,
+    names: list[str],
+    draft_year: Optional[int] = None,
+    create_stubs: bool = True,
+) -> dict[str, int]:
+    """Resolve player name strings to a map of input_name -> player_id.
+
+    Unlike resolve_player_names(), this maps each *input* name (lowered) to
+    its resolved player_id, ensuring alias-matched names are correctly keyed
+    by the caller's original string rather than the canonical display_name.
+
+    Args:
+        db: Async database session (caller manages transaction)
+        names: List of player name strings to resolve
+        draft_year: Optional draft year to set on created stubs
+        create_stubs: Whether to create stub records for unmatched names
+
+    Returns:
+        Dict mapping lowered input name -> player_id
+    """
+    if not names:
+        return {}
+    pairs = await _resolve_iter(db, names, draft_year, create_stubs)
+    return {input_name.lower(): match.player_id for input_name, match in pairs}
+
+
+async def _match_display_name(db: AsyncSession, name: str) -> Optional[PlayerMatch]:
+    """Try to match a name against PlayerMaster.display_name (case-insensitive)."""
+    stmt = select(PlayerMaster.id, PlayerMaster.display_name).where(  # type: ignore[call-overload]
+        func.lower(PlayerMaster.display_name) == name.lower()  # type: ignore[arg-type]
+    )
+    row = (await db.execute(stmt)).first()
+    if row is not None:
+        return PlayerMatch(
+            player_id=row[0],  # type: ignore[arg-type]
+            display_name=row[1] or name,  # type: ignore[arg-type]
+            matched_via="display_name",
+        )
+    return None
+
+
+async def _match_alias(db: AsyncSession, name: str) -> Optional[PlayerMatch]:
+    """Try to match a name against PlayerAlias.full_name (case-insensitive)."""
+    stmt = (
+        select(PlayerMaster.id, PlayerMaster.display_name)  # type: ignore[call-overload]
+        .join(PlayerAlias, PlayerAlias.player_id == PlayerMaster.id)  # type: ignore[arg-type]
+        .where(func.lower(PlayerAlias.full_name) == name.lower())  # type: ignore[arg-type]
+    )
+    row = (await db.execute(stmt)).first()
+    if row is not None:
+        return PlayerMatch(
+            player_id=row[0],  # type: ignore[arg-type]
+            display_name=row[1] or name,  # type: ignore[arg-type]
+            matched_via="alias",
+        )
+    return None
+
+
+async def _create_stub_player(
+    db: AsyncSession,
+    full_name: str,
+    draft_year: Optional[int] = None,
+) -> Optional[PlayerMatch]:
+    """Create a minimal stub PlayerMaster record for an unknown player.
+
+    Args:
+        db: Async database session
+        full_name: Full player name
+        draft_year: Optional draft year
+
+    Returns:
+        PlayerMatch if created successfully, None otherwise
+    """
+    first_name, last_name = split_name(full_name)
+    display_name = full_name.strip()
+
+    player = PlayerMaster(
+        first_name=first_name or None,
+        last_name=last_name,
+        display_name=display_name,
+        draft_year=draft_year,
+        is_stub=True,
+    )
+    db.add(player)
+    await db.flush()
+    logger.info(f"Created stub player: {display_name} (id={player.id})")
+    return PlayerMatch(
+        player_id=player.id,  # type: ignore[arg-type]
+        display_name=display_name,
+        matched_via="stub_created",
+    )

--- a/app/static/css/feed.css
+++ b/app/static/css/feed.css
@@ -199,6 +199,50 @@
   fill: none;
 }
 
+/* Player-specific card highlight */
+.feed-card--player-specific {
+  border-left: 3px solid var(--color-accent-emerald);
+}
+
+/* "Mentioned" badge on player-specific articles */
+.feed-card__mention-badge {
+  display: inline-block;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 9999px;
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: #d1fae5;
+  color: #065f46;
+}
+
+/* Divider between player-specific and backfill articles */
+.feed-divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.5rem 0;
+}
+
+.feed-divider::before,
+.feed-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--color-slate-200);
+}
+
+.feed-divider__label {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-slate-400);
+  white-space: nowrap;
+}
+
 /* Responsive: Stack on mobile */
 @media (max-width: 480px) {
   .feed-card {

--- a/app/static/css/home.css
+++ b/app/static/css/home.css
@@ -173,6 +173,105 @@ tbody td {
 }
 
 /* ============================================================================
+   TRENDING PLAYERS
+   Grid of trending player cards with thumbnails and sparklines
+   ========================================================================= */
+.trending-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+}
+
+.trending-card {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.625rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--color-slate-200);
+  background: var(--color-white);
+  text-decoration: none;
+  color: inherit;
+  transition: transform var(--transition-speed), box-shadow var(--transition-speed);
+}
+
+.trending-card:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border-color: var(--color-accent-emerald);
+}
+
+/* Thumbnail */
+.trending-card__thumb {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+  object-position: 50% 20%;
+  border: 1px solid var(--color-slate-200);
+  background: var(--color-slate-100);
+}
+
+.trending-card__thumb--placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--color-slate-500);
+}
+
+.trending-card__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.trending-card__name {
+  font-weight: 600;
+  font-size: 0.8125rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.trending-card__school {
+  font-size: 0.6875rem;
+  color: var(--color-slate-500);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Visual wrapper: sparkline + count badge */
+.trending-card__visual {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.trending-card__sparkline {
+  width: 64px;
+  height: 24px;
+  display: block;
+}
+
+.trending-card__count {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--color-accent-emerald);
+  background: #d1fae5;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+}
+
+/* ============================================================================
    VS ARENA / PLAYER COMPARISON
    Interactive player comparison section with toggles
    ========================================================================= */
@@ -343,7 +442,17 @@ tbody td {
    RESPONSIVE DESIGN - HOMEPAGE
    Mobile-first breakpoints for homepage components
    ========================================================================= */
+@media (max-width: 1024px) {
+  .trending-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 @media (max-width: 768px) {
+  .trending-grid {
+    grid-template-columns: 1fr;
+  }
+
   .prospects-grid {
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   }

--- a/app/static/js/home.js
+++ b/app/static/js/home.js
@@ -89,25 +89,26 @@ const ProspectsModule = {
    * @returns {string} HTML string
    */
   renderProspects() {
+    const esc = DraftGuru.escapeHtml.bind(DraftGuru);
     return window.PLAYERS.map((player) => {
       const badge = player.change !== 0
         ? this.renderBadge(player.change)
         : '';
 
 	      return `
-	        <a href="/players/${player.slug}" class="prospect-card" style="text-decoration: none; color: inherit;">
+	        <a href="/players/${esc(player.slug)}" class="prospect-card" style="text-decoration: none; color: inherit;">
 	          <div class="prospect-image-wrapper">
 	            <img
-	              src="${player.img}"
-	              alt="${player.name}"
+	              src="${esc(player.img)}"
+	              alt="${esc(player.name)}"
 	              class="prospect-image"
-	              onerror="if(!this.dataset.dgFallback){this.dataset.dgFallback='1';this.src='${player.img_default}';}else{this.onerror=null;this.src='${player.img_placeholder}';}"
+	              onerror="if(!this.dataset.dgFallback){this.dataset.dgFallback='1';this.src='${esc(player.img_default)}';}else{this.onerror=null;this.src='${esc(player.img_placeholder)}';}"
 	            />
 	            ${badge}
 	          </div>
 	          <div class="prospect-info">
-	            <h4 class="prospect-name">${player.name}</h4>
-            <p class="prospect-meta">${player.position} • ${player.college}</p>
+	            <h4 class="prospect-name">${esc(player.name)}</h4>
+            <p class="prospect-meta">${esc(player.position)} • ${esc(player.college)}</p>
             <div class="prospect-stats">
               ${this.renderStatPill('HT', `${player.measurables.ht}"`)}
               ${this.renderStatPill('WS', `${player.measurables.ws}"`)}
@@ -227,16 +228,6 @@ const HeroModule = {
   },
 
   /**
-   * Convert tag name to CSS class
-   * @param {string} tag - Tag name like "Scouting Report"
-   * @returns {string} CSS class like "scouting-report"
-   */
-  getTagClass(tag) {
-    if (!tag) return 'scouting-report';
-    return tag.toLowerCase().replace(/\s+/g, '-');
-  },
-
-  /**
    * Render the hero section based on mode
    * @param {string} mode - Display mode
    */
@@ -244,7 +235,7 @@ const HeroModule = {
     const hero = document.getElementById('heroArticle');
     const article = this.article;
     const imageUrl = article.image_url;
-    const tagClass = this.getTagClass(article.tag);
+    const tagClass = DraftGuru.getTagClass(article.tag);
 
     // Reset classes
     hero.className = 'news-hero';
@@ -252,10 +243,14 @@ const HeroModule = {
     // Add click handler to open article
     hero.onclick = () => window.open(article.url, '_blank');
 
+    const esc = DraftGuru.escapeHtml.bind(DraftGuru);
+    const safeImageUrl = esc(imageUrl || '');
+    const safeTitle = esc(article.title);
+
     if (mode === 'full' && imageUrl) {
       // Full wide image - best case
       hero.innerHTML = `
-        <img class="news-hero__image" src="${imageUrl}" alt="${article.title}" />
+        <img class="news-hero__image" src="${safeImageUrl}" alt="${safeTitle}" />
         ${this.renderOverlay(article, tagClass)}
       `;
     } else if (mode === 'split' && imageUrl) {
@@ -263,26 +258,26 @@ const HeroModule = {
       hero.classList.add('news-hero--split');
       hero.innerHTML = `
         <div class="news-hero__text-area">
-          <span class="news-hero__tag tag--${tagClass}">${article.tag}</span>
-          <h2 class="news-hero__title">${article.title}</h2>
-          <p class="news-hero__summary">${article.summary || ''}</p>
+          <span class="news-hero__tag tag--${tagClass}">${esc(article.tag)}</span>
+          <h2 class="news-hero__title">${safeTitle}</h2>
+          <p class="news-hero__summary">${esc(article.summary || '')}</p>
           <div class="news-hero__meta">
-            <span class="news-hero__source">${article.source}</span>
-            ${article.author ? `<span class="news-hero__author">by ${article.author}</span>` : ''}
-            <span class="news-hero__time">${article.time}</span>
+            <span class="news-hero__source">${esc(article.source)}</span>
+            ${article.author ? `<span class="news-hero__author">by ${esc(article.author)}</span>` : ''}
+            <span class="news-hero__time">${esc(article.time)}</span>
           </div>
         </div>
         <div class="news-hero__image-area">
-          <img class="news-hero__image" src="${imageUrl}" alt="${article.title}" />
+          <img class="news-hero__image" src="${safeImageUrl}" alt="${safeTitle}" />
         </div>
       `;
     } else if (mode === 'blurred' && imageUrl) {
       // Blurred background with contained image
       hero.classList.add('news-hero--blurred');
       hero.innerHTML = `
-        <div class="news-hero__background" style="background-image: url('${imageUrl}');"></div>
+        <div class="news-hero__background" style="background-image: url('${safeImageUrl}');"></div>
         <div class="news-hero__image-container">
-          <img class="news-hero__image" src="${imageUrl}" alt="${article.title}" />
+          <img class="news-hero__image" src="${safeImageUrl}" alt="${safeTitle}" />
         </div>
         ${this.renderOverlay(article, tagClass)}
       `;
@@ -308,15 +303,16 @@ const HeroModule = {
    * @returns {string} HTML string
    */
   renderOverlay(article, tagClass) {
+    const esc = DraftGuru.escapeHtml.bind(DraftGuru);
     return `
       <div class="news-hero__overlay">
-        <span class="news-hero__tag tag--${tagClass}">${article.tag}</span>
-        <h2 class="news-hero__title">${article.title}</h2>
-        <p class="news-hero__summary">${article.summary || ''}</p>
+        <span class="news-hero__tag tag--${tagClass}">${esc(article.tag)}</span>
+        <h2 class="news-hero__title">${esc(article.title)}</h2>
+        <p class="news-hero__summary">${esc(article.summary || '')}</p>
         <div class="news-hero__meta">
-          <span class="news-hero__source">${article.source}</span>
-          ${article.author ? `<span class="news-hero__author">by ${article.author}</span>` : ''}
-          <span class="news-hero__time">${article.time}</span>
+          <span class="news-hero__source">${esc(article.source)}</span>
+          ${article.author ? `<span class="news-hero__author">by ${esc(article.author)}</span>` : ''}
+          <span class="news-hero__time">${esc(article.time)}</span>
         </div>
       </div>
     `;
@@ -360,8 +356,8 @@ const SidebarModule = {
     }
 
     container.innerHTML = sources.map(s => `
-      <div class="source-item" data-source="${this.escapeHtml(s.source_name)}">
-        <span class="source-item__name">${this.escapeHtml(s.source_name)}</span>
+      <div class="source-item" data-source="${DraftGuru.escapeHtml(s.source_name)}">
+        <span class="source-item__name">${DraftGuru.escapeHtml(s.source_name)}</span>
         <span class="source-item__count">${s.count}</span>
       </div>
     `).join('');
@@ -391,8 +387,8 @@ const SidebarModule = {
     }
 
     container.innerHTML = authors.map(a => `
-      <div class="source-item" data-author="${this.escapeHtml(a.author)}">
-        <span class="source-item__name">${this.escapeHtml(a.author)}</span>
+      <div class="source-item" data-author="${DraftGuru.escapeHtml(a.author)}">
+        <span class="source-item__name">${DraftGuru.escapeHtml(a.author)}</span>
         <span class="source-item__count">${a.count}</span>
       </div>
     `).join('');
@@ -531,18 +527,6 @@ const SidebarModule = {
     document.querySelectorAll('.sidebar-section').forEach(section => {
       section.classList.remove('sidebar-section--filtered');
     });
-  },
-
-  /**
-   * Escape HTML to prevent XSS
-   * @param {string} str - String to escape
-   * @returns {string} Escaped string
-   */
-  escapeHtml(str) {
-    if (!str) return '';
-    const div = document.createElement('div');
-    div.textContent = str;
-    return div.innerHTML;
   },
 
   /**
@@ -695,38 +679,28 @@ const NewsGridModule = {
    * @returns {string} HTML string
    */
   renderArticleCard(item) {
-    const tagClass = this.getTagClass(item.tag);
+    const tagClass = DraftGuru.getTagClass(item.tag);
     const hasImage = item.image_url && item.image_url.trim() !== '';
 
     return `
-      <article class="article-card" onclick="window.open('${this.escapeHtml(item.url)}', '_blank')">
+      <article class="article-card" onclick="window.open('${DraftGuru.escapeHtml(item.url)}', '_blank')">
         <div class="article-card__image-wrapper">
           ${hasImage
-            ? `<img src="${this.escapeHtml(item.image_url)}" class="article-card__image" alt="" loading="lazy" />`
+            ? `<img src="${DraftGuru.escapeHtml(item.image_url)}" class="article-card__image" alt="" loading="lazy" />`
             : `<div class="article-card__image-placeholder">DG</div>`
           }
-          <span class="article-card__tag tag--${tagClass}">${this.escapeHtml(item.tag)}</span>
+          <span class="article-card__tag tag--${tagClass}">${DraftGuru.escapeHtml(item.tag)}</span>
         </div>
         <div class="article-card__content">
-          <h3 class="article-card__title">${this.escapeHtml(item.title)}</h3>
-          ${item.summary ? `<p class="article-card__summary">${this.escapeHtml(item.summary)}</p>` : ''}
+          <h3 class="article-card__title">${DraftGuru.escapeHtml(item.title)}</h3>
+          ${item.summary ? `<p class="article-card__summary">${DraftGuru.escapeHtml(item.summary)}</p>` : ''}
           <div class="article-card__meta">
-            <span class="article-card__source">${this.escapeHtml(item.source)}</span>
-            <span class="article-card__time">${this.escapeHtml(item.time)}</span>
+            <span class="article-card__source">${DraftGuru.escapeHtml(item.source)}</span>
+            <span class="article-card__time">${DraftGuru.escapeHtml(item.time)}</span>
           </div>
         </div>
       </article>
     `;
-  },
-
-  /**
-   * Get tag class from tag name
-   * @param {string} tag - Tag name
-   * @returns {string} CSS class
-   */
-  getTagClass(tag) {
-    if (!tag) return 'scouting-report';
-    return tag.toLowerCase().replace(/\s+/g, '-');
   },
 
   /**
@@ -855,28 +829,116 @@ const NewsGridModule = {
     if (grid) {
       grid.innerHTML = '<div class="articles-grid--empty">No news items yet. Check back soon!</div>';
     }
-  },
-
-  /**
-   * Escape HTML to prevent XSS
-   * @param {string} str - String to escape
-   * @returns {string} Escaped string
-   */
-  escapeHtml(str) {
-    if (!str) return '';
-    const div = document.createElement('div');
-    div.textContent = str;
-    return div.innerHTML;
   }
 };
 
 /**
  * ============================================================================
- * LEGACY FEED MODULE (kept for backwards compatibility)
- * Deprecated: Use NewsGridModule instead
+ * TRENDING MODULE
+ * Renders the trending players section based on recent mention volume
  * ============================================================================
  */
-const FeedModule = NewsGridModule;
+const TrendingModule = {
+  /**
+   * Initialize the trending players section
+   */
+  init() {
+    const data = window.TRENDING_PLAYERS;
+    if (!data || data.length === 0) return;
+
+    const section = document.getElementById('trendingSection');
+    const divider = document.getElementById('trendingDivider');
+    const grid = document.getElementById('trendingGrid');
+    if (!section || !grid) return;
+
+    section.style.display = '';
+    if (divider) divider.style.display = '';
+
+    grid.innerHTML = data.map(player => this.renderCard(player)).join('');
+  },
+
+  /**
+   * Render a single trending player card
+   * @param {Object} player - Trending player data
+   * @returns {string} HTML string
+   */
+  renderCard(player) {
+    const esc = DraftGuru.escapeHtml.bind(DraftGuru);
+    const school = player.school
+      ? `<span class="trending-card__school">${esc(player.school)}</span>`
+      : '';
+    const thumbnail = this.renderThumbnail(player);
+    const sparkline = this.renderSparkline(player.daily_counts || []);
+
+    return `
+      <a href="/players/${esc(player.slug)}" class="trending-card">
+        ${thumbnail}
+        <div class="trending-card__info">
+          <span class="trending-card__name">${esc(player.display_name)}</span>
+          ${school}
+        </div>
+        <div class="trending-card__visual">
+          ${sparkline}
+          <span class="trending-card__count">${player.mention_count}</span>
+        </div>
+      </a>
+    `;
+  },
+
+  /**
+   * Render a small circular player thumbnail
+   * @param {Object} player - Trending player data
+   * @returns {string} HTML string
+   */
+  renderThumbnail(player) {
+    const esc = DraftGuru.escapeHtml.bind(DraftGuru);
+    const imgUrl = ImageUtils.getPhotoUrl(player.player_id, player.display_name, player.slug);
+    const initial = (player.display_name || '?').charAt(0).toUpperCase();
+    return `
+      <img
+        src="${esc(imgUrl)}"
+        alt="${esc(player.display_name)}"
+        class="trending-card__thumb"
+        onerror="this.onerror=null;this.replaceWith(Object.assign(document.createElement('span'),{className:'trending-card__thumb trending-card__thumb--placeholder',textContent:'${initial}'}))"
+      />
+    `;
+  },
+
+  /**
+   * Render an inline SVG sparkline from daily mention counts
+   * @param {number[]} counts - Array of daily counts (oldest-first)
+   * @returns {string} SVG HTML string
+   */
+  renderSparkline(counts) {
+    if (!counts || counts.length === 0) return '';
+
+    const width = 64;
+    const height = 24;
+    const padding = 2;
+    const maxVal = Math.max(...counts, 1);
+    const step = (width - padding * 2) / Math.max(counts.length - 1, 1);
+
+    const points = counts.map((v, i) => {
+      const x = padding + i * step;
+      const y = height - padding - ((v / maxVal) * (height - padding * 2));
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    }).join(' ');
+
+    return `
+      <svg class="trending-card__sparkline" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">
+        <polyline
+          points="${points}"
+          fill="none"
+          stroke="var(--color-accent-emerald, #10b981)"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    `;
+  },
+
+};
 
 /**
  * ============================================================================
@@ -918,7 +980,8 @@ document.addEventListener('DOMContentLoaded', () => {
     tweetBtnId: 'vsArenaTweetBtn'
   });
 
-  // Initialize news section modules
+  // Initialize trending players and news section modules
+  TrendingModule.init();
   HeroModule.init();
   SidebarModule.init();
   NewsGridModule.init();

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -247,6 +247,28 @@ const DraftGuru = {
     const div = document.createElement('div');
     div.textContent = text;
     return div.innerHTML;
+  },
+
+  /**
+   * Convert a tag name to its CSS class suffix.
+   * @param {string} tag - Tag name like "Scouting Report"
+   * @returns {string} CSS class like "scouting-report"
+   */
+  getTagClass(tag) {
+    if (!tag) return 'scouting-report';
+    const tagMap = {
+      'Scouting Report': 'scouting-report',
+      'Big Board': 'big-board',
+      'Mock Draft': 'mock-draft',
+      'Tier Update': 'tier-update',
+      'Game Recap': 'game-recap',
+      'Film Study': 'film-study',
+      'Skill Theme': 'skill-theme',
+      'Team Fit': 'team-fit',
+      'Draft Intel': 'draft-intel',
+      'Statistical Analysis': 'stats-analysis',
+    };
+    return tagMap[tag] || 'scouting-report';
   }
 };
 

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -35,6 +35,8 @@
     <button class="story-filter" data-tag="Game Recap">Game Recap</button>
     <button class="story-filter" data-tag="Film Study">Film Study</button>
     <button class="story-filter" data-tag="Team Fit">Team Fit</button>
+    <button class="story-filter" data-tag="Skill Theme">Skill Theme</button>
+    <button class="story-filter" data-tag="Statistical Analysis">Stats</button>
   </div>
 
   <div class="section-divider"></div>
@@ -89,6 +91,20 @@
   </div>
 
   <div class="section-divider"></div>
+
+  <!-- ==========================================================================
+       TRENDING PLAYERS
+       Players with the most recent article mentions
+       ========================================================================== -->
+  <section class="section" id="trendingSection" style="display: none;">
+    <h3 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-emerald);">
+      Trending Players
+    </h3>
+
+    <div id="trendingGrid" class="trending-grid"></div>
+  </section>
+
+  <div class="section-divider" id="trendingDivider" style="display: none;"></div>
 
   <!-- ==========================================================================
        TOP PROSPECTS
@@ -222,6 +238,7 @@
 <script>
   // Server-side data injection
   window.PLAYERS = {{ players | tojson | safe }};
+  window.TRENDING_PLAYERS = {{ trending_players | tojson | safe }};
   window.FEED_ITEMS = {{ feed_items | tojson | safe }};
   // Hero article and sidebar data for news section
   window.HERO_ARTICLE = {{ hero_article | tojson | safe }};

--- a/app/templates/player-detail.html
+++ b/app/templates/player-detail.html
@@ -441,7 +441,7 @@
        Player-specific news and updates
        ========================================================================== -->
   <section class="section">
-    <h3 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-cyan);">
+    <h3 id="newsFeedHeading" class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-cyan);">
       {{ player.name }} News
     </h3>
 

--- a/docs/player_tags_review.md
+++ b/docs/player_tags_review.md
@@ -1,0 +1,92 @@
+# Player Tags Feature — Code Review
+
+**Date**: 2026-02-08
+**Branch**: `feature/player-tags`
+**Scope**: Working tree (11 modified, 9 new files)
+
+## Checks
+
+| Check | Result |
+|-------|--------|
+| Unit tests (`pytest tests/unit -q`) | 59 passed |
+| mypy (`mypy app --ignore-missing-imports`) | 0 errors |
+| Lint (`ruff check .`) | All checks passed |
+
+## Regressions
+
+- **None found.**
+- `player_id` parameter removed from `get_news_feed()` — confirmed no remaining callers use it. Replaced by dedicated `get_player_news_feed()`.
+- `ingest_rss_source` return type changed from `tuple[int, int]` to `tuple[int, int, int]` — the only caller (`run_ingestion_cycle`) is updated to match.
+- New fields on `IngestionResult` (`mentions_added`) and `NewsItemRead` (`is_player_specific`) both have defaults, so existing consumers are unaffected.
+
+## Issues Found & Fixes Applied
+
+### 1. `union_all` should be `union` in player feed query (Fixed)
+
+**File**: `app/services/news_service.py:279`
+
+`union_all(mention_subq, direct_subq)` does not deduplicate. If an article has both a mention row AND `NewsItem.player_id` set, its ID appears twice in the subquery. The outer `IN` clause deduplicates implicitly, so results were correct — but `union()` communicates intent better.
+
+**Fix**: Changed `union_all` to `union`.
+
+### 2. Missing story filter buttons for two tag types (Fixed)
+
+**File**: `app/templates/home.html:28-38`
+
+The story type filter buttons did not include "Skill Theme" or "Statistical Analysis" tags, though both are valid `NewsItemTag` values that Gemini can return. Articles tagged with these types were not filterable from the homepage UI.
+
+**Fix**: Added "Skill Theme" and "Stats" (Statistical Analysis) filter buttons.
+
+### 3. `MentionSource.source` column type in migration (Not fixed — acceptable)
+
+**File**: `alembic/versions/h7i8j9k0l1m2_add_player_mentions.py:34`
+
+The migration declares `sa.Column("source", sa.String())` but the SQLModel schema uses `MentionSource` (a `str` enum). This works because SQLModel stores `str` Enum values as plain strings. If DB-level enum enforcement is desired later, this would need updating. Fine for now.
+
+### 4. Backfill script loads all news items into memory (Not fixed — acceptable at current scale)
+
+**File**: `scripts/backfill_player_mentions.py:104-112`
+
+`result.all()` fetches all `NewsItem` rows at once. For very large datasets this could be memory-intensive. Consider batching with `.yield_per()` or `LIMIT/OFFSET` if the news table grows large.
+
+## Duplications
+
+### Test fixture overlap (acceptable)
+
+`_make_article()` is defined separately in both `tests/integration/test_trending.py` and `tests/integration/test_player_feed.py` with slightly different signatures. The `news_source` fixture is also duplicated. Consider extracting into a shared `tests/integration/factories.py` when the integration test count grows further. Low priority since signatures differ.
+
+No significant production code duplication was found. The `_NEWS_FEED_COLUMNS` shared column list is well DRY'd across `get_news_feed`, `get_hero_article`, and `get_player_news_feed`.
+
+## Architecture Notes (Positive)
+
+- **3-phase ingestion**: Network/AI work -> DB insert -> mention persistence. Each phase has its own transaction boundary with good error isolation.
+- **`resolve_player_names_as_map()`**: Keying by lowered input name is a smart design for handling alias mismatches (e.g., "D.J. Harper" -> Dylan Harper's player_id).
+- **`_NEWS_FEED_COLUMNS`**: Shared column list with "keep in sync" comment is good practice.
+- **Integration tests**: Thorough coverage of mention-based feeds, direct `player_id`, dedup, backfill, and the API endpoint.
+- **`is_player_specific` flag**: Clean way to let the UI differentiate player-relevant vs backfilled articles.
+
+## Files Changed
+
+### Modified
+- `app/models/news.py` — Added `is_player_specific` field to `NewsItemRead`, `mentions_added` to `IngestionResult`
+- `app/routes/news.py` — Route delegates to `get_player_news_feed` when `player_id` is provided
+- `app/routes/ui.py` — Homepage renders trending players section; player detail uses player-specific feed
+- `app/schemas/players_master.py` — Added `is_stub` field
+- `app/services/news_ingestion_service.py` — Phase 3 mention persistence; AI-detected player names resolved and stored
+- `app/services/news_service.py` — `get_trending_players`, `get_player_news_feed` (UNION-based), shared `_NEWS_FEED_COLUMNS`
+- `app/services/news_summarization_service.py` — Gemini prompt extended to extract `mentioned_players`; `ArticleAnalysis` model updated
+- `app/static/css/home.css` — Trending player card styles
+- `app/static/js/home.js` — `TrendingModule` for rendering trending players
+- `app/templates/home.html` — Trending section markup, story filter buttons
+- `tests/integration/conftest.py` — Added `news_item_player_mentions` schema import
+
+### New
+- `alembic/versions/h7i8j9k0l1m2_add_player_mentions.py` — Migration: junction table + `is_stub` column
+- `app/schemas/news_item_player_mentions.py` — `NewsItemPlayerMention` junction table schema
+- `app/services/player_mention_service.py` — Name resolution service (display_name, alias, stub creation)
+- `scripts/backfill_player_mentions.py` — Backfill script for existing articles
+- `tests/integration/test_player_feed.py` — Player feed service + API integration tests
+- `tests/integration/test_player_mentions.py` — Player mention resolution integration tests
+- `tests/integration/test_trending.py` — Trending players integration tests
+- `tests/unit/test_news_summarization.py` — Parse response unit tests (mentioned_players handling)
+- `tests/unit/test_player_mention_service.py` — `split_name` unit tests

--- a/scripts/backfill_player_mentions.py
+++ b/scripts/backfill_player_mentions.py
@@ -1,0 +1,160 @@
+"""Backfill player mentions for existing news items using string matching.
+
+Scans title + description of each NewsItem against known PlayerMaster
+display names and PlayerAlias full names (case-insensitive word-boundary match).
+Also creates mention rows for any existing NewsItem.player_id associations.
+
+Usage:
+    python scripts/backfill_player_mentions.py
+
+Requires DATABASE_URL in environment or .env file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import sys
+
+from dotenv import load_dotenv
+
+# Ensure project root is on sys.path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+load_dotenv()
+
+from sqlalchemy import select  # noqa: E402
+from sqlalchemy.dialects.postgresql import insert  # noqa: E402
+from sqlalchemy.ext.asyncio import (  # noqa: E402
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from app.schemas.news_item_player_mentions import (  # noqa: E402
+    MentionSource,
+    NewsItemPlayerMention,
+)
+from app.schemas.news_items import NewsItem  # noqa: E402
+from app.schemas.player_aliases import PlayerAlias  # noqa: E402
+from app.schemas.players_master import PlayerMaster  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+async def _build_name_lookup(
+    db: AsyncSession,
+) -> dict[re.Pattern[str], int]:
+    """Build a word-boundary regex -> player_id lookup from display names and aliases."""
+    lookup: dict[re.Pattern[str], int] = {}
+
+    # Load display names
+    result = await db.execute(
+        select(PlayerMaster.id, PlayerMaster.display_name).where(
+            PlayerMaster.display_name.isnot(None)  # type: ignore[union-attr]
+        )
+    )
+    for player_id, display_name in result.all():
+        if display_name and len(display_name) >= 4:
+            pattern = re.compile(r"\b" + re.escape(display_name.lower()) + r"\b")
+            lookup[pattern] = player_id  # type: ignore[assignment]
+
+    # Load aliases
+    result = await db.execute(select(PlayerAlias.player_id, PlayerAlias.full_name))
+    for player_id, full_name in result.all():
+        if full_name and len(full_name) >= 4:
+            pattern = re.compile(r"\b" + re.escape(full_name.lower()) + r"\b")
+            lookup[pattern] = player_id  # type: ignore[assignment]
+
+    return lookup
+
+
+def _find_mentions(text: str, name_lookup: dict[re.Pattern[str], int]) -> set[int]:
+    """Find all player IDs mentioned in the given text via word-boundary regex."""
+    text_lower = text.lower()
+    found: set[int] = set()
+    for pattern, player_id in name_lookup.items():
+        if pattern.search(text_lower):
+            found.add(player_id)
+    return found
+
+
+async def backfill() -> None:
+    """Run the backfill process."""
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        logger.error("DATABASE_URL not set")
+        sys.exit(1)
+
+    engine = create_async_engine(database_url, echo=False)
+
+    session_factory = async_sessionmaker(
+        bind=engine, expire_on_commit=False, class_=AsyncSession
+    )
+
+    async with session_factory() as db:
+        name_lookup = await _build_name_lookup(db)
+        logger.info(f"Loaded {len(name_lookup)} player name entries for matching")
+
+        # Fetch all news items
+        result = await db.execute(
+            select(
+                NewsItem.id,
+                NewsItem.title,
+                NewsItem.description,
+                NewsItem.player_id,
+            )
+        )
+        items = result.all()
+        logger.info(f"Processing {len(items)} news items")
+
+        mention_rows: list[dict] = []
+        seen: set[tuple[int, int]] = set()
+
+        for news_item_id, title, description, existing_player_id in items:
+            # Word-boundary regex matching
+            text = f"{title or ''} {description or ''}"
+            matched_ids = _find_mentions(text, name_lookup)
+
+            # Also include existing player_id association
+            if existing_player_id is not None:
+                matched_ids.add(existing_player_id)
+
+            for player_id in matched_ids:
+                key = (news_item_id, player_id)
+                if key not in seen:
+                    seen.add(key)
+                    mention_rows.append(
+                        {
+                            "news_item_id": news_item_id,
+                            "player_id": player_id,
+                            "source": MentionSource.BACKFILL,
+                        }
+                    )
+
+        if mention_rows:
+            stmt = (
+                insert(NewsItemPlayerMention)
+                .values(mention_rows)
+                .on_conflict_do_nothing(constraint="uq_news_item_player_mention")
+                .returning(NewsItemPlayerMention.__table__.c.id)  # type: ignore[attr-defined]
+            )
+            result = await db.execute(stmt)
+            inserted_count = len(list(result.scalars().all()))
+            await db.commit()
+            logger.info(
+                f"Inserted {inserted_count} mention rows "
+                f"({len(mention_rows)} attempted, "
+                f"{len(mention_rows) - inserted_count} already existed)"
+            )
+        else:
+            logger.info("No mentions found to backfill")
+
+    await engine.dispose()
+    logger.info("Backfill complete")
+
+
+if __name__ == "__main__":
+    asyncio.run(backfill())

--- a/tests/integration/test_persist_player_mentions.py
+++ b/tests/integration/test_persist_player_mentions.py
@@ -1,0 +1,211 @@
+"""Integration tests for _persist_player_mentions in news_ingestion_service."""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.news_item_player_mentions import MentionSource, NewsItemPlayerMention
+from app.schemas.news_sources import NewsSource
+from app.schemas.players_master import PlayerMaster
+from app.services.news_ingestion_service import _persist_player_mentions
+from tests.integration.conftest import make_article, make_player
+
+
+@pytest.mark.asyncio
+class TestPersistPlayerMentions:
+    """Tests for the _persist_player_mentions ingestion phase."""
+
+    async def test_creates_mention_rows_for_known_players(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+    ) -> None:
+        """Known player names are resolved and mention rows are inserted."""
+        player = make_player("Cooper", "Flagg")
+        db_session.add(player)
+        await db_session.flush()
+
+        article = make_article(news_source.id, "ext-1")  # type: ignore[arg-type]
+        db_session.add(article)
+        await db_session.commit()
+
+        inserted = await _persist_player_mentions(
+            db_session,
+            source_id=news_source.id,  # type: ignore[arg-type]
+            mention_map={"ext-1": ["Cooper Flagg"]},
+        )
+        assert inserted == 1
+
+        # Verify the row in the database
+        stmt = select(NewsItemPlayerMention).where(
+            NewsItemPlayerMention.news_item_id == article.id  # type: ignore[arg-type]
+        )
+        rows = (await db_session.execute(stmt)).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].player_id == player.id
+        assert rows[0].source == MentionSource.AI
+
+    async def test_creates_stub_for_unknown_player(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+    ) -> None:
+        """Unknown player names create stub records and mention rows."""
+        article = make_article(news_source.id, "ext-2")  # type: ignore[arg-type]
+        db_session.add(article)
+        await db_session.commit()
+
+        inserted = await _persist_player_mentions(
+            db_session,
+            source_id=news_source.id,  # type: ignore[arg-type]
+            mention_map={"ext-2": ["Brand New Prospect"]},
+        )
+        assert inserted == 1
+
+        # Verify stub player was created
+        stmt = select(PlayerMaster).where(
+            PlayerMaster.display_name == "Brand New Prospect"
+        )
+        stub = (await db_session.execute(stmt)).scalar_one()
+        assert stub.is_stub is True
+
+    async def test_multiple_players_per_article(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+    ) -> None:
+        """Multiple player names for one article create separate mention rows."""
+        player_a = make_player("Cooper", "Flagg")
+        player_b = make_player("Ace", "Bailey")
+        db_session.add_all([player_a, player_b])
+        await db_session.flush()
+
+        article = make_article(news_source.id, "ext-3")  # type: ignore[arg-type]
+        db_session.add(article)
+        await db_session.commit()
+
+        inserted = await _persist_player_mentions(
+            db_session,
+            source_id=news_source.id,  # type: ignore[arg-type]
+            mention_map={"ext-3": ["Cooper Flagg", "Ace Bailey"]},
+        )
+        assert inserted == 2
+
+    async def test_deduplicates_same_player_in_article(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+    ) -> None:
+        """Duplicate player name in the same article produces only one mention."""
+        player = make_player("Cooper", "Flagg")
+        db_session.add(player)
+        await db_session.flush()
+
+        article = make_article(news_source.id, "ext-4")  # type: ignore[arg-type]
+        db_session.add(article)
+        await db_session.commit()
+
+        inserted = await _persist_player_mentions(
+            db_session,
+            source_id=news_source.id,  # type: ignore[arg-type]
+            mention_map={"ext-4": ["Cooper Flagg", "Cooper Flagg"]},
+        )
+        assert inserted == 1
+
+    async def test_skips_unknown_external_ids(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+    ) -> None:
+        """External IDs not in the database are silently skipped."""
+        player = make_player("Cooper", "Flagg")
+        db_session.add(player)
+        await db_session.flush()
+        await db_session.commit()
+
+        inserted = await _persist_player_mentions(
+            db_session,
+            source_id=news_source.id,  # type: ignore[arg-type]
+            mention_map={"nonexistent-ext-id": ["Cooper Flagg"]},
+        )
+        assert inserted == 0
+
+    async def test_empty_mention_map_returns_zero(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+    ) -> None:
+        """Empty mention_map returns zero without any DB operations."""
+        inserted = await _persist_player_mentions(
+            db_session,
+            source_id=news_source.id,  # type: ignore[arg-type]
+            mention_map={},
+        )
+        assert inserted == 0
+
+    async def test_conflict_handling_on_duplicate_insert(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+    ) -> None:
+        """Re-running with same data should not raise and returns 0 new inserts."""
+        player = make_player("Cooper", "Flagg")
+        db_session.add(player)
+        await db_session.flush()
+
+        article = make_article(news_source.id, "ext-dup")  # type: ignore[arg-type]
+        db_session.add(article)
+        await db_session.commit()
+
+        mention_map = {"ext-dup": ["Cooper Flagg"]}
+
+        first = await _persist_player_mentions(
+            db_session,
+            source_id=news_source.id,  # type: ignore[arg-type]
+            mention_map=mention_map,
+        )
+        assert first == 1
+
+        # Second call with same data should skip via ON CONFLICT DO NOTHING
+        second = await _persist_player_mentions(
+            db_session,
+            source_id=news_source.id,  # type: ignore[arg-type]
+            mention_map=mention_map,
+        )
+        assert second == 0
+
+    async def test_multiple_articles_with_mentions(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+    ) -> None:
+        """Mention map spanning multiple articles creates correct rows."""
+        player = make_player("Cooper", "Flagg")
+        db_session.add(player)
+        await db_session.flush()
+
+        art1 = make_article(news_source.id, "multi-1")  # type: ignore[arg-type]
+        art2 = make_article(news_source.id, "multi-2", hours_ago=2)  # type: ignore[arg-type]
+        db_session.add_all([art1, art2])
+        await db_session.commit()
+
+        inserted = await _persist_player_mentions(
+            db_session,
+            source_id=news_source.id,  # type: ignore[arg-type]
+            mention_map={
+                "multi-1": ["Cooper Flagg"],
+                "multi-2": ["Cooper Flagg"],
+            },
+        )
+        assert inserted == 2
+
+        # Verify each article has its own mention row
+        stmt = select(NewsItemPlayerMention).where(
+            NewsItemPlayerMention.player_id == player.id  # type: ignore[arg-type]
+        )
+        rows = (await db_session.execute(stmt)).scalars().all()
+        article_ids = {r.news_item_id for r in rows}
+        assert art1.id in article_ids
+        assert art2.id in article_ids

--- a/tests/integration/test_player_feed.py
+++ b/tests/integration/test_player_feed.py
@@ -1,0 +1,258 @@
+"""Integration tests for get_player_news_feed service function."""
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.news_item_player_mentions import MentionSource, NewsItemPlayerMention
+from app.schemas.news_sources import NewsSource
+from app.schemas.players_master import PlayerMaster
+from app.services.news_service import get_player_news_feed
+from tests.integration.conftest import make_article
+
+
+@pytest_asyncio.fixture()
+async def target_player(db_session: AsyncSession) -> PlayerMaster:
+    """Create the player whose feed we're testing."""
+    player = PlayerMaster(
+        first_name="Cooper",
+        last_name="Flagg",
+        display_name="Cooper Flagg",
+        draft_year=2025,
+        is_stub=False,
+    )
+    db_session.add(player)
+    await db_session.flush()
+    return player
+
+
+@pytest.mark.asyncio
+class TestGetPlayerNewsFeed:
+    """Tests for the get_player_news_feed service function."""
+
+    async def test_returns_articles_via_mention(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+        target_player: PlayerMaster,
+    ) -> None:
+        """Articles linked via the mention junction table are returned."""
+        article = make_article(news_source.id, "mention-art")  # type: ignore[arg-type]
+        db_session.add(article)
+        await db_session.flush()
+
+        mention = NewsItemPlayerMention(
+            news_item_id=article.id,  # type: ignore[arg-type]
+            player_id=target_player.id,  # type: ignore[arg-type]
+            source=MentionSource.AI,
+            created_at=datetime.now(timezone.utc).replace(tzinfo=None),
+        )
+        db_session.add(mention)
+        await db_session.commit()
+
+        result = await get_player_news_feed(
+            db_session, player_id=target_player.id  # type: ignore[arg-type]
+        )
+        assert len(result.items) >= 1
+        titles = [item.title for item in result.items]
+        assert "Article mention-art" in titles
+
+    async def test_returns_articles_via_direct_player_id(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+        target_player: PlayerMaster,
+    ) -> None:
+        """Articles with NewsItem.player_id set directly are returned."""
+        article = make_article(
+            news_source.id,  # type: ignore[arg-type]
+            "direct-art",
+            player_id=target_player.id,  # type: ignore[arg-type]
+        )
+        db_session.add(article)
+        await db_session.commit()
+
+        result = await get_player_news_feed(
+            db_session, player_id=target_player.id  # type: ignore[arg-type]
+        )
+        titles = [item.title for item in result.items]
+        assert "Article direct-art" in titles
+
+    async def test_no_duplicates_between_mention_and_direct(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+        target_player: PlayerMaster,
+    ) -> None:
+        """An article linked both ways should appear only once."""
+        article = make_article(
+            news_source.id,  # type: ignore[arg-type]
+            "both-art",
+            player_id=target_player.id,  # type: ignore[arg-type]
+        )
+        db_session.add(article)
+        await db_session.flush()
+
+        mention = NewsItemPlayerMention(
+            news_item_id=article.id,  # type: ignore[arg-type]
+            player_id=target_player.id,  # type: ignore[arg-type]
+            source=MentionSource.AI,
+            created_at=datetime.now(timezone.utc).replace(tzinfo=None),
+        )
+        db_session.add(mention)
+        await db_session.commit()
+
+        result = await get_player_news_feed(
+            db_session, player_id=target_player.id  # type: ignore[arg-type]
+        )
+        article_ids = [item.id for item in result.items if item.title == "Article both-art"]
+        assert len(article_ids) == 1
+
+    async def test_backfills_when_insufficient_player_articles(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+        target_player: PlayerMaster,
+    ) -> None:
+        """When player-specific articles < min_items, general articles are added."""
+        # Create 1 player-specific article
+        player_art = make_article(
+            news_source.id,  # type: ignore[arg-type]
+            "player-only",
+            player_id=target_player.id,  # type: ignore[arg-type]
+        )
+        db_session.add(player_art)
+
+        # Create several general articles (no player association)
+        for i in range(5):
+            general = make_article(
+                news_source.id,  # type: ignore[arg-type]
+                f"general-{i}",
+                hours_ago=2 + i,
+            )
+            db_session.add(general)
+        await db_session.commit()
+
+        result = await get_player_news_feed(
+            db_session,
+            player_id=target_player.id,  # type: ignore[arg-type]
+            min_items=5,
+        )
+        # Should have the 1 player-specific + 4 backfilled = 5 total
+        assert len(result.items) >= 5
+
+    async def test_is_player_specific_flag(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+        target_player: PlayerMaster,
+    ) -> None:
+        """Player-specific items are flagged; backfilled items are not."""
+        # Player article
+        player_art = make_article(
+            news_source.id,  # type: ignore[arg-type]
+            "flagged-art",
+            player_id=target_player.id,  # type: ignore[arg-type]
+        )
+        db_session.add(player_art)
+
+        # General article for backfill
+        general_art = make_article(
+            news_source.id,  # type: ignore[arg-type]
+            "general-art",
+            hours_ago=5,
+        )
+        db_session.add(general_art)
+        await db_session.commit()
+
+        result = await get_player_news_feed(
+            db_session,
+            player_id=target_player.id,  # type: ignore[arg-type]
+            min_items=3,
+        )
+        player_items = [i for i in result.items if i.is_player_specific]
+        general_items = [i for i in result.items if not i.is_player_specific]
+        assert len(player_items) >= 1
+        assert any(i.title == "Article flagged-art" for i in player_items)
+        assert any(i.title == "Article general-art" for i in general_items)
+
+    async def test_empty_feed_for_player_with_no_articles(
+        self,
+        db_session: AsyncSession,
+        target_player: PlayerMaster,
+    ) -> None:
+        """Player with no mentions or direct articles returns empty feed."""
+        result = await get_player_news_feed(
+            db_session,
+            player_id=target_player.id,  # type: ignore[arg-type]
+            min_items=0,
+        )
+        assert result.items == []
+        assert result.total == 0
+
+    async def test_total_count_reflects_player_specific_only(
+        self,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+        target_player: PlayerMaster,
+    ) -> None:
+        """The total count should reflect player-specific articles, not backfill."""
+        # Create 2 player-specific articles
+        for i in range(2):
+            art = make_article(
+                news_source.id,  # type: ignore[arg-type]
+                f"count-art-{i}",
+                player_id=target_player.id,  # type: ignore[arg-type]
+                hours_ago=i + 1,
+            )
+            db_session.add(art)
+
+        # Create general articles
+        for i in range(3):
+            general = make_article(
+                news_source.id,  # type: ignore[arg-type]
+                f"count-general-{i}",
+                hours_ago=10 + i,
+            )
+            db_session.add(general)
+        await db_session.commit()
+
+        result = await get_player_news_feed(
+            db_session,
+            player_id=target_player.id,  # type: ignore[arg-type]
+            min_items=5,
+        )
+        # Total should be 2 (player-specific only), even though items list has backfill
+        assert result.total == 2
+        assert len(result.items) >= 5
+
+
+@pytest.mark.asyncio
+class TestPlayerFeedAPI:
+    """Tests for the /api/news?player_id= endpoint."""
+
+    async def test_api_returns_player_feed(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        news_source: NewsSource,
+        target_player: PlayerMaster,
+    ) -> None:
+        """GET /api/news?player_id=X delegates to player-specific feed."""
+        article = make_article(
+            news_source.id,  # type: ignore[arg-type]
+            "api-art",
+            player_id=target_player.id,  # type: ignore[arg-type]
+        )
+        db_session.add(article)
+        await db_session.commit()
+
+        response = await app_client.get(f"/api/news?player_id={target_player.id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) >= 1
+        titles = [item["title"] for item in data["items"]]
+        assert "Article api-art" in titles

--- a/tests/integration/test_player_mentions.py
+++ b/tests/integration/test_player_mentions.py
@@ -1,0 +1,176 @@
+"""Integration tests for player mention resolution and junction table."""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.player_aliases import PlayerAlias
+from app.schemas.players_master import PlayerMaster
+from app.services.player_mention_service import (
+    PlayerMatch,
+    resolve_player_names,
+)
+
+
+@pytest_asyncio.fixture()
+async def known_player(db_session: AsyncSession) -> PlayerMaster:
+    """Insert a known player for matching tests."""
+    player = PlayerMaster(
+        first_name="Cooper",
+        last_name="Flagg",
+        display_name="Cooper Flagg",
+        draft_year=2025,
+        is_stub=False,
+    )
+    db_session.add(player)
+    await db_session.flush()
+    return player
+
+
+@pytest_asyncio.fixture()
+async def player_with_alias(db_session: AsyncSession) -> PlayerMaster:
+    """Insert a player with an alias for alias-matching tests."""
+    player = PlayerMaster(
+        first_name="Dylan",
+        last_name="Harper",
+        display_name="Dylan Harper",
+        draft_year=2025,
+        is_stub=False,
+    )
+    db_session.add(player)
+    await db_session.flush()
+
+    alias = PlayerAlias(
+        player_id=player.id,  # type: ignore[arg-type]
+        full_name="D.J. Harper",
+        first_name="D.J.",
+        last_name="Harper",
+    )
+    db_session.add(alias)
+    await db_session.flush()
+
+    return player
+
+
+@pytest.mark.asyncio
+async def test_resolve_known_player_by_display_name(
+    db_session: AsyncSession, known_player: PlayerMaster
+) -> None:
+    """Resolving an exact display_name match should return the known player."""
+    results = await resolve_player_names(
+        db_session, ["Cooper Flagg"], create_stubs=False
+    )
+    assert len(results) == 1
+    assert results[0].player_id == known_player.id
+    assert results[0].matched_via == "display_name"
+
+
+@pytest.mark.asyncio
+async def test_resolve_case_insensitive(
+    db_session: AsyncSession, known_player: PlayerMaster
+) -> None:
+    """Name matching should be case-insensitive."""
+    results = await resolve_player_names(
+        db_session, ["cooper flagg"], create_stubs=False
+    )
+    assert len(results) == 1
+    assert results[0].player_id == known_player.id
+
+
+@pytest.mark.asyncio
+async def test_resolve_via_alias(
+    db_session: AsyncSession, player_with_alias: PlayerMaster
+) -> None:
+    """Should match via PlayerAlias when display_name doesn't match."""
+    results = await resolve_player_names(
+        db_session, ["D.J. Harper"], create_stubs=False
+    )
+    assert len(results) == 1
+    assert results[0].player_id == player_with_alias.id
+    assert results[0].matched_via == "alias"
+
+
+@pytest.mark.asyncio
+async def test_create_stub_for_unknown_name(db_session: AsyncSession) -> None:
+    """Unknown names should create stub PlayerMaster records."""
+    results = await resolve_player_names(
+        db_session, ["Totally New Player"], create_stubs=True
+    )
+    assert len(results) == 1
+    assert results[0].matched_via == "stub_created"
+    assert results[0].display_name == "Totally New Player"
+
+    # Verify the stub was created in the database
+    stmt = select(PlayerMaster).where(
+        PlayerMaster.id == results[0].player_id
+    )
+    row = (await db_session.execute(stmt)).scalar_one()
+    assert row.is_stub is True
+    assert row.first_name == "Totally"
+    assert row.last_name == "New Player"
+
+
+@pytest.mark.asyncio
+async def test_stub_gets_slug(db_session: AsyncSession) -> None:
+    """Stub players should get auto-generated slugs via the before_insert listener."""
+    results = await resolve_player_names(
+        db_session, ["Brand New Prospect"], create_stubs=True
+    )
+    assert len(results) == 1
+
+    stmt = select(PlayerMaster).where(
+        PlayerMaster.id == results[0].player_id
+    )
+    row = (await db_session.execute(stmt)).scalar_one()
+    assert row.slug is not None
+    assert "brand-new-prospect" in row.slug
+
+
+@pytest.mark.asyncio
+async def test_dedup_within_batch(
+    db_session: AsyncSession, known_player: PlayerMaster
+) -> None:
+    """Duplicate names in a single batch should be deduplicated."""
+    results = await resolve_player_names(
+        db_session,
+        ["Cooper Flagg", "Cooper Flagg", "cooper flagg"],
+        create_stubs=False,
+    )
+    assert len(results) == 1
+    assert results[0].player_id == known_player.id
+
+
+@pytest.mark.asyncio
+async def test_no_stub_when_disabled(db_session: AsyncSession) -> None:
+    """With create_stubs=False, unknown names should be skipped."""
+    results = await resolve_player_names(
+        db_session, ["Unknown Player X"], create_stubs=False
+    )
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_names_list(db_session: AsyncSession) -> None:
+    """Empty input should return empty results."""
+    results = await resolve_player_names(db_session, [])
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_mixed_known_and_unknown(
+    db_session: AsyncSession, known_player: PlayerMaster
+) -> None:
+    """Mix of known and unknown names should resolve correctly."""
+    results = await resolve_player_names(
+        db_session,
+        ["Cooper Flagg", "Brand New Prospect"],
+        create_stubs=True,
+    )
+    assert len(results) == 2
+    ids = {r.player_id for r in results}
+    assert known_player.id in ids
+    # Second result should be a newly created stub
+    stub = [r for r in results if r.matched_via == "stub_created"]
+    assert len(stub) == 1
+    assert stub[0].display_name == "Brand New Prospect"

--- a/tests/integration/test_trending.py
+++ b/tests/integration/test_trending.py
@@ -1,0 +1,269 @@
+"""Integration tests for get_trending_players service function."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.news_item_player_mentions import MentionSource, NewsItemPlayerMention
+from app.schemas.news_sources import NewsSource
+from app.services.news_service import get_trending_players
+from tests.integration.conftest import make_article, make_player
+
+
+@pytest.mark.asyncio
+class TestGetTrendingPlayers:
+    """Tests for the get_trending_players service function."""
+
+    async def test_empty_when_no_mentions(self, db_session: AsyncSession) -> None:
+        """Returns empty list when no mention rows exist."""
+        result = await get_trending_players(db_session)
+        assert result == []
+
+    async def test_returns_players_ordered_by_recency_weighted_score(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """Players with more mentions rank higher by trending_score."""
+        player_a = make_player("Cooper", "Flagg", school="Duke")
+        player_b = make_player("Dylan", "Harper", school="Rutgers")
+        db_session.add_all([player_a, player_b])
+        await db_session.flush()
+
+        # Player A: 3 articles published now, Player B: 1 article published now
+        articles = [
+            make_article(news_source.id, f"art-{i}", hours_ago=0)  # type: ignore[arg-type]
+            for i in range(4)
+        ]
+        for a in articles:
+            db_session.add(a)
+        await db_session.flush()
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        mentions = [
+            NewsItemPlayerMention(
+                news_item_id=articles[0].id,  # type: ignore[arg-type]
+                player_id=player_a.id,  # type: ignore[arg-type]
+                source=MentionSource.AI,
+                created_at=now,
+            ),
+            NewsItemPlayerMention(
+                news_item_id=articles[1].id,  # type: ignore[arg-type]
+                player_id=player_a.id,  # type: ignore[arg-type]
+                source=MentionSource.AI,
+                created_at=now,
+            ),
+            NewsItemPlayerMention(
+                news_item_id=articles[2].id,  # type: ignore[arg-type]
+                player_id=player_a.id,  # type: ignore[arg-type]
+                source=MentionSource.AI,
+                created_at=now,
+            ),
+            NewsItemPlayerMention(
+                news_item_id=articles[3].id,  # type: ignore[arg-type]
+                player_id=player_b.id,  # type: ignore[arg-type]
+                source=MentionSource.AI,
+                created_at=now,
+            ),
+        ]
+        for m in mentions:
+            db_session.add(m)
+        await db_session.commit()
+
+        result = await get_trending_players(db_session, days=7, limit=10)
+        assert len(result) == 2
+        assert result[0].player_id == player_a.id
+        assert result[0].mention_count == 3
+        assert result[0].trending_score > 0
+        assert result[1].player_id == player_b.id
+        assert result[1].mention_count == 1
+
+    async def test_recency_weighting_affects_ranking(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """A player with 1 recent mention outranks a player with 1 old mention."""
+        player_recent = make_player("Recent", "Player", school="Duke")
+        player_old = make_player("Old", "Player", school="Rutgers")
+        db_session.add_all([player_recent, player_old])
+        await db_session.flush()
+
+        # Article published ~0h ago vs ~6 days ago
+        art_recent = make_article(
+            news_source.id, "recent-art", hours_ago=0  # type: ignore[arg-type]
+        )
+        art_old = make_article(
+            news_source.id, "old-art", hours_ago=6 * 24  # type: ignore[arg-type]
+        )
+        db_session.add_all([art_recent, art_old])
+        await db_session.flush()
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        db_session.add_all(
+            [
+                NewsItemPlayerMention(
+                    news_item_id=art_recent.id,  # type: ignore[arg-type]
+                    player_id=player_recent.id,  # type: ignore[arg-type]
+                    source=MentionSource.AI,
+                    created_at=now,
+                ),
+                NewsItemPlayerMention(
+                    news_item_id=art_old.id,  # type: ignore[arg-type]
+                    player_id=player_old.id,  # type: ignore[arg-type]
+                    source=MentionSource.AI,
+                    created_at=now - timedelta(days=6),
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        result = await get_trending_players(db_session, days=7, limit=10)
+        assert len(result) == 2
+        # Recent player should rank first due to higher recency weight
+        assert result[0].player_id == player_recent.id
+        assert result[0].trending_score > result[1].trending_score
+        assert result[1].player_id == player_old.id
+
+    async def test_daily_counts_populated(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """Daily counts list has correct length and non-zero values on the right days."""
+        player = make_player("Daily", "Count", school="UNC")
+        db_session.add(player)
+        await db_session.flush()
+
+        # Articles published today and 2 days ago
+        art_today = make_article(
+            news_source.id, "today-art", hours_ago=1  # type: ignore[arg-type]
+        )
+        art_2d = make_article(
+            news_source.id, "2d-art", hours_ago=48  # type: ignore[arg-type]
+        )
+        db_session.add_all([art_today, art_2d])
+        await db_session.flush()
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        db_session.add_all(
+            [
+                NewsItemPlayerMention(
+                    news_item_id=art_today.id,  # type: ignore[arg-type]
+                    player_id=player.id,  # type: ignore[arg-type]
+                    source=MentionSource.AI,
+                    created_at=now,
+                ),
+                NewsItemPlayerMention(
+                    news_item_id=art_2d.id,  # type: ignore[arg-type]
+                    player_id=player.id,  # type: ignore[arg-type]
+                    source=MentionSource.AI,
+                    created_at=now - timedelta(days=2),
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        result = await get_trending_players(db_session, days=7, limit=10)
+        assert len(result) == 1
+        tp = result[0]
+        # daily_counts should be a list of 7 ints (oldest-first)
+        assert len(tp.daily_counts) == 7
+        assert sum(tp.daily_counts) == 2
+        # Last element (today) should be >= 1
+        assert tp.daily_counts[-1] >= 1
+
+    async def test_excludes_mentions_outside_time_window(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """Mentions older than the time window are excluded."""
+        player = make_player("Old", "Mention")
+        db_session.add(player)
+        await db_session.flush()
+
+        # Article published 10 days ago
+        article = make_article(
+            news_source.id, "old-art", hours_ago=10 * 24  # type: ignore[arg-type]
+        )
+        db_session.add(article)
+        await db_session.flush()
+
+        old_time = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=10)
+        mention = NewsItemPlayerMention(
+            news_item_id=article.id,  # type: ignore[arg-type]
+            player_id=player.id,  # type: ignore[arg-type]
+            source=MentionSource.AI,
+            created_at=old_time,
+        )
+        db_session.add(mention)
+        await db_session.commit()
+
+        # Default 7-day window should exclude it
+        result = await get_trending_players(db_session, days=7)
+        assert result == []
+
+        # Wider window should include it
+        result = await get_trending_players(db_session, days=30)
+        assert len(result) == 1
+        assert result[0].player_id == player.id
+
+    async def test_includes_player_metadata(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """Trending results include display_name, slug, school, and new fields."""
+        player = make_player("Ace", "Bailey", school="Rutgers")
+        db_session.add(player)
+        await db_session.flush()
+
+        article = make_article(
+            news_source.id, "meta-art", hours_ago=0  # type: ignore[arg-type]
+        )
+        db_session.add(article)
+        await db_session.flush()
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        mention = NewsItemPlayerMention(
+            news_item_id=article.id,  # type: ignore[arg-type]
+            player_id=player.id,  # type: ignore[arg-type]
+            source=MentionSource.AI,
+            created_at=now,
+        )
+        db_session.add(mention)
+        await db_session.commit()
+
+        result = await get_trending_players(db_session)
+        assert len(result) == 1
+        tp = result[0]
+        assert tp.display_name == "Ace Bailey"
+        assert tp.slug is not None
+        assert "ace-bailey" in tp.slug
+        assert tp.school == "Rutgers"
+        assert tp.trending_score > 0
+        assert isinstance(tp.daily_counts, list)
+        assert len(tp.daily_counts) == 7
+        assert tp.latest_mention_at is not None
+
+    async def test_respects_limit(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """Limit parameter caps the number of returned players."""
+        players = [make_player(f"Player{i}", "Test") for i in range(5)]
+        db_session.add_all(players)
+        await db_session.flush()
+
+        articles = [
+            make_article(news_source.id, f"lim-art-{i}", hours_ago=0)  # type: ignore[arg-type]
+            for i in range(5)
+        ]
+        for a in articles:
+            db_session.add(a)
+        await db_session.flush()
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        for i, player in enumerate(players):
+            mention = NewsItemPlayerMention(
+                news_item_id=articles[i].id,  # type: ignore[arg-type]
+                player_id=player.id,  # type: ignore[arg-type]
+                source=MentionSource.AI,
+                created_at=now,
+            )
+            db_session.add(mention)
+        await db_session.commit()
+
+        result = await get_trending_players(db_session, limit=3)
+        assert len(result) == 3

--- a/tests/unit/test_news_summarization.py
+++ b/tests/unit/test_news_summarization.py
@@ -1,0 +1,57 @@
+"""Unit tests for the news summarization service parse logic."""
+
+from app.schemas.news_items import NewsItemTag
+from app.services.news_summarization_service import NewsSummarizationService
+
+
+class TestParseResponse:
+    """Tests for NewsSummarizationService._parse_response()."""
+
+    def setup_method(self) -> None:
+        self.service = NewsSummarizationService()
+
+    def test_parse_with_mentioned_players(self) -> None:
+        """Should extract mentioned_players from valid JSON."""
+        response = '{"summary": "A deep dive.", "tag": "Scouting Report", "mentioned_players": ["Cooper Flagg", "Ace Bailey"]}'
+        result = self.service._parse_response(response)
+        assert result.summary == "A deep dive."
+        assert result.tag == NewsItemTag.SCOUTING_REPORT
+        assert result.mentioned_players == ["Cooper Flagg", "Ace Bailey"]
+
+    def test_parse_without_mentioned_players(self) -> None:
+        """Should default to empty list when mentioned_players is absent."""
+        response = '{"summary": "A mock draft.", "tag": "Mock Draft"}'
+        result = self.service._parse_response(response)
+        assert result.summary == "A mock draft."
+        assert result.tag == NewsItemTag.MOCK_DRAFT
+        assert result.mentioned_players == []
+
+    def test_parse_with_empty_mentioned_players(self) -> None:
+        """Should handle empty mentioned_players list."""
+        response = '{"summary": "General analysis.", "tag": "Big Board", "mentioned_players": []}'
+        result = self.service._parse_response(response)
+        assert result.mentioned_players == []
+
+    def test_parse_with_non_list_mentioned_players(self) -> None:
+        """Should handle non-list mentioned_players gracefully."""
+        response = '{"summary": "Test.", "tag": "Big Board", "mentioned_players": "Cooper Flagg"}'
+        result = self.service._parse_response(response)
+        assert result.mentioned_players == []
+
+    def test_parse_filters_non_string_entries(self) -> None:
+        """Should filter out non-string entries from mentioned_players."""
+        response = '{"summary": "Test.", "tag": "Big Board", "mentioned_players": ["Cooper Flagg", 42, null, "Ace Bailey"]}'
+        result = self.service._parse_response(response)
+        assert result.mentioned_players == ["Cooper Flagg", "Ace Bailey"]
+
+    def test_parse_strips_whitespace_from_names(self) -> None:
+        """Should strip whitespace from player names."""
+        response = '{"summary": "Test.", "tag": "Big Board", "mentioned_players": ["  Cooper Flagg  ", "Ace Bailey"]}'
+        result = self.service._parse_response(response)
+        assert result.mentioned_players == ["Cooper Flagg", "Ace Bailey"]
+
+    def test_parse_json_in_code_block(self) -> None:
+        """Should handle JSON wrapped in markdown code blocks."""
+        response = '```json\n{"summary": "Test.", "tag": "Big Board", "mentioned_players": ["Cooper Flagg"]}\n```'
+        result = self.service._parse_response(response)
+        assert result.mentioned_players == ["Cooper Flagg"]

--- a/tests/unit/test_player_mention_service.py
+++ b/tests/unit/test_player_mention_service.py
@@ -1,0 +1,49 @@
+"""Unit tests for the player mention service name-splitting logic."""
+
+from app.services.player_mention_service import split_name
+
+
+class TestSplitName:
+    """Tests for the split_name utility function."""
+
+    def test_two_part_name(self) -> None:
+        """Standard first-last name should split correctly."""
+        first, last = split_name("Cooper Flagg")
+        assert first == "Cooper"
+        assert last == "Flagg"
+
+    def test_three_part_name(self) -> None:
+        """Multi-word last name should be preserved."""
+        first, last = split_name("Lamine Camara Jr")
+        assert first == "Lamine"
+        assert last == "Camara Jr"
+
+    def test_single_word_name(self) -> None:
+        """Single name should return first_name with no last_name."""
+        first, last = split_name("Nene")
+        assert first == "Nene"
+        assert last is None
+
+    def test_empty_string(self) -> None:
+        """Empty string should return empty first_name and None last."""
+        first, last = split_name("")
+        assert first == ""
+        assert last is None
+
+    def test_whitespace_only(self) -> None:
+        """Whitespace-only should return empty first_name and None last."""
+        first, last = split_name("   ")
+        assert first == ""
+        assert last is None
+
+    def test_leading_trailing_whitespace(self) -> None:
+        """Leading/trailing whitespace should be stripped."""
+        first, last = split_name("  Ace Bailey  ")
+        assert first == "Ace"
+        assert last == "Bailey"
+
+    def test_extra_internal_whitespace(self) -> None:
+        """Extra internal whitespace should be collapsed by split."""
+        first, last = split_name("VJ  Edgecombe")
+        assert first == "VJ"
+        assert last == "Edgecombe"


### PR DESCRIPTION
…nd player feed UX

- Rewrite get_trending_players() with linear-decay recency weighting using article published_at for scoring and mention created_at for time window
- Add daily_counts bucketing via _get_daily_mention_counts() helper
- Render inline SVG sparklines and circular player thumbnails in trending cards
- Update trending grid to 2-column layout with responsive breakpoints
- Distinguish player-specific vs backfill articles in player feed with "Mentioned" badge, green left border, and "More Draft News" divider
- Show "Draft News" heading when player has no mention-based articles