### PR TITLE
fix: use enum value lookup for NewsItemTag to fix homepage crash

### DIFF
--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -622,7 +622,7 @@ def _row_to_news_item_read(row: dict, is_player_specific: bool = False) -> NewsI
         image_url=row["image_url"],
         author=row["author"],
         time=format_relative_time(row["published_at"]),
-        tag=NewsItemTag[row["tag"]].value
+        tag=NewsItemTag(row["tag"]).value
         if isinstance(row["tag"], str)
         else row["tag"].value,
         read_more_text=build_read_more_text(source_name),


### PR DESCRIPTION
NewsItemTag[row["tag"]] does name-based lookup (e.g. "GAME_RECAP") but the DB stores the value (e.g. "Game Recap"), causing a KeyError. Switched to NewsItemTag(row["tag"]) for value-based lookup.