### PR TITLE
Fix empty film-player categories and filtered playlists

### DIFF
--- a/app/static/css/film-room.css
+++ b/app/static/css/film-room.css
@@ -630,6 +630,15 @@
   color: var(--color-slate-200);
 }
 
+.film-tab:disabled {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.film-tab:disabled:hover {
+  color: var(--color-slate-400);
+}
+
 .film-tab.active {
   color: var(--film-accent);
 }
@@ -658,18 +667,15 @@
   opacity: 0.5;
 }
 
-.film-tab--empty.active {
-  opacity: 1;
-  color: var(--color-slate-400);
-}
-
-.film-tab--empty.active::after {
-  background: var(--color-slate-500);
-}
-
 .film-tab__count--empty {
   color: var(--color-slate-600);
   opacity: 0.5;
+}
+
+.film-playlist[hidden],
+.film-empty-tab[hidden],
+.film-thumb[hidden] {
+  display: none !important;
 }
 
 .film-playlist {

--- a/app/static/js/film-room.js
+++ b/app/static/js/film-room.js
@@ -66,6 +66,30 @@ function initTabbedFilmPlayer(config) {
   const thumbs = Array.from(playlistItems.querySelectorAll('.film-thumb'));
   if (!tabs.length || !thumbs.length) return;
 
+  const thumbCountsByTag = new Map();
+  thumbs.forEach((thumb) => {
+    const tag = thumb.dataset.tag || '';
+    thumbCountsByTag.set(tag, (thumbCountsByTag.get(tag) || 0) + 1);
+  });
+
+  const getTabVideoCount = (tab) => {
+    const explicitCount = Number.parseInt(tab.dataset.videoCount || '', 10);
+    if (Number.isFinite(explicitCount)) return explicitCount;
+    return thumbCountsByTag.get(tab.dataset.tag || '') || 0;
+  };
+
+  tabs.forEach((tab) => {
+    const count = thumbCountsByTag.get(tab.dataset.tag || '') || 0;
+    tab.dataset.videoCount = String(count);
+    if (count === 0) {
+      tab.disabled = true;
+      tab.setAttribute('aria-disabled', 'true');
+    } else {
+      tab.disabled = false;
+      tab.removeAttribute('aria-disabled');
+    }
+  });
+
   const updateFeaturedFromThumb = (thumb) => {
     thumbs.forEach((item) => item.classList.remove('active'));
     thumb.classList.add('active');
@@ -81,6 +105,8 @@ function initTabbedFilmPlayer(config) {
   };
 
   const refreshPlaylistForTab = (tab) => {
+    if (getTabVideoCount(tab) === 0) return;
+
     tabs.forEach((item) => item.classList.remove('active'));
     tab.classList.add('active');
 
@@ -121,7 +147,10 @@ function initTabbedFilmPlayer(config) {
   };
 
   tabs.forEach((tab) => {
-    tab.addEventListener('click', () => refreshPlaylistForTab(tab));
+    tab.addEventListener('click', () => {
+      if (tab.disabled || getTabVideoCount(tab) === 0) return;
+      refreshPlaylistForTab(tab);
+    });
   });
 
   thumbs.forEach((thumb) => {
@@ -132,7 +161,10 @@ function initTabbedFilmPlayer(config) {
     });
   });
 
-  const initialTab = tabs.find((tab) => tab.classList.contains('active')) || tabs[0];
+  const initialTab =
+    tabs.find((tab) => tab.classList.contains('active') && getTabVideoCount(tab) > 0) ||
+    tabs.find((tab) => getTabVideoCount(tab) > 0);
+  if (!initialTab) return;
   refreshPlaylistForTab(initialTab);
 }
 

--- a/app/templates/partials/film-room-section.html
+++ b/app/templates/partials/film-room-section.html
@@ -48,14 +48,21 @@
 
     <div class="film-tabs" id="homeFilmTabs">
       {% for tag in film_tags %}
-      {% set tag_count = film_room_video_counts.get(tag, 0) %}
+      {% set tag_count = namespace(value=0) %}
+      {% for video in film_room_videos %}
+        {% if video.tag == tag %}
+          {% set tag_count.value = tag_count.value + 1 %}
+        {% endif %}
+      {% endfor %}
       <button
         type="button"
-        class="film-tab{% if ns.active_tag == tag %} active{% endif %}{% if tag_count == 0 %} film-tab--empty{% endif %}"
+        class="film-tab{% if ns.active_tag == tag %} active{% endif %}{% if tag_count.value == 0 %} film-tab--empty{% endif %}"
         data-tag="{{ tag }}"
         data-label="{{ tag }}s"
+        data-video-count="{{ tag_count.value }}"
+        {% if tag_count.value == 0 %}disabled aria-disabled="true"{% endif %}
       >
-        {{ tag }}s <span class="film-tab__count{% if tag_count == 0 %} film-tab__count--empty{% endif %}">({{ tag_count }})</span>
+        {{ tag }}s <span class="film-tab__count{% if tag_count.value == 0 %} film-tab__count--empty{% endif %}">({{ tag_count.value }})</span>
       </button>
       {% endfor %}
     </div>

--- a/app/templates/partials/film-study-section.html
+++ b/app/templates/partials/film-study-section.html
@@ -30,9 +30,16 @@
       </div>
     </div>
     {% else %}
+    {% set loaded_tags = namespace(set=[]) %}
+    {% for video in player_video_feed %}
+      {% if video.tag not in loaded_tags.set %}
+        {% set loaded_tags.set = loaded_tags.set + [video.tag] %}
+      {% endif %}
+    {% endfor %}
+
     {% set ns = namespace(active_tag=None) %}
     {% for tag in film_tags %}
-      {% if ns.active_tag is none and player_video_counts.get(tag, 0) > 0 %}
+      {% if ns.active_tag is none and tag in loaded_tags.set %}
         {% set ns.active_tag = tag %}
       {% endif %}
     {% endfor %}
@@ -52,14 +59,21 @@
 
     <div class="film-tabs" id="filmStudyTabs">
       {% for tag in film_tags %}
-      {% set tag_count = player_video_counts.get(tag, 0) %}
+      {% set tag_count = namespace(value=0) %}
+      {% for video in player_video_feed %}
+        {% if video.tag == tag %}
+          {% set tag_count.value = tag_count.value + 1 %}
+        {% endif %}
+      {% endfor %}
       <button
         type="button"
-        class="film-tab{% if ns.active_tag == tag %} active{% endif %}{% if tag_count == 0 %} film-tab--empty{% endif %}"
+        class="film-tab{% if ns.active_tag == tag %} active{% endif %}{% if tag_count.value == 0 %} film-tab--empty{% endif %}"
         data-tag="{{ tag }}"
         data-label="{{ tag }}"
+        data-video-count="{{ tag_count.value }}"
+        {% if tag_count.value == 0 %}disabled aria-disabled="true"{% endif %}
       >
-        {{ tag }} <span class="film-tab__count{% if tag_count == 0 %} film-tab__count--empty{% endif %}">({{ tag_count }})</span>
+        {{ tag }} <span class="film-tab__count{% if tag_count.value == 0 %} film-tab__count--empty{% endif %}">({{ tag_count.value }})</span>
       </button>
       {% endfor %}
     </div>

--- a/tests/integration/test_videos.py
+++ b/tests/integration/test_videos.py
@@ -373,6 +373,15 @@ class TestFilmRoomPages:
         assert "filmRoomHomeSection" in response.text
         assert "/static/js/film-room.js" in response.text
 
+        soup = BeautifulSoup(response.text, "html.parser")
+        scouting_tab = soup.select_one('#homeFilmTabs .film-tab[data-tag="Scouting Report"]')
+        highlights_tab = soup.select_one('#homeFilmTabs .film-tab[data-tag="Highlights"]')
+
+        assert scouting_tab is not None
+        assert highlights_tab is not None
+        assert scouting_tab.get("disabled") is None
+        assert highlights_tab.get("disabled") == ""
+
     async def test_film_room_stats_follow_tag_filter(
         self,
         app_client: AsyncClient,

--- a/tests/visual/test_film_room_interactions.py
+++ b/tests/visual/test_film_room_interactions.py
@@ -38,6 +38,9 @@ def _homepage_markup() -> str:
                 <button type="button" class="film-tab" data-tag="Conversation" data-label="Conversations">
                   Conversations <span class="film-tab__count">(1)</span>
                 </button>
+                <button type="button" class="film-tab" data-tag="Montage" data-label="Montages">
+                  Montages <span class="film-tab__count">(0)</span>
+                </button>
               </div>
 
               <div class="film-playlist" id="homeFilmPlaylist">
@@ -156,6 +159,9 @@ def _player_markup() -> str:
                 <button type="button" class="film-tab" data-tag="Montage" data-label="Montage">
                   Montage <span class="film-tab__count">(1)</span>
                 </button>
+                <button type="button" class="film-tab" data-tag="Think Piece" data-label="Think Piece">
+                  Think Piece <span class="film-tab__count">(0)</span>
+                </button>
               </div>
 
               <div class="film-playlist" id="playerFilmPlaylist">
@@ -268,6 +274,9 @@ class TestFilmRoomInteractions:
         expect(page.locator("#homeFilmTags .film-player-tag")).to_have_text(
             ["Cooper Flagg"]
         )
+        expect(
+            page.locator('#homeFilmTabs .film-tab[data-tag="Montage"]')
+        ).to_be_disabled()
 
         page.locator('#homeFilmTabs .film-tab[data-tag="Conversation"]').click()
         expect(page.locator("#homeFilmTitle")).to_have_text(
@@ -312,6 +321,9 @@ class TestFilmRoomInteractions:
         )
         expect(page.locator("#playerFilmPlaylistLabel")).to_have_text("Highlights")
         expect(page.locator("#playerFilmPlaylistCount")).to_have_text("2 videos")
+        expect(
+            page.locator('#filmStudyTabs .film-tab[data-tag="Think Piece"]')
+        ).to_be_disabled()
 
         page.locator('#filmStudyTabs .film-tab[data-tag="Montage"]').click()
         expect(page.locator("#playerFilmTitle")).to_have_text(


### PR DESCRIPTION
## Summary
- disable homepage and player-page film tabs when the loaded video set has no videos for that category
- keep the side playlist filtered to the active category so only playable videos remain visible
- add browser and rendered-markup coverage for disabled tabs and filtered playlist behavior

## Checks
- conda run -n draftguru make precommit
- conda run -n draftguru mypy app --ignore-missing-imports
- DATABASE_URL=postgresql://user:pass@localhost:5432/draftguru_test SECRET_KEY=test-secret ENV=dev conda run -n draftguru pytest tests/unit -q
- conda run -n draftguru pytest tests/visual/test_film_room_interactions.py -q
- DATABASE_URL=postgresql://user:pass@localhost:5432/draftguru_test SECRET_KEY=test-secret ENV=dev TEST=film_room_interactions conda run -n draftguru make visual

## Notes
- conda run -n draftguru pytest tests/integration/test_videos.py -q was attempted, but it skips here because TEST_DATABASE_URL and PYTEST_ALLOW_DB are not configured in this environment.