### PR TITLE
fix: video ingestion never committed transactions to database

### DIFF
--- a/app/cli/cron_runner.py
+++ b/app/cli/cron_runner.py
@@ -70,8 +70,7 @@ async def _run_podcast_job() -> None:
 
 async def _run_video_job() -> None:
     """Run video ingestion and log a concise summary."""
-    async with SessionLocal() as db:
-        result = await run_video_ingestion_cycle(db)
+    result = await run_video_ingestion_cycle(SessionLocal)
 
     logger.info(
         "Video ingestion complete: %s channels, %s added, %s skipped",

--- a/app/routes/admin/youtube_channels.py
+++ b/app/routes/admin/youtube_channels.py
@@ -19,7 +19,7 @@ from app.schemas.player_content_mentions import ContentType, PlayerContentMentio
 from app.schemas.youtube_channels import YouTubeChannel
 from app.schemas.youtube_videos import YouTubeVideo
 from app.services.video_ingestion_service import run_ingestion_cycle
-from app.utils.db_async import get_session
+from app.utils.db_async import SessionLocal, get_session
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +104,7 @@ async def ingest_youtube_channels(
     assert user is not None
 
     try:
-        result = await run_ingestion_cycle(db)
+        result = await run_ingestion_cycle(SessionLocal)
         return RedirectResponse(
             url=(
                 f"/admin/youtube-channels?success=ingested"

--- a/app/routes/videos.py
+++ b/app/routes/videos.py
@@ -18,6 +18,7 @@ from app.models.videos import (
 from app.schemas.youtube_channels import YouTubeChannel
 from app.services.staff_authz import require_dataset_permission
 from app.services.video_ingestion_service import add_video_by_url, run_ingestion_cycle
+from app.utils.db_async import SessionLocal
 from app.services.video_service import get_film_search_suggestions, get_video_feed
 from app.utils.db_async import get_session
 
@@ -145,11 +146,9 @@ async def create_channel(
     response_model=VideoIngestionResult,
     dependencies=[Depends(require_dataset_permission("youtube_ingestion", "edit"))],
 )
-async def trigger_video_ingestion(
-    db: AsyncSession = Depends(get_session),
-) -> VideoIngestionResult:
+async def trigger_video_ingestion() -> VideoIngestionResult:
     """Trigger YouTube ingestion cycle (admin)."""
-    return await run_ingestion_cycle(db)
+    return await run_ingestion_cycle(SessionLocal)
 
 
 @router.post(

--- a/app/services/video_ingestion_service.py
+++ b/app/services/video_ingestion_service.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 import httpx
 from sqlalchemy import delete, select, update
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.config import settings
 from app.models.videos import VideoIngestionResult
@@ -65,8 +65,15 @@ class RawVideo:
     published_at: datetime
 
 
-async def run_ingestion_cycle(db: AsyncSession) -> VideoIngestionResult:
-    """Ingest active YouTube channels into film-room videos."""
+async def run_ingestion_cycle(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> VideoIngestionResult:
+    """Ingest active YouTube channels into film-room videos.
+
+    Accepts a session factory instead of a long-lived session so that DB
+    connections are only held open during short read/write bursts, not
+    across the full multi-channel fetch + AI analysis cycle.
+    """
     api_key = settings.youtube_api_key
     if not api_key:
         return VideoIngestionResult(
@@ -78,7 +85,10 @@ async def run_ingestion_cycle(db: AsyncSession) -> VideoIngestionResult:
             errors=["YOUTUBE_API_KEY is not configured"],
         )
 
-    channels = await _get_active_channel_snapshots(db)
+    async with session_factory() as db:
+        async with db.begin():
+            channels = await _get_active_channel_snapshots(db)
+
     added = 0
     skipped = 0
     filtered = 0
@@ -92,6 +102,7 @@ async def run_ingestion_cycle(db: AsyncSession) -> VideoIngestionResult:
                 if channel.last_fetched_at
                 else datetime.now(UTC).replace(tzinfo=None) - timedelta(days=30)
             )
+            # Network + AI phase — no DB connection held.
             raw_videos, uploads_playlist_id = await fetch_channel_videos(
                 channel=channel,
                 api_key=api_key,
@@ -147,21 +158,24 @@ async def run_ingestion_cycle(db: AsyncSession) -> VideoIngestionResult:
                     }
                 )
 
-            inserted, conflict_skipped = await _persist_videos(
-                db=db,
-                channel_id=channel.id,
-                rows=rows,
-                uploads_playlist_id=uploads_playlist_id,
-            )
+            # Persist phase — short-lived sessions per DB operation.
+            async with session_factory() as db:
+                inserted, conflict_skipped = await _persist_videos(
+                    db=db,
+                    channel_id=channel.id,
+                    rows=rows,
+                    uploads_playlist_id=uploads_playlist_id,
+                )
             added += inserted
             skipped += conflict_skipped
 
-            mentions_added = await _persist_ai_mentions(
-                db=db,
-                channel_id=channel.id,
-                mention_map=mention_map,
-                fetched_at=now,
-            )
+            async with session_factory() as db:
+                mentions_added = await _persist_ai_mentions(
+                    db=db,
+                    channel_id=channel.id,
+                    mention_map=mention_map,
+                    fetched_at=now,
+                )
             mentions += mentions_added
         except Exception as exc:
             message = f"Failed channel {channel.display_name}: {exc}"
@@ -466,7 +480,7 @@ async def _persist_videos(
 ) -> tuple[int, int]:
     if not rows and uploads_playlist_id is None:
         return 0, 0
-    async with db.begin_nested():
+    async with db.begin():
         inserted = 0
         conflict_skipped = 0
         if rows:
@@ -498,7 +512,7 @@ async def _persist_ai_mentions(
     fetched_at: datetime,
 ) -> int:
     """Persist AI mentions and finalize channel watermark in one transaction."""
-    async with db.begin_nested():
+    async with db.begin():
         inserted = 0
         if mention_map:
             ext_ids = list(mention_map.keys())

--- a/tests/unit/test_cron_runner.py
+++ b/tests/unit/test_cron_runner.py
@@ -40,7 +40,7 @@ def _make_stubs(monkeypatch: pytest.MonkeyPatch, calls: list[str]) -> None:
             mentions_added=1, errors=[],
         )
 
-    async def _fake_video(_: object) -> VideoIngestionResult:
+    async def _fake_video(_session_factory: object) -> VideoIngestionResult:
         calls.append("videos")
         return VideoIngestionResult(
             channels_processed=1, videos_added=3, videos_skipped=1,
@@ -98,7 +98,7 @@ async def test_main_returns_failure_when_video_job_raises(
     calls: list[str] = []
     _make_stubs(monkeypatch, calls)
 
-    async def _failing_video(_: object) -> VideoIngestionResult:
+    async def _failing_video(_session_factory: object) -> VideoIngestionResult:
         calls.append("videos_fail")
         raise RuntimeError("video boom")
 


### PR DESCRIPTION
Video ingestion used begin_nested() (SAVEPOINTs) without an outer commit, so all inserts and watermark updates were silently rolled back on session close. Replaced with begin() and switched run_ingestion_cycle to accept a session factory instead of a long-lived session, so DB connections are only held during short read/write bursts — not across the full multi-channel YouTube API + Gemini AI analysis cycle.