### PR TITLE
feat: add stats homepage with leader cards for all combine metrics

### DIFF
--- a/app/services/combine_stats_service.py
+++ b/app/services/combine_stats_service.py
@@ -9,13 +9,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, NamedTuple
 
-from sqlalchemy import cast, func, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.types import Float
 
 from app.schemas.combine_agility import CombineAgility
 from app.schemas.combine_anthro import CombineAnthro
-from app.schemas.combine_shooting import CombineShooting, SHOOTING_DRILL_COLUMNS
+from app.schemas.combine_shooting import (
+    SHOOTING_DRILL_COLUMNS,
+    SHOOTING_PCT_COLUMNS,
+    CombineShooting,
+)
 from app.schemas.players_master import PlayerMaster
 from app.schemas.player_status import PlayerStatus
 from app.schemas.positions import Position
@@ -781,23 +784,24 @@ async def get_shooting_leaders(
     drill_key: str,
     limit: int = 4,
 ) -> list[ShootingLeaderEntry]:
-    """Fetch the top N leaders for a shooting drill, ranked by FG%."""
+    """Fetch the top N leaders for a shooting drill, ranked by FG%.
+
+    Uses the pre-computed _pct column (0-100 scale) stored in the DB.
+    """
     cols = SHOOTING_DRILL_COLUMNS.get(drill_key)
-    if not cols:
+    pct_col_name = SHOOTING_PCT_COLUMNS.get(drill_key)
+    if not cols or not pct_col_name:
         return []
     fgm_col_name, fga_col_name = cols
     fgm_col = getattr(CombineShooting, fgm_col_name)
     fga_col = getattr(CombineShooting, fga_col_name)
+    pct_col = getattr(CombineShooting, pct_col_name)
 
-    fg_pct_expr = cast(fgm_col, Float) / cast(fga_col, Float)  # type: ignore[arg-type]
-
-    # Select individual columns instead of the full CombineShooting entity
-    # to avoid loading _pct columns that may not exist in the DB yet.
     stmt: Any = (
         select(  # type: ignore[call-overload]
             fgm_col.label("fgm"),
             fga_col.label("fga"),
-            fg_pct_expr.label("fg_pct"),
+            pct_col.label("fg_pct"),
             PlayerMaster.id.label("player_id"),  # type: ignore[union-attr]
             PlayerMaster.display_name,
             PlayerMaster.slug,
@@ -818,11 +822,9 @@ async def get_shooting_leaders(
             Season,
             CombineShooting.season_id == Season.id,  # type: ignore[arg-type]
         )
-        .where(fgm_col.isnot(None))  # type: ignore[union-attr]
-        .where(fga_col.isnot(None))  # type: ignore[union-attr]
-        .where(fga_col > 0)  # type: ignore[operator]
+        .where(pct_col.isnot(None))  # type: ignore[union-attr]
         .order_by(
-            fg_pct_expr.desc(),
+            pct_col.desc(),  # type: ignore[union-attr]
             fga_col.desc(),  # type: ignore[union-attr]
             PlayerMaster.id.asc(),  # type: ignore[union-attr]
         )
@@ -836,7 +838,7 @@ async def get_shooting_leaders(
     for i, row in enumerate(rows):
         fgm = row.fgm
         fga = row.fga
-        pct = row.fg_pct
+        pct = row.fg_pct  # already 0-100 scale
         entries.append(
             ShootingLeaderEntry(
                 rank=i + 1,
@@ -850,7 +852,7 @@ async def get_shooting_leaders(
                 fga=fga,
                 fg_pct=float(pct) if pct is not None else 0.0,
                 formatted_value=f"{fgm}/{fga}",
-                formatted_pct=f"{float(pct) * 100:.1f}%" if pct is not None else "0.0%",
+                formatted_pct=f"{pct:.1f}%" if pct is not None else "0.0%",
             )
         )
     return entries
@@ -899,37 +901,14 @@ async def get_year_player_counts(db: AsyncSession) -> list[YearStats]:
         reverse=True,
     )
 
-    # Compute distinct player counts across all sources per year
-    union_stmt: Any = (
-        select(  # type: ignore[call-overload]
-            Season.end_year,
-            CombineAnthro.player_id,
-        )
-        .join(Season, CombineAnthro.season_id == Season.id)  # type: ignore[arg-type]
-        .union(
-            select(  # type: ignore[call-overload]
-                Season.end_year,
-                CombineAgility.player_id,
-            ).join(Season, CombineAgility.season_id == Season.id)  # type: ignore[arg-type]
-        )
-        .union(
-            select(  # type: ignore[call-overload]
-                Season.end_year,
-                CombineShooting.player_id,
-            ).join(Season, CombineShooting.season_id == Season.id)  # type: ignore[arg-type]
-        )
-    ).subquery()
-    count_stmt: Any = select(  # type: ignore[call-overload]
-        union_stmt.c.end_year,
-        func.count(func.distinct(union_stmt.c.player_id)),
-    ).group_by(union_stmt.c.end_year)
-    count_result = await db.execute(count_stmt)
-    combined_counts: dict[int, int] = {row[0]: row[1] for row in count_result.all()}
-
     return [
         YearStats(
             year=y,
-            player_count=combined_counts.get(y, 0),
+            player_count=max(
+                anthro_counts.get(y, 0),
+                agility_counts.get(y, 0),
+                shooting_counts.get(y, 0),
+            ),
             has_anthro=y in anthro_counts,
             has_agility=y in agility_counts,
             has_shooting=y in shooting_counts,
@@ -942,15 +921,15 @@ async def get_homepage_data(db: AsyncSession) -> HomepageData:
     """Gather all data for the stats homepage."""
     measurement_leaders: dict[str, list[LeaderboardEntry]] = {}
     for key in MEASUREMENT_KEYS:
-        measurement_leaders[key] = await get_metric_leaders(db, key)
+        measurement_leaders[key] = await get_metric_leaders(db, key, limit=5)
 
     athletic_leaders: dict[str, list[LeaderboardEntry]] = {}
     for key in ATHLETIC_KEYS:
-        athletic_leaders[key] = await get_metric_leaders(db, key)
+        athletic_leaders[key] = await get_metric_leaders(db, key, limit=5)
 
     shooting_leaders: dict[str, list[ShootingLeaderEntry]] = {}
     for key in SHOOTING_KEYS:
-        shooting_leaders[key] = await get_shooting_leaders(db, key)
+        shooting_leaders[key] = await get_shooting_leaders(db, key, limit=5)
 
     year_stats = await get_year_player_counts(db)
 

--- a/app/static/css/stats.css
+++ b/app/static/css/stats.css
@@ -670,3 +670,545 @@
     justify-content: space-between;
   }
 }
+
+/* ============================================================================
+   STATS HOMEPAGE
+   ========================================================================= */
+
+/* --- Hero --- */
+.stats-hero {
+  padding: 5rem 0 1.5rem;
+  margin-top: 4rem;
+}
+
+.stats-hero h2 {
+  font-family: var(--font-heading);
+  font-size: 2rem;
+  color: var(--color-slate-900);
+  letter-spacing: 0.02em;
+}
+
+.stats-hero-tagline {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--color-slate-500);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-top: 0.25rem;
+}
+
+/* --- Sticky Section Nav --- */
+.stats-section-nav {
+  position: sticky;
+  top: 68px;
+  z-index: 900;
+  background: var(--color-white);
+  border-bottom: 1px solid var(--color-slate-200);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.06);
+  margin-bottom: 2rem;
+}
+
+.stats-section-nav__inner {
+  max-width: 1152px;
+  width: 80%;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.stats-nav-tab {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-slate-500);
+  padding: 0.875rem 1.25rem;
+  border-bottom: 3px solid transparent;
+  transition: all 0.2s;
+  cursor: pointer;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+}
+
+.stats-nav-tab:hover {
+  color: var(--color-slate-800);
+  background: var(--color-slate-50);
+}
+
+.stats-nav-tab--measurements:hover { background: rgba(6, 182, 212, 0.04); }
+.stats-nav-tab--athletic:hover { background: rgba(245, 158, 11, 0.04); }
+.stats-nav-tab--shooting:hover { background: rgba(244, 63, 94, 0.04); }
+.stats-nav-tab--classes:hover { background: rgba(16, 185, 129, 0.04); }
+
+.stats-nav-tab.active {
+  color: var(--color-slate-900);
+  border-bottom-color: var(--color-accent-cyan);
+}
+
+.stats-nav-tab--measurements.active {
+  border-bottom-color: var(--color-accent-cyan);
+  background: rgba(6, 182, 212, 0.06);
+  color: #0e7490;
+}
+.stats-nav-tab--athletic.active {
+  border-bottom-color: var(--color-accent-amber);
+  background: rgba(245, 158, 11, 0.06);
+  color: #b45309;
+}
+.stats-nav-tab--shooting.active {
+  border-bottom-color: var(--color-accent-rose);
+  background: rgba(244, 63, 94, 0.06);
+  color: #be123c;
+}
+.stats-nav-tab--classes.active {
+  border-bottom-color: var(--color-accent-emerald);
+  background: rgba(16, 185, 129, 0.06);
+  color: #047857;
+}
+
+.stats-nav-tab__icon {
+  font-size: 0.875rem;
+}
+
+.stats-nav-tab__count {
+  font-size: 0.5625rem;
+  background: var(--color-slate-100);
+  color: var(--color-slate-500);
+  padding: 0.125rem 0.375rem;
+  border-radius: 9999px;
+  font-weight: 600;
+}
+
+.stats-nav-tab.active .stats-nav-tab__count {
+  background: rgba(6, 182, 212, 0.1);
+  color: var(--color-accent-cyan);
+}
+
+.stats-nav-tab--athletic.active .stats-nav-tab__count {
+  background: rgba(245, 158, 11, 0.1);
+  color: var(--color-accent-amber);
+}
+
+.stats-nav-tab--shooting.active .stats-nav-tab__count {
+  background: rgba(244, 63, 94, 0.1);
+  color: var(--color-accent-rose);
+}
+
+.stats-nav-tab--classes.active .stats-nav-tab__count {
+  background: rgba(16, 185, 129, 0.1);
+  color: var(--color-accent-emerald);
+}
+
+/* --- Section Layout --- */
+.section {
+  margin-bottom: 4rem;
+}
+
+.section-header {
+  font-size: 1.5rem;
+  font-weight: 600;
+  padding-left: 0.5rem;
+  border-left: 4px solid;
+  margin-bottom: 0.5rem;
+}
+
+.section-subtitle {
+  font-size: 0.875rem;
+  color: var(--color-slate-500);
+  margin-bottom: 1.5rem;
+  padding-left: 0.5rem;
+}
+
+.section-divider {
+  height: 1px;
+  background: linear-gradient(
+    to right, transparent,
+    rgba(148, 163, 184, 0.3) 20%,
+    rgba(148, 163, 184, 0.3) 80%,
+    transparent
+  );
+  margin: 3rem 0;
+}
+
+/* --- Leaderboard Grid --- */
+.leaderboard-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+/* --- Stat Leader Cards --- */
+.stat-leader-card {
+  background: var(--color-white);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  outline: 2px solid;
+  outline-offset: -2px;
+  transition: transform 0.2s, box-shadow 0.2s;
+  position: relative;
+}
+
+.stat-leader-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+}
+
+/* Pixel corner accents */
+.stat-leader-card::before,
+.stat-leader-card::after {
+  content: '';
+  position: absolute;
+  width: 0.75rem;
+  height: 0.75rem;
+  opacity: 0;
+  transition: opacity 0.2s;
+  z-index: 10;
+}
+
+.stat-leader-card::before { top: -0.25rem; left: -0.25rem; }
+.stat-leader-card::after { bottom: -0.25rem; right: -0.25rem; }
+
+.stat-leader-card:hover::before,
+.stat-leader-card:hover::after { opacity: 1; }
+
+/* Cyan variant */
+.stat-leader-card--cyan {
+  outline-color: rgba(6, 182, 212, 0.5);
+  background-image:
+    linear-gradient(#ffffff, #ffffff),
+    radial-gradient(circle at 1px 1px, rgba(6, 182, 212, 0.05) 1px, transparent 1px);
+  background-size: 100% 100%, 12px 12px;
+}
+.stat-leader-card--cyan::before { background: linear-gradient(45deg, transparent 50%, var(--color-accent-cyan) 50%); }
+.stat-leader-card--cyan::after { background: linear-gradient(225deg, transparent 50%, var(--color-accent-cyan) 50%); }
+.stat-leader-card--cyan .stat-leader-card__header {
+  background: linear-gradient(to right, #cffafe, #a5f3fc);
+  border-bottom: 2px solid var(--color-accent-cyan);
+}
+.stat-leader-card--cyan .featured-player-rank { color: var(--color-accent-cyan); }
+.stat-leader-card--cyan .featured-player-image { border-color: rgba(6, 182, 212, 0.4); }
+.stat-leader-card--cyan .stat-leader-card__view-all { color: var(--color-accent-cyan); }
+
+/* Amber variant */
+.stat-leader-card--amber {
+  outline-color: rgba(245, 158, 11, 0.5);
+  background-image:
+    linear-gradient(#ffffff, #ffffff),
+    radial-gradient(circle at 1px 1px, rgba(245, 158, 11, 0.05) 1px, transparent 1px);
+  background-size: 100% 100%, 12px 12px;
+}
+.stat-leader-card--amber::before { background: linear-gradient(45deg, transparent 50%, var(--color-accent-amber) 50%); }
+.stat-leader-card--amber::after { background: linear-gradient(225deg, transparent 50%, var(--color-accent-amber) 50%); }
+.stat-leader-card--amber .stat-leader-card__header {
+  background: linear-gradient(to right, #fef3c7, #fde68a);
+  border-bottom: 2px solid var(--color-accent-amber);
+}
+.stat-leader-card--amber .featured-player-rank { color: var(--color-accent-amber); }
+.stat-leader-card--amber .featured-player-image { border-color: rgba(245, 158, 11, 0.4); }
+.stat-leader-card--amber .stat-leader-card__view-all { color: var(--color-accent-amber); }
+
+/* Rose variant */
+.stat-leader-card--rose {
+  outline-color: rgba(244, 63, 94, 0.4);
+  background-image:
+    linear-gradient(#ffffff, #ffffff),
+    radial-gradient(circle at 1px 1px, rgba(244, 63, 94, 0.05) 1px, transparent 1px);
+  background-size: 100% 100%, 12px 12px;
+}
+.stat-leader-card--rose::before { background: linear-gradient(45deg, transparent 50%, var(--color-accent-rose) 50%); }
+.stat-leader-card--rose::after { background: linear-gradient(225deg, transparent 50%, var(--color-accent-rose) 50%); }
+.stat-leader-card--rose .stat-leader-card__header {
+  background: linear-gradient(to right, #ffe4e6, #fecdd3);
+  border-bottom: 2px solid var(--color-accent-rose);
+}
+.stat-leader-card--rose .featured-player-rank { color: var(--color-accent-rose); }
+.stat-leader-card--rose .featured-player-image { border-color: rgba(244, 63, 94, 0.4); }
+.stat-leader-card--rose .stat-leader-card__view-all { color: var(--color-accent-rose); }
+
+/* Card header */
+.stat-leader-card__header {
+  padding: 0.875rem 1rem 0.625rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.stat-leader-card__metric {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-slate-800);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.stat-leader-card__metric-icon {
+  font-size: 1rem;
+}
+
+.stat-leader-card__view-all {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.stat-leader-card__view-all-label {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  color: var(--color-slate-400);
+}
+
+/* Featured player */
+.stat-leader-card__featured {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  border-bottom: 1px solid var(--color-slate-200);
+  align-items: center;
+  text-decoration: none;
+  color: inherit;
+}
+
+.featured-player-image {
+  width: 100px;
+  height: 120px;
+  border-radius: 0.5rem;
+  object-fit: cover;
+  object-position: 50% 20%;
+  border: 2px solid;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+.featured-player-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.featured-player-rank {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.featured-player-name {
+  font-family: var(--font-heading);
+  font-size: 1.125rem;
+  color: var(--color-slate-900);
+  line-height: 1.2;
+}
+
+.featured-player-meta {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--color-slate-500);
+}
+
+.featured-player-value {
+  font-family: var(--font-heading);
+  font-size: 1.75rem;
+  color: var(--color-slate-900);
+  line-height: 1;
+  margin-top: 0.25rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.featured-player-unit {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--color-slate-500);
+  margin-left: 0.25rem;
+}
+
+/* Runners-up */
+.stat-leader-card__runners {
+  padding: 0.5rem 0;
+}
+
+.runner-row {
+  display: grid;
+  grid-template-columns: 2rem 1fr auto;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  gap: 0.5rem;
+  transition: background 0.2s;
+  text-decoration: none;
+  color: inherit;
+}
+
+.runner-row:hover {
+  background: var(--color-slate-50);
+}
+
+.runner-rank {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-slate-400);
+  text-align: center;
+}
+
+.runner-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.runner-name {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-slate-800);
+  line-height: 1.2;
+}
+
+.runner-meta {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  color: var(--color-slate-400);
+}
+
+.runner-value {
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-slate-700);
+  font-variant-numeric: tabular-nums;
+}
+
+/* --- Draft Class Year Grid --- */
+.year-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.year-card {
+  background: var(--color-white);
+  border-radius: 0.75rem;
+  padding: 1.25rem 1rem;
+  text-align: center;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.06);
+  outline: 2px solid rgba(16, 185, 129, 0.4);
+  outline-offset: -2px;
+  transition: all 0.2s;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  background-image:
+    linear-gradient(#ffffff, #ffffff),
+    radial-gradient(circle at 1px 1px, rgba(16, 185, 129, 0.06) 1px, transparent 1px);
+  background-size: 100% 100%, 12px 12px;
+}
+
+.year-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0,0,0,0.12);
+  outline-color: rgba(16, 185, 129, 0.7);
+}
+
+.year-card::before,
+.year-card::after {
+  content: '';
+  position: absolute;
+  width: 0.625rem;
+  height: 0.625rem;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.year-card::before {
+  top: -0.2rem; left: -0.2rem;
+  background: linear-gradient(45deg, transparent 50%, var(--color-accent-emerald) 50%);
+}
+
+.year-card::after {
+  bottom: -0.2rem; right: -0.2rem;
+  background: linear-gradient(225deg, transparent 50%, var(--color-accent-emerald) 50%);
+}
+
+.year-card:hover::before,
+.year-card:hover::after { opacity: 1; }
+
+.year-card__year {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  color: var(--color-slate-900);
+  line-height: 1;
+  margin-bottom: 0.5rem;
+}
+
+.year-card__count {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--color-slate-500);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.year-card__metrics {
+  margin-top: 0.75rem;
+  padding-top: 0.625rem;
+  border-top: 1px solid var(--color-slate-200);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  justify-content: center;
+}
+
+.year-card__metric-pill {
+  font-family: var(--font-mono);
+  font-size: 0.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  line-height: 1.4;
+}
+
+.year-card__metric-pill--cyan {
+  background: rgba(6, 182, 212, 0.1);
+  color: #0891b2;
+}
+
+.year-card__metric-pill--amber {
+  background: rgba(245, 158, 11, 0.1);
+  color: #d97706;
+}
+
+.year-card__metric-pill--rose {
+  background: rgba(244, 63, 94, 0.1);
+  color: #e11d48;
+}
+
+/* --- Homepage Responsive --- */
+@media (max-width: 1024px) {
+  .leaderboard-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 768px) {
+  .leaderboard-grid { grid-template-columns: 1fr; }
+  .year-grid { grid-template-columns: repeat(auto-fill, minmax(130px, 1fr)); }
+  .stats-section-nav__inner { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  .stats-nav-tab { padding: 0.75rem 1rem; font-size: 0.6875rem; }
+}

--- a/app/templates/stats/index.html
+++ b/app/templates/stats/index.html
@@ -1,0 +1,248 @@
+{% extends "base.html" %}
+
+{% block title %}NBA Draft Combine Stats & Leaderboards — DraftGuru{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', path='css/stats.css') }}">
+{% endblock %}
+
+{% block content %}
+
+{# ══════════════════════════════════════════════════════════════════════
+   MACROS — Leader card components (must be defined before use)
+   ══════════════════════════════════════════════════════════════════════ #}
+
+{# Standard leader card for anthro/agility metrics #}
+{% macro leader_card(metric_key, display, leaders, color) %}
+<div class="stat-leader-card stat-leader-card--{{ color }}">
+  <div class="stat-leader-card__header">
+    <span class="stat-leader-card__metric">
+      <span class="stat-leader-card__metric-icon">{{ display.icon | safe }}</span>
+      {{ display.superlative }}
+    </span>
+    <a href="/stats/{{ metric_key }}" class="stat-leader-card__view-all">View All &#8594;</a>
+  </div>
+
+  {# Featured player (#1) #}
+  {% set featured = leaders[0] %}
+  <a href="/players/{{ featured.slug }}" class="stat-leader-card__featured">
+    <img
+      src="{{ featured.photo_url }}"
+      alt="{{ featured.display_name }}"
+      class="featured-player-image"
+      onerror="this.onerror=null;this.src='{{ featured.photo_url_placeholder }}';"
+      loading="lazy"
+    >
+    <div class="featured-player-info">
+      <span class="featured-player-name">{{ featured.display_name }}</span>
+      <div>
+        <span class="featured-player-value">{{ featured.formatted_value }}</span>
+        <span class="featured-player-unit">{{ display.unit_label }}</span>
+      </div>
+    </div>
+  </a>
+
+  {# Runners-up #}
+  {% if leaders|length > 1 %}
+  <div class="stat-leader-card__runners">
+    {% for entry in leaders[1:] %}
+    <a href="/players/{{ entry.slug }}" class="runner-row">
+      <span class="runner-rank">{{ entry.rank }}</span>
+      <span class="runner-name">{{ entry.display_name }}</span>
+      <span class="runner-value tabular-nums">{{ entry.formatted_value }}</span>
+    </a>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>
+{% endmacro %}
+
+{# Shooting drill leader card #}
+{% macro shooting_leader_card(drill_key, display, leaders) %}
+<div class="stat-leader-card stat-leader-card--rose">
+  <div class="stat-leader-card__header">
+    <span class="stat-leader-card__metric">
+      <span class="stat-leader-card__metric-icon">{{ display.icon | safe }}</span>
+      {{ display.superlative }}
+    </span>
+    <span class="stat-leader-card__view-all-label">All-Time</span>
+  </div>
+
+  {# Featured player (#1) #}
+  {% set featured = leaders[0] %}
+  <a href="/players/{{ featured.slug }}" class="stat-leader-card__featured">
+    <img
+      src="{{ featured.photo_url }}"
+      alt="{{ featured.display_name }}"
+      class="featured-player-image"
+      onerror="this.onerror=null;this.src='{{ featured.photo_url_placeholder }}';"
+      loading="lazy"
+    >
+    <div class="featured-player-info">
+      <span class="featured-player-name">{{ featured.display_name }}</span>
+      <div>
+        <span class="featured-player-value">{{ featured.formatted_value }}</span>
+        <span class="featured-player-unit">{{ featured.formatted_pct }}</span>
+      </div>
+    </div>
+  </a>
+
+  {# Runners-up #}
+  {% if leaders|length > 1 %}
+  <div class="stat-leader-card__runners">
+    {% for entry in leaders[1:] %}
+    <a href="/players/{{ entry.slug }}" class="runner-row">
+      <span class="runner-rank">{{ entry.rank }}</span>
+      <span class="runner-name">{{ entry.display_name }}</span>
+      <span class="runner-value tabular-nums">{{ entry.formatted_value }}</span>
+    </a>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>
+{% endmacro %}
+
+<main>
+  {# ══════════════════════════════════════════════════════════════════════
+     HERO
+     ══════════════════════════════════════════════════════════════════════ #}
+  <section class="stats-hero">
+    <div class="container">
+      <h2>NBA Draft Combine</h2>
+      <p class="stats-hero-tagline">Measurements, Testing & Leaderboards</p>
+    </div>
+  </section>
+
+  {# ══════════════════════════════════════════════════════════════════════
+     STICKY SECTION NAV
+     ══════════════════════════════════════════════════════════════════════ #}
+  <nav class="stats-section-nav">
+    <div class="stats-section-nav__inner">
+      <a href="#measurements" class="stats-nav-tab stats-nav-tab--measurements active">
+        <span class="stats-nav-tab__icon">&#x1F4CF;</span>
+        Measurements
+        <span class="stats-nav-tab__count">{{ measurement_keys|length }}</span>
+      </a>
+      <a href="#athletic-testing" class="stats-nav-tab stats-nav-tab--athletic">
+        <span class="stats-nav-tab__icon">&#x26A1;</span>
+        Athletic Testing
+        <span class="stats-nav-tab__count">{{ athletic_keys|length }}</span>
+      </a>
+      <a href="#shooting-drills" class="stats-nav-tab stats-nav-tab--shooting">
+        <span class="stats-nav-tab__icon">&#x1F3AF;</span>
+        Shooting Drills
+        <span class="stats-nav-tab__count">{{ shooting_keys|length }}</span>
+      </a>
+      <a href="#draft-classes" class="stats-nav-tab stats-nav-tab--classes">
+        <span class="stats-nav-tab__icon">&#x1F4C5;</span>
+        Draft Classes
+        <span class="stats-nav-tab__count">{{ year_stats|length }}</span>
+      </a>
+    </div>
+  </nav>
+
+  {# ══════════════════════════════════════════════════════════════════════
+     MEASUREMENTS — Cyan theme
+     ══════════════════════════════════════════════════════════════════════ #}
+  <section id="measurements" class="section">
+    <div class="container">
+      <h3 class="section-header heading-font" style="border-color: var(--color-accent-cyan);">
+        Measurements
+      </h3>
+      <p class="section-subtitle">Height, wingspan, reach, weight, and hand size</p>
+
+      <div class="leaderboard-grid">
+        {% for key in measurement_keys %}
+          {% set display = metric_display[key] %}
+          {% set leaders = measurement_leaders.get(key, []) %}
+          {% if leaders %}
+            {{ leader_card(key, display, leaders, "cyan") }}
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+
+  <div class="container"><div class="section-divider"></div></div>
+
+  {# ══════════════════════════════════════════════════════════════════════
+     ATHLETIC TESTING — Amber theme
+     ══════════════════════════════════════════════════════════════════════ #}
+  <section id="athletic-testing" class="section">
+    <div class="container">
+      <h3 class="section-header heading-font" style="border-color: var(--color-accent-amber);">
+        Athletic Testing
+      </h3>
+      <p class="section-subtitle">Speed, explosiveness, agility, and strength</p>
+
+      <div class="leaderboard-grid">
+        {% for key in athletic_keys %}
+          {% set display = metric_display[key] %}
+          {% set leaders = athletic_leaders.get(key, []) %}
+          {% if leaders %}
+            {{ leader_card(key, display, leaders, "amber") }}
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+
+  <div class="container"><div class="section-divider"></div></div>
+
+  {# ══════════════════════════════════════════════════════════════════════
+     SHOOTING DRILLS — Rose theme
+     ══════════════════════════════════════════════════════════════════════ #}
+  <section id="shooting-drills" class="section">
+    <div class="container">
+      <h3 class="section-header heading-font" style="border-color: var(--color-accent-rose);">
+        Shooting Drills
+      </h3>
+      <p class="section-subtitle">Spot-up, off-dribble, three-point, midrange, and free throw results</p>
+
+      <div class="leaderboard-grid">
+        {% for key in shooting_keys %}
+          {% set display = shooting_display[key] %}
+          {% set leaders = shooting_leaders.get(key, []) %}
+          {% if leaders %}
+            {{ shooting_leader_card(key, display, leaders) }}
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+
+  <div class="container"><div class="section-divider"></div></div>
+
+  {# ══════════════════════════════════════════════════════════════════════
+     DRAFT CLASS YEAR GRID
+     ══════════════════════════════════════════════════════════════════════ #}
+  <section id="draft-classes" class="section">
+    <div class="container">
+      <h3 class="section-header heading-font" style="border-color: var(--color-accent-emerald);">
+        Browse by Draft Class
+      </h3>
+      <p class="section-subtitle">Explore full combine results for every year</p>
+
+      <div class="year-grid">
+        {% for ys in year_stats %}
+        <a href="/stats/combine/{{ ys.year }}" class="year-card">
+          <div class="year-card__year">{{ ys.year }}</div>
+          <div class="year-card__count">{{ ys.player_count }} Players</div>
+          <div class="year-card__metrics">
+            {% if ys.has_anthro %}
+              <span class="year-card__metric-pill year-card__metric-pill--cyan">Anthro</span>
+            {% endif %}
+            {% if ys.has_agility %}
+              <span class="year-card__metric-pill year-card__metric-pill--amber">Agility</span>
+            {% endif %}
+            {% if ys.has_shooting %}
+              <span class="year-card__metric-pill year-card__metric-pill--rose">Shooting</span>
+            {% endif %}
+          </div>
+        </a>
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}


### PR DESCRIPTION
Replace the /stats/ redirect with a full landing page showing top 5 leaders for every combine metric (measurements, athletic testing, and shooting drills) plus a browse-by-draft-class year grid.