### PR TITLE
feat: NBA team logos and school schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HOST ?= 0.0.0.0
 PORT ?= 8000
 
 .PHONY: dev run mig.revision mig.up mig.down mig.history mig.current scrape ingest metrics bio.scrape bio.ingest
-.PHONY: news-seed
+.PHONY: news-seed nba-seed nba-logos
 
 # Start FastAPI with auto-reload (development)
 dev:
@@ -37,6 +37,19 @@ ingest:
 # Seed curated RSS news sources into the database
 news-seed:
 	$(PYTHON) scripts/seed_news_sources.py
+
+# Seed NBA teams into database
+nba-seed:
+	$(PYTHON) scripts/seed_nba_teams.py
+
+# Download and upload NBA team logos
+# Usage:
+#   make nba-logos                # all teams
+#   make nba-logos TEAM=LAL       # single team
+#   make nba-logos DRY=1          # dry-run (download + process only)
+TEAM ?=
+nba-logos:
+	$(PYTHON) scripts/collect_nba_logos.py $(if $(DRY),--dry-run,) $(if $(TEAM),--team $(TEAM),)
 
 # Derived metrics computation
 COHORT ?= current_draft

--- a/alembic/versions/b9705695210a_add_nba_teams_and_college_schools_tables.py
+++ b/alembic/versions/b9705695210a_add_nba_teams_and_college_schools_tables.py
@@ -1,0 +1,63 @@
+"""add nba_teams and college_schools tables
+
+Revision ID: b9705695210a
+Revises: bc8962e9d4d3
+Create Date: 2026-04-05
+"""
+
+from alembic import op  # type: ignore[attr-defined]
+import sqlalchemy as sa
+
+revision = "b9705695210a"
+down_revision = "bc8962e9d4d3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Tables may already exist via AUTO_INIT_DB; create only if missing.
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing = inspector.get_table_names()
+
+    if "nba_teams" not in existing:
+        op.create_table(
+            "nba_teams",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("name", sa.String, nullable=False),
+            sa.Column("abbreviation", sa.String, nullable=False),
+            sa.Column("slug", sa.String, nullable=False),
+            sa.Column("city", sa.String, nullable=True),
+            sa.Column("conference", sa.String, nullable=True),
+            sa.Column("division", sa.String, nullable=True),
+            sa.Column("logo_url", sa.String, nullable=True),
+            sa.Column("primary_color", sa.String, nullable=True),
+            sa.Column("secondary_color", sa.String, nullable=True),
+            sa.Column("created_at", sa.DateTime, nullable=False),
+            sa.Column("updated_at", sa.DateTime, nullable=False),
+        )
+        op.create_index("ix_nba_teams_name", "nba_teams", ["name"])
+        op.create_index("ix_nba_teams_abbreviation", "nba_teams", ["abbreviation"], unique=True)
+        op.create_index("ix_nba_teams_slug", "nba_teams", ["slug"], unique=True)
+
+    if "college_schools" not in existing:
+        op.create_table(
+            "college_schools",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("name", sa.String, nullable=False),
+            sa.Column("slug", sa.String, nullable=False),
+            sa.Column("conference", sa.String, nullable=True),
+            sa.Column("logo_url", sa.String, nullable=True),
+            sa.Column("primary_color", sa.String, nullable=True),
+            sa.Column("secondary_color", sa.String, nullable=True),
+            sa.Column("created_at", sa.DateTime, nullable=False),
+            sa.Column("updated_at", sa.DateTime, nullable=False),
+        )
+        op.create_index("ix_college_schools_name", "college_schools", ["name"], unique=True)
+        op.create_index("ix_college_schools_slug", "college_schools", ["slug"], unique=True)
+        op.create_index("ix_college_schools_conference", "college_schools", ["conference"])
+
+
+def downgrade() -> None:
+    op.drop_table("college_schools")
+    op.drop_table("nba_teams")

--- a/app/schemas/college_schools.py
+++ b/app/schemas/college_schools.py
@@ -1,0 +1,32 @@
+from typing import Optional
+from datetime import datetime
+
+from sqlmodel import SQLModel, Field
+
+
+class CollegeSchool(SQLModel, table=True):  # type: ignore[call-arg]
+    __tablename__ = "college_schools"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(
+        unique=True, index=True, description="Official school name, e.g. 'Duke'"
+    )
+    slug: str = Field(
+        unique=True, index=True, description="URL-safe identifier, e.g. 'duke'"
+    )
+    conference: Optional[str] = Field(
+        default=None, index=True, description="e.g. 'ACC'"
+    )
+
+    logo_url: Optional[str] = Field(
+        default=None, description="S3/CDN path to school logo"
+    )
+    primary_color: Optional[str] = Field(
+        default=None, description="Hex color, e.g. '#003087'"
+    )
+    secondary_color: Optional[str] = Field(
+        default=None, description="Hex color, e.g. '#FFFFFF'"
+    )
+
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)

--- a/app/schemas/nba_teams.py
+++ b/app/schemas/nba_teams.py
@@ -1,0 +1,39 @@
+from typing import Optional
+from datetime import datetime
+
+from sqlmodel import SQLModel, Field
+
+
+class NbaTeam(SQLModel, table=True):  # type: ignore[call-arg]
+    __tablename__ = "nba_teams"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(
+        index=True, description="Full team name, e.g. 'Los Angeles Lakers'"
+    )
+    abbreviation: str = Field(
+        unique=True, index=True, description="Standard 3-letter code, e.g. 'LAL'"
+    )
+    slug: str = Field(
+        unique=True, index=True, description="URL-safe identifier, e.g. 'lakers'"
+    )
+    city: Optional[str] = Field(
+        default=None, description="Team city, e.g. 'Los Angeles'"
+    )
+    conference: Optional[str] = Field(
+        default=None, description="'Eastern' or 'Western'"
+    )
+    division: Optional[str] = Field(default=None)
+
+    logo_url: Optional[str] = Field(
+        default=None, description="S3/CDN path to team logo"
+    )
+    primary_color: Optional[str] = Field(
+        default=None, description="Hex color, e.g. '#552583'"
+    )
+    secondary_color: Optional[str] = Field(
+        default=None, description="Hex color, e.g. '#FDB927'"
+    )
+
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)

--- a/app/utils/images.py
+++ b/app/utils/images.py
@@ -137,6 +137,20 @@ def get_available_styles(player_id: int, slug: str) -> list[str]:
     return available
 
 
+def get_logo_url(entity_type: str, slug: str) -> str:
+    """Build a canonical URL for a team or school logo.
+
+    Args:
+        entity_type: 'nba' or 'college'.
+        slug: Team or school slug (e.g. 'lakers', 'duke').
+
+    Returns:
+        URL like '{base}/logos/nba/{slug}.png'.
+    """
+    base = get_s3_image_base_url()
+    return f"{base}/logos/{entity_type}/{slug}.png"
+
+
 def get_placeholder_url(
     display_name: Optional[str] = None,
     *,

--- a/docs/team_logos_implementation.md
+++ b/docs/team_logos_implementation.md
@@ -1,0 +1,176 @@
+# Team & School Logo System
+
+## Overview
+
+Logos for NBA teams and college schools, stored in S3 alongside player images, with database metadata (colors, conference, division) to support visual branding across the site — player pages, mock draft boards, stats tables, and SVG share cards.
+
+## Current State (NBA Complete, College Pending)
+
+### What's Built
+
+| Component | Status | Details |
+|-----------|--------|---------|
+| **`nba_teams` table** | Seeded (30 rows) | Name, abbreviation, slug, city, conference, division, brand colors |
+| **`college_schools` table** | Created (empty) | Name, slug, conference, brand colors — ready for data |
+| **NBA logos** | Collected (30/30) | 200×200 RGBA PNGs on S3 at `logos/nba/{slug}.png` |
+| **College logos** | Not started | Blocked on school name deduplication |
+| **Template integration** | Not started | Will implement after college logos are collected |
+| **Share card integration** | Not started | Will embed logos as base64 data URIs |
+
+### Schema
+
+**`nba_teams`** (`app/schemas/nba_teams.py`)
+
+| Column | Type | Example |
+|--------|------|---------|
+| `id` | int (PK) | 1 |
+| `name` | str (indexed) | "Los Angeles Lakers" |
+| `abbreviation` | str (unique) | "LAL" |
+| `slug` | str (unique) | "lakers" |
+| `city` | str | "Los Angeles" |
+| `conference` | str | "Western" |
+| `division` | str | "Pacific" |
+| `logo_url` | str | `https://...s3.../logos/nba/lakers.png` |
+| `primary_color` | str | "#552583" |
+| `secondary_color` | str | "#FDB927" |
+
+**`college_schools`** (`app/schemas/college_schools.py`)
+
+| Column | Type | Example |
+|--------|------|---------|
+| `id` | int (PK) | 1 |
+| `name` | str (unique) | "Duke" |
+| `slug` | str (unique) | "duke" |
+| `conference` | str (indexed) | "ACC" |
+| `logo_url` | str | `https://...s3.../logos/college/duke.png` |
+| `primary_color` | str | "#003087" |
+| `secondary_color` | str | "#FFFFFF" |
+
+### Scripts
+
+| Script | Purpose | Usage |
+|--------|---------|-------|
+| `scripts/seed_nba_teams.py` | Seed all 30 NBA teams with metadata | `make nba-seed` |
+| `scripts/collect_nba_logos.py` | Download, process (200×200 PNG), upload logos | `make nba-logos` |
+
+**Logo collection flags:**
+- `--dry-run` — download + process only, no upload or DB update
+- `--local-only` — force local filesystem storage
+- `--team ABBR` — process a single team (e.g., `--team LAL`)
+
+### Utilities
+
+**`get_logo_url(entity_type, slug)`** in `app/utils/images.py`
+
+Builds a canonical logo URL using the same S3/CDN base as player images:
+```
+get_logo_url("nba", "lakers")
+→ "https://.../logos/nba/lakers.png"
+
+get_logo_url("college", "duke")
+→ "https://.../logos/college/duke.png"
+```
+
+### S3 Layout
+
+```
+s3://draft-app-public-static/
+├── players/                    # Existing player images
+│   └── {id}_{slug}_{style}.png
+└── logos/
+    ├── nba/                    # ✅ 30 logos collected
+    │   ├── lakers.png
+    │   ├── celtics.png
+    │   └── ...
+    └── college/                # ⏳ Pending dedup + collection
+        ├── duke.png
+        └── ...
+```
+
+### Logo Processing Pipeline
+
+1. **Download** — Fetch 500px PNG from ESPN CDN (`a.espncdn.com/i/teamlogos/nba/500/{abbr}.png`)
+2. **Process** — Resize to 200×200 via Pillow, convert to RGBA, center on transparent canvas, optimize
+3. **Upload** — Via `s3_client.upload()` (handles S3 in prod, local filesystem in dev)
+4. **Link** — Update `logo_url` column in the corresponding DB row
+
+ESPN uses non-standard slugs for some teams (mapped in `ESPN_ABBR_OVERRIDES`):
+- Utah Jazz: `utah` (not `uta`)
+- New Orleans Pelicans: `no` (not `nop`)
+
+---
+
+## Next Step: College School Deduplication
+
+### The Problem
+
+`players_master.school` contains **573 distinct string values**, but many are duplicates or non-college entries:
+
+**Duplicate patterns:**
+- Short vs full name: "Duke" / "Duke University"
+- Nickname included: "Arizona" / "Arizona Wildcats"
+- Official vs common: "BYU" / "Brigham Young University"
+- Inconsistent format: "Miami (FL)" / "Miami (Florida)" / "Miami Hurricanes" / "University of Miami"
+
+**Non-college entries (~20-30):**
+- Professional clubs: "FC Barcelona Bàsquet", "KK Mega Basket", "Real Madrid (Spain)"
+- G League: "Greensboro Swarm (NBA G League)", "Mexico City Capitanes (NBA G League)"
+- International: "Guangzhou Loong Lions (CBA)", "New Zealand Breakers"
+- Alternative paths: "Overtime Elite"
+
+### Proposed Approach
+
+1. **Build a canonical mapping** — Map all 573 raw values to canonical school names (or flag as non-college). AI-assisted draft, human-reviewed.
+2. **Seed `college_schools`** — Insert the ~200-250 canonical schools with slug, conference, and colors.
+3. **Collect college logos** — Same ESPN CDN pipeline, adapted for NCAA logos (requires ESPN team ID mapping since NCAA logos use IDs, not abbreviations).
+4. **Optionally backfill** — Update `players_master.school` to use canonical names (or keep raw strings and join through a mapping table).
+
+### Scope Estimate
+
+- ~200-250 real US college programs after dedup
+- ~20-30 non-college entries to flag/exclude
+- ESPN has NCAA logos keyed by ESPN team ID (not by name), so we'll need a name → ESPN ID mapping
+
+---
+
+## Future: Template & Share Card Integration
+
+Once both NBA and college logos are collected:
+
+### Templates
+
+Small inline logos alongside team/school text:
+```html
+<img class="team-logo team-logo--sm" src="{{ school_logo_url }}" alt="{{ player.college }}">
+```
+
+Display contexts:
+- **Player detail page** — next to school name and draft team
+- **Mock draft / consensus board** — beside each pick
+- **Stats tables** — inline in the school column
+- **News feed** — team badges on articles
+
+### Share Cards (SVG Export)
+
+Embed logos as base64 data URIs using the existing `image_embedder.py` pattern (same approach as player photos).
+
+### Team Color Accents (Optional)
+
+With `primary_color` / `secondary_color` stored per team, inject CSS custom properties:
+```css
+.player-card { --team-color: #552583; }
+.player-card__accent { border-color: var(--team-color); }
+```
+
+Can also apply retro tinting via CSS filters on display rather than storing multiple logo variants:
+```css
+.team-logo--muted { filter: grayscale(0.6) sepia(0.2); }
+```
+
+---
+
+## Alembic Migration History
+
+| Revision | Description |
+|----------|-------------|
+| `b9705695210a` | Create `nba_teams` and `college_schools` tables (safe `IF NOT EXISTS` — tables may already exist via `AUTO_INIT_DB`) |

--- a/scripts/collect_nba_logos.py
+++ b/scripts/collect_nba_logos.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+"""Download, process, and upload NBA team logos.
+
+Fetches logos from ESPN CDN, resizes to a consistent 200x200 PNG with
+transparent background, and uploads via the app's S3 client (which
+falls back to local filesystem in dev mode).
+
+Usage:
+    python scripts/collect_nba_logos.py              # Process all teams
+    python scripts/collect_nba_logos.py --dry-run     # Download + process only
+    python scripts/collect_nba_logos.py --team LAL    # Single team
+    python scripts/collect_nba_logos.py --local-only  # Force local storage
+"""
+
+import argparse
+import asyncio
+import io
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+import httpx
+from dotenv import load_dotenv
+from PIL import Image
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+# ESPN CDN serves 500px PNGs for every NBA team by lowercase abbreviation
+ESPN_LOGO_URL = "https://a.espncdn.com/i/teamlogos/nba/500/{abbr}.png"
+
+# ESPN uses non-standard slugs for some teams
+ESPN_ABBR_OVERRIDES: dict[str, str] = {
+    "UTA": "utah",
+    "NOP": "no",
+}
+
+# Target dimensions for processed logos
+LOGO_SIZE = (200, 200)
+
+
+def process_logo(raw_bytes: bytes) -> bytes:
+    """Resize and normalize a logo image to a consistent PNG.
+
+    Args:
+        raw_bytes: Raw image bytes from download.
+
+    Returns:
+        Processed PNG bytes (200x200, RGBA, optimized).
+    """
+    img = Image.open(io.BytesIO(raw_bytes))
+    img = img.convert("RGBA")
+
+    # Use LANCZOS resampling for high-quality downscale
+    img.thumbnail(LOGO_SIZE, Image.LANCZOS)
+
+    # Center on a transparent canvas if thumbnail isn't exactly square
+    if img.size != LOGO_SIZE:
+        canvas = Image.new("RGBA", LOGO_SIZE, (0, 0, 0, 0))
+        offset = ((LOGO_SIZE[0] - img.width) // 2, (LOGO_SIZE[1] - img.height) // 2)
+        canvas.paste(img, offset, mask=img)
+        img = canvas
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
+
+
+async def collect_logos(
+    *,
+    dry_run: bool = False,
+    local_only: bool = False,
+    team_filter: str | None = None,
+) -> None:
+    """Download, process, and upload NBA team logos.
+
+    Args:
+        dry_run: If True, download and process but don't upload or update DB.
+        local_only: If True, force local filesystem storage.
+        team_filter: If set, only process this abbreviation (e.g. 'LAL').
+    """
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        logger.error("DATABASE_URL not set")
+        sys.exit(1)
+
+    engine = create_async_engine(db_url)
+    session_factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    from app.schemas.nba_teams import NbaTeam
+
+    # Optionally force local storage
+    if local_only:
+        from app.config import settings
+
+        settings.image_storage_local = True
+
+    from app.services.s3_client import s3_client
+
+    # Load teams from DB
+    async with session_factory() as session:
+        query = select(NbaTeam)
+        if team_filter:
+            query = query.where(NbaTeam.abbreviation == team_filter.upper())
+        result = await session.execute(query)
+        teams = result.scalars().all()
+
+    if not teams:
+        logger.error("No teams found. Run seed_nba_teams.py first.")
+        sys.exit(1)
+
+    logger.info(f"Processing {len(teams)} team(s)...\n")
+
+    succeeded = 0
+    failed = 0
+
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        for team in teams:
+            espn_abbr = ESPN_ABBR_OVERRIDES.get(
+                team.abbreviation, team.abbreviation.lower()
+            )
+            url = ESPN_LOGO_URL.format(abbr=espn_abbr)
+            s3_key = f"logos/nba/{team.slug}.png"
+
+            # Download
+            try:
+                resp = await http.get(url)
+                resp.raise_for_status()
+                raw_bytes = resp.content
+                logger.info(
+                    f"  DOWNLOAD  {team.abbreviation} — {len(raw_bytes):,} bytes"
+                )
+            except httpx.HTTPError as e:
+                logger.error(f"  FAIL      {team.abbreviation} — download error: {e}")
+                failed += 1
+                continue
+
+            # Process
+            try:
+                processed = process_logo(raw_bytes)
+                logger.info(
+                    f"  PROCESS   {team.abbreviation} — "
+                    f"{len(raw_bytes):,} → {len(processed):,} bytes"
+                )
+            except Exception as e:
+                logger.error(f"  FAIL      {team.abbreviation} — processing error: {e}")
+                failed += 1
+                continue
+
+            if dry_run:
+                logger.info(f"  DRY-RUN   {team.abbreviation} — skipping upload")
+                succeeded += 1
+                continue
+
+            # Upload
+            try:
+                public_url = s3_client.upload(
+                    key=s3_key,
+                    data=processed,
+                    content_type="image/png",
+                )
+                logger.info(f"  UPLOAD    {team.abbreviation} → {public_url}")
+            except Exception as e:
+                logger.error(f"  FAIL      {team.abbreviation} — upload error: {e}")
+                failed += 1
+                continue
+
+            # Update DB
+            async with session_factory() as session:
+                await session.execute(
+                    update(NbaTeam)
+                    .where(NbaTeam.id == team.id)
+                    .values(
+                        logo_url=public_url,
+                        updated_at=datetime.now(timezone.utc).replace(tzinfo=None),
+                    )
+                )
+                await session.commit()
+
+            succeeded += 1
+
+    await engine.dispose()
+
+    logger.info(f"\nDone: {succeeded} succeeded, {failed} failed ({len(teams)} total)")
+    if dry_run:
+        logger.info("(dry-run mode — nothing was uploaded or saved)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Collect NBA team logos")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Download + process only"
+    )
+    parser.add_argument(
+        "--local-only", action="store_true", help="Force local filesystem"
+    )
+    parser.add_argument(
+        "--team", type=str, default=None, help="Single team abbreviation"
+    )
+    args = parser.parse_args()
+
+    asyncio.run(
+        collect_logos(
+            dry_run=args.dry_run,
+            local_only=args.local_only,
+            team_filter=args.team,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed_nba_teams.py
+++ b/scripts/seed_nba_teams.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""Seed the nba_teams table with all 30 current NBA franchises.
+
+Usage:
+    python scripts/seed_nba_teams.py
+
+Idempotent: skips teams that already exist (matched by abbreviation).
+"""
+
+import asyncio
+import os
+import sys
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+load_dotenv()
+
+# fmt: off
+NBA_TEAMS = [
+    # Atlantic Division — Eastern Conference
+    {"name": "Boston Celtics",       "abbreviation": "BOS", "slug": "celtics",       "city": "Boston",        "conference": "Eastern", "division": "Atlantic",  "primary_color": "#007A33", "secondary_color": "#BA9653"},
+    {"name": "Brooklyn Nets",        "abbreviation": "BKN", "slug": "nets",          "city": "Brooklyn",      "conference": "Eastern", "division": "Atlantic",  "primary_color": "#000000", "secondary_color": "#FFFFFF"},
+    {"name": "New York Knicks",      "abbreviation": "NYK", "slug": "knicks",        "city": "New York",      "conference": "Eastern", "division": "Atlantic",  "primary_color": "#006BB6", "secondary_color": "#F58426"},
+    {"name": "Philadelphia 76ers",   "abbreviation": "PHI", "slug": "76ers",         "city": "Philadelphia",  "conference": "Eastern", "division": "Atlantic",  "primary_color": "#006BB6", "secondary_color": "#ED174C"},
+    {"name": "Toronto Raptors",      "abbreviation": "TOR", "slug": "raptors",       "city": "Toronto",       "conference": "Eastern", "division": "Atlantic",  "primary_color": "#CE1141", "secondary_color": "#000000"},
+    # Central Division — Eastern Conference
+    {"name": "Chicago Bulls",        "abbreviation": "CHI", "slug": "bulls",         "city": "Chicago",       "conference": "Eastern", "division": "Central",   "primary_color": "#CE1141", "secondary_color": "#000000"},
+    {"name": "Cleveland Cavaliers",  "abbreviation": "CLE", "slug": "cavaliers",     "city": "Cleveland",     "conference": "Eastern", "division": "Central",   "primary_color": "#860038", "secondary_color": "#FDBB30"},
+    {"name": "Detroit Pistons",      "abbreviation": "DET", "slug": "pistons",       "city": "Detroit",       "conference": "Eastern", "division": "Central",   "primary_color": "#C8102E", "secondary_color": "#1D42BA"},
+    {"name": "Indiana Pacers",       "abbreviation": "IND", "slug": "pacers",        "city": "Indianapolis",  "conference": "Eastern", "division": "Central",   "primary_color": "#002D62", "secondary_color": "#FDBB30"},
+    {"name": "Milwaukee Bucks",      "abbreviation": "MIL", "slug": "bucks",         "city": "Milwaukee",     "conference": "Eastern", "division": "Central",   "primary_color": "#00471B", "secondary_color": "#EEE1C6"},
+    # Southeast Division — Eastern Conference
+    {"name": "Atlanta Hawks",        "abbreviation": "ATL", "slug": "hawks",         "city": "Atlanta",       "conference": "Eastern", "division": "Southeast", "primary_color": "#E03A3E", "secondary_color": "#C1D32F"},
+    {"name": "Charlotte Hornets",    "abbreviation": "CHA", "slug": "hornets",       "city": "Charlotte",     "conference": "Eastern", "division": "Southeast", "primary_color": "#1D1160", "secondary_color": "#00788C"},
+    {"name": "Miami Heat",           "abbreviation": "MIA", "slug": "heat",          "city": "Miami",         "conference": "Eastern", "division": "Southeast", "primary_color": "#98002E", "secondary_color": "#F9A01B"},
+    {"name": "Orlando Magic",        "abbreviation": "ORL", "slug": "magic",         "city": "Orlando",       "conference": "Eastern", "division": "Southeast", "primary_color": "#0077C0", "secondary_color": "#C4CED4"},
+    {"name": "Washington Wizards",   "abbreviation": "WAS", "slug": "wizards",       "city": "Washington",    "conference": "Eastern", "division": "Southeast", "primary_color": "#002B5C", "secondary_color": "#E31837"},
+    # Northwest Division — Western Conference
+    {"name": "Denver Nuggets",       "abbreviation": "DEN", "slug": "nuggets",       "city": "Denver",        "conference": "Western", "division": "Northwest", "primary_color": "#0E2240", "secondary_color": "#FEC524"},
+    {"name": "Minnesota Timberwolves", "abbreviation": "MIN", "slug": "timberwolves", "city": "Minneapolis", "conference": "Western", "division": "Northwest", "primary_color": "#0C2340", "secondary_color": "#236192"},
+    {"name": "Oklahoma City Thunder", "abbreviation": "OKC", "slug": "thunder",      "city": "Oklahoma City", "conference": "Western", "division": "Northwest", "primary_color": "#007AC1", "secondary_color": "#EF6020"},
+    {"name": "Portland Trail Blazers", "abbreviation": "POR", "slug": "trail-blazers", "city": "Portland",   "conference": "Western", "division": "Northwest", "primary_color": "#E03A3E", "secondary_color": "#000000"},
+    {"name": "Utah Jazz",            "abbreviation": "UTA", "slug": "jazz",          "city": "Salt Lake City", "conference": "Western", "division": "Northwest", "primary_color": "#002B5C", "secondary_color": "#F9A01B"},
+    # Pacific Division — Western Conference
+    {"name": "Golden State Warriors", "abbreviation": "GSW", "slug": "warriors",     "city": "San Francisco", "conference": "Western", "division": "Pacific",   "primary_color": "#1D428A", "secondary_color": "#FFC72C"},
+    {"name": "Los Angeles Clippers", "abbreviation": "LAC", "slug": "clippers",      "city": "Los Angeles",   "conference": "Western", "division": "Pacific",   "primary_color": "#C8102E", "secondary_color": "#1D428A"},
+    {"name": "Los Angeles Lakers",   "abbreviation": "LAL", "slug": "lakers",        "city": "Los Angeles",   "conference": "Western", "division": "Pacific",   "primary_color": "#552583", "secondary_color": "#FDB927"},
+    {"name": "Phoenix Suns",         "abbreviation": "PHX", "slug": "suns",          "city": "Phoenix",       "conference": "Western", "division": "Pacific",   "primary_color": "#1D1160", "secondary_color": "#E56020"},
+    {"name": "Sacramento Kings",     "abbreviation": "SAC", "slug": "kings",         "city": "Sacramento",    "conference": "Western", "division": "Pacific",   "primary_color": "#5A2D81", "secondary_color": "#63727A"},
+    # Southwest Division — Western Conference
+    {"name": "Dallas Mavericks",     "abbreviation": "DAL", "slug": "mavericks",     "city": "Dallas",        "conference": "Western", "division": "Southwest", "primary_color": "#00538C", "secondary_color": "#002B5E"},
+    {"name": "Houston Rockets",      "abbreviation": "HOU", "slug": "rockets",       "city": "Houston",       "conference": "Western", "division": "Southwest", "primary_color": "#CE1141", "secondary_color": "#000000"},
+    {"name": "Memphis Grizzlies",    "abbreviation": "MEM", "slug": "grizzlies",     "city": "Memphis",       "conference": "Western", "division": "Southwest", "primary_color": "#5D76A9", "secondary_color": "#12173F"},
+    {"name": "New Orleans Pelicans",  "abbreviation": "NOP", "slug": "pelicans",     "city": "New Orleans",   "conference": "Western", "division": "Southwest", "primary_color": "#0C2340", "secondary_color": "#C8102E"},
+    {"name": "San Antonio Spurs",    "abbreviation": "SAS", "slug": "spurs",         "city": "San Antonio",   "conference": "Western", "division": "Southwest", "primary_color": "#C4CED4", "secondary_color": "#000000"},
+]
+# fmt: on
+
+
+async def seed_nba_teams() -> None:
+    """Insert NBA teams into nba_teams table, skipping existing rows."""
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        print("ERROR: DATABASE_URL not set")
+        sys.exit(1)
+
+    engine = create_async_engine(db_url)
+    session_factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    # Import here to avoid import-time side effects
+    from app.schemas.nba_teams import NbaTeam
+
+    added = 0
+    skipped = 0
+
+    async with session_factory() as session:
+        for team_data in NBA_TEAMS:
+            result = await session.execute(
+                select(NbaTeam).where(NbaTeam.abbreviation == team_data["abbreviation"])
+            )
+            existing = result.scalar_one_or_none()
+
+            if existing:
+                print(f"  SKIP  {team_data['abbreviation']} — {team_data['name']}")
+                skipped += 1
+                continue
+
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
+            team = NbaTeam(
+                **team_data,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(team)
+            print(f"  ADD   {team_data['abbreviation']} — {team_data['name']}")
+            added += 1
+
+        await session.commit()
+
+    await engine.dispose()
+    print(f"\nDone: {added} added, {skipped} skipped ({added + skipped} total)")
+
+
+if __name__ == "__main__":
+    asyncio.run(seed_nba_teams())


### PR DESCRIPTION
## Summary
### NBA Teams (commit 1)
- Add nba_teams and college_schools database tables with Alembic migration
- Seed all 30 current NBA franchises with metadata
- Collect 30 NBA logos from ESPN CDN (200x200 RGBA PNG) to S3
- Add get_logo_url() utility and nba-seed / nba-logos Makefile targets

### College Schools (commit 2)
- Canonicalize 574 raw school values into 474 distinct schools via heuristic clustering
- Resolve ESPN team IDs, conferences, and brand colors for 314 schools
- Seed college_schools table with all 474 schools
- Backfill players_master.school to canonical names (589 players updated)
- Add school_raw column to preserve original values
- Collect 314 college logos from ESPN CDN to S3
- 21 non-college entries (international clubs, G League) excluded

### Totals
- 344 logos on S3 (30 NBA + 314 college)
- 474 college schools + 30 NBA teams seeded with metadata
- Template integration deferred to a follow-up PR

## Test plan
- [x] All seed scripts idempotent (re-run skips existing)
- [x] 30/30 NBA logos + 314/314 college logos collected
- [x] Both Alembic migrations succeed
- [x] make precommit passes clean