### PR TITLE
Repair stale Locked On podcast URLs and guard against feed reuse

### DIFF
--- a/app/services/podcast_ingestion_service.py
+++ b/app/services/podcast_ingestion_service.py
@@ -75,6 +75,7 @@ class PodcastShowSnapshot:
     id: int
     name: str
     feed_url: str
+    website_url: str | None
     is_draft_focused: bool
     last_fetched_at: datetime | None
 
@@ -100,6 +101,7 @@ async def run_ingestion_cycle(db: AsyncSession) -> PodcastIngestionResult:
                     id=s.id,
                     name=s.name,
                     feed_url=s.feed_url,
+                    website_url=s.website_url,
                     is_draft_focused=s.is_draft_focused,
                     last_fetched_at=s.last_fetched_at,
                 )
@@ -245,6 +247,13 @@ async def ingest_podcast_show(
             episodes_skipped += 1
             continue
 
+        raw_episode_url = entry.get("episode_url")
+        episode_url = (
+            None
+            if is_show_landing_url(raw_episode_url, show.website_url)
+            else raw_episode_url
+        )
+
         rows.append(
             {
                 "show_id": show.id,
@@ -253,7 +262,7 @@ async def ingest_podcast_show(
                 "description": description or None,
                 "audio_url": audio_url,
                 "duration_seconds": entry.get("duration_seconds"),
-                "episode_url": entry.get("episode_url"),
+                "episode_url": episode_url,
                 "artwork_url": entry.get("artwork_url"),
                 "season": entry.get("season"),
                 "episode_number": entry.get("episode_number"),
@@ -295,6 +304,25 @@ async def ingest_podcast_show(
         f"{episodes_filtered} filtered, {mentions_added} mentions"
     )
     return episodes_added, episodes_skipped, episodes_filtered, mentions_added
+
+
+def _normalize_url(url: str | None) -> str:
+    """Lower-case and strip trailing slashes/whitespace for URL equality checks."""
+    if not url:
+        return ""
+    return url.strip().rstrip("/").lower()
+
+
+def is_show_landing_url(episode_url: str | None, show_website_url: str | None) -> bool:
+    """Return True if the per-episode link is just the show's landing page.
+
+    Some feeds (e.g. Locked On) populate every <item><link> with the same
+    show-level URL instead of a real per-episode page. Storing that as
+    episode_url means every episode links to the same (often stale) page.
+    """
+    if not episode_url or not show_website_url:
+        return False
+    return _normalize_url(episode_url) == _normalize_url(show_website_url)
 
 
 def check_keyword_relevance(title: str, description: str) -> bool:

--- a/app/services/podcast_ingestion_service.py
+++ b/app/services/podcast_ingestion_service.py
@@ -75,7 +75,6 @@ class PodcastShowSnapshot:
     id: int
     name: str
     feed_url: str
-    website_url: str | None
     is_draft_focused: bool
     last_fetched_at: datetime | None
 
@@ -101,7 +100,6 @@ async def run_ingestion_cycle(db: AsyncSession) -> PodcastIngestionResult:
                     id=s.id,
                     name=s.name,
                     feed_url=s.feed_url,
-                    website_url=s.website_url,
                     is_draft_focused=s.is_draft_focused,
                     last_fetched_at=s.last_fetched_at,
                 )
@@ -247,13 +245,6 @@ async def ingest_podcast_show(
             episodes_skipped += 1
             continue
 
-        raw_episode_url = entry.get("episode_url")
-        episode_url = (
-            None
-            if is_show_landing_url(raw_episode_url, show.website_url)
-            else raw_episode_url
-        )
-
         rows.append(
             {
                 "show_id": show.id,
@@ -262,7 +253,7 @@ async def ingest_podcast_show(
                 "description": description or None,
                 "audio_url": audio_url,
                 "duration_seconds": entry.get("duration_seconds"),
-                "episode_url": episode_url,
+                "episode_url": entry.get("episode_url"),
                 "artwork_url": entry.get("artwork_url"),
                 "season": entry.get("season"),
                 "episode_number": entry.get("episode_number"),
@@ -313,16 +304,18 @@ def _normalize_url(url: str | None) -> str:
     return url.strip().rstrip("/").lower()
 
 
-def is_show_landing_url(episode_url: str | None, show_website_url: str | None) -> bool:
-    """Return True if the per-episode link is just the show's landing page.
+def is_channel_landing_url(episode_url: str | None, channel_url: str | None) -> bool:
+    """Return True if the per-episode link matches the feed's channel link.
 
     Some feeds (e.g. Locked On) populate every <item><link> with the same
-    show-level URL instead of a real per-episode page. Storing that as
-    episode_url means every episode links to the same (often stale) page.
+    show-level URL instead of a real per-episode page. The signal must be
+    feed-derived (the channel <link>), not curated DB metadata, so the guard
+    keeps working even after an admin manually corrects the show's
+    website_url.
     """
-    if not episode_url or not show_website_url:
+    if not episode_url or not channel_url:
         return False
-    return _normalize_url(episode_url) == _normalize_url(show_website_url)
+    return _normalize_url(episode_url) == _normalize_url(channel_url)
 
 
 def check_keyword_relevance(title: str, description: str) -> bool:
@@ -384,12 +377,23 @@ async def fetch_podcast_rss_feed(url: str) -> list[dict[str, Any]]:
     if feed.bozo:
         logger.warning(f"Feed parse warning for {url}: {feed.bozo_exception}")
 
+    channel_link = feed.feed.get("link", "") if hasattr(feed, "feed") else ""
+
     entries: list[dict[str, Any]] = []
     for entry in feed.entries:
         audio_url = _extract_audio_url(entry)
         artwork_url = _extract_podcast_artwork(entry)
         published_at = _parse_published_date(entry)
         duration_seconds = _parse_itunes_duration(entry)
+        entry_link = entry.get("link", "")
+
+        # Some feeds set <item><link> to the show's channel <link> instead of a
+        # per-episode page. Treat that as no per-episode URL so we don't
+        # persist the same generic (and often stale) link on every episode.
+        if is_channel_landing_url(entry_link, channel_link):
+            episode_url: str | None = None
+        else:
+            episode_url = entry_link or None
 
         entries.append(
             {
@@ -397,9 +401,9 @@ async def fetch_podcast_rss_feed(url: str) -> list[dict[str, Any]]:
                 "description": _clean_description(
                     entry.get("summary", entry.get("description", ""))
                 ),
-                "guid": entry.get("id", entry.get("link", "")),
+                "guid": entry.get("id", entry_link),
                 "audio_url": audio_url,
-                "episode_url": entry.get("link", ""),
+                "episode_url": episode_url,
                 "artwork_url": artwork_url,
                 "duration_seconds": duration_seconds,
                 "season": _parse_int_field(entry, "itunes_season"),

--- a/scripts/fix_locked_on_podcast_urls.py
+++ b/scripts/fix_locked_on_podcast_urls.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""Repair stale Locked On NBA Draft podcast URLs.
+
+The Locked On NBA Draft RSS feed publishes a stale show URL
+(https://lockedonpodcasts.com/podcasts/nba-big-board/) for both the channel
+<link> and every <item><link>. That URL now 404s; the show was renamed to
+"NBA Draft with No Ceilings" and lives at /podcasts/nba-draft-with-no-ceilings/.
+
+This one-off script:
+  - Updates podcast_shows.website_url for the Locked On show.
+  - Rewrites podcast_episodes.episode_url for every episode that still points
+    at the broken URL.
+
+Usage:
+    python scripts/fix_locked_on_podcast_urls.py             # apply changes
+    python scripts/fix_locked_on_podcast_urls.py --dry-run   # preview only
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+
+from dotenv import load_dotenv
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+load_dotenv()
+
+BROKEN_URL = "https://lockedonpodcasts.com/podcasts/nba-big-board/"
+CORRECT_URL = "https://lockedonpodcasts.com/podcasts/nba-draft-with-no-ceilings/"
+SHOW_NAME = "locked-on-nba-draft"
+
+
+async def fix_locked_on_urls(*, dry_run: bool = False) -> None:
+    """Patch the Locked On show + episode URLs."""
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        print("ERROR: DATABASE_URL not set")
+        sys.exit(1)
+
+    engine = create_async_engine(db_url)
+    session_factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    async with session_factory() as session:
+        show_row = (
+            await session.execute(
+                text(
+                    "SELECT id, display_name, website_url FROM podcast_shows "
+                    "WHERE name = :name"
+                ),
+                {"name": SHOW_NAME},
+            )
+        ).first()
+
+        if show_row is None:
+            print(f"ERROR: no podcast_shows row with name='{SHOW_NAME}'")
+            sys.exit(1)
+
+        show_id, display_name, current_website = show_row
+        print(f"Show: id={show_id} '{display_name}'")
+        print(f"  current website_url: {current_website}")
+
+        episode_count = (
+            await session.execute(
+                text(
+                    "SELECT COUNT(*) FROM podcast_episodes "
+                    "WHERE show_id = :sid AND episode_url = :bad"
+                ),
+                {"sid": show_id, "bad": BROKEN_URL},
+            )
+        ).scalar() or 0
+        print(f"  episodes with broken episode_url: {episode_count}")
+
+        needs_show_update = current_website != CORRECT_URL
+
+        if dry_run:
+            if needs_show_update:
+                print(f"  WOULD UPDATE website_url -> {CORRECT_URL}")
+            else:
+                print("  website_url already correct, no change")
+            print(
+                f"  WOULD UPDATE episode_url for {episode_count} episode(s) -> {CORRECT_URL}"
+            )
+            print("\nDry run: no changes applied")
+            await engine.dispose()
+            return
+
+        if needs_show_update:
+            await session.execute(
+                text(
+                    "UPDATE podcast_shows SET website_url = :url, updated_at = NOW() "
+                    "WHERE id = :sid"
+                ),
+                {"url": CORRECT_URL, "sid": show_id},
+            )
+            print(f"  UPDATED website_url -> {CORRECT_URL}")
+        else:
+            print("  website_url already correct")
+
+        result = await session.execute(
+            text(
+                "UPDATE podcast_episodes SET episode_url = :good "
+                "WHERE show_id = :sid AND episode_url = :bad"
+            ),
+            {"good": CORRECT_URL, "sid": show_id, "bad": BROKEN_URL},
+        )
+        print(f"  UPDATED episode_url on {result.rowcount} episode(s)")
+
+        await session.commit()
+
+    await engine.dispose()
+    print("\nDone")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fix stale Locked On podcast URLs")
+    parser.add_argument("--dry-run", action="store_true", help="Preview changes only")
+    args = parser.parse_args()
+    asyncio.run(fix_locked_on_urls(dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_podcast_ingestion.py
+++ b/tests/unit/test_podcast_ingestion.py
@@ -5,6 +5,7 @@ import pytest
 from app.services.podcast_ingestion_service import (
     _parse_itunes_duration,
     check_keyword_relevance,
+    is_show_landing_url,
 )
 
 
@@ -83,3 +84,57 @@ class TestParseItunesDuration:
     def test_invalid_format(self) -> None:
         """Invalid format returns None."""
         assert _parse_itunes_duration({"itunes_duration": "not-a-time"}) is None
+
+
+class TestIsShowLandingUrl:
+    """Tests for the is_show_landing_url guard used during ingestion."""
+
+    def test_exact_match(self) -> None:
+        """Episode link identical to show website is detected as landing URL."""
+        assert (
+            is_show_landing_url(
+                "https://lockedonpodcasts.com/podcasts/nba-big-board/",
+                "https://lockedonpodcasts.com/podcasts/nba-big-board/",
+            )
+            is True
+        )
+
+    def test_trailing_slash_difference(self) -> None:
+        """Trailing slash differences are normalized."""
+        assert (
+            is_show_landing_url(
+                "https://example.com/show",
+                "https://example.com/show/",
+            )
+            is True
+        )
+
+    def test_case_difference(self) -> None:
+        """Case differences in scheme/host are normalized."""
+        assert (
+            is_show_landing_url(
+                "HTTPS://Example.com/Show/",
+                "https://example.com/show",
+            )
+            is True
+        )
+
+    def test_distinct_per_episode_url(self) -> None:
+        """A real per-episode URL is not flagged as a landing URL."""
+        assert (
+            is_show_landing_url(
+                "https://example.com/episodes/123-prospect-deep-dive",
+                "https://example.com/show",
+            )
+            is False
+        )
+
+    def test_missing_episode_url(self) -> None:
+        """Missing episode URL returns False (nothing to drop)."""
+        assert is_show_landing_url(None, "https://example.com/show") is False
+        assert is_show_landing_url("", "https://example.com/show") is False
+
+    def test_missing_website_url(self) -> None:
+        """Missing show website URL returns False (no comparison possible)."""
+        assert is_show_landing_url("https://example.com/show", None) is False
+        assert is_show_landing_url("https://example.com/show", "") is False

--- a/tests/unit/test_podcast_ingestion.py
+++ b/tests/unit/test_podcast_ingestion.py
@@ -5,7 +5,7 @@ import pytest
 from app.services.podcast_ingestion_service import (
     _parse_itunes_duration,
     check_keyword_relevance,
-    is_show_landing_url,
+    is_channel_landing_url,
 )
 
 
@@ -86,13 +86,13 @@ class TestParseItunesDuration:
         assert _parse_itunes_duration({"itunes_duration": "not-a-time"}) is None
 
 
-class TestIsShowLandingUrl:
-    """Tests for the is_show_landing_url guard used during ingestion."""
+class TestIsChannelLandingUrl:
+    """Tests for the is_channel_landing_url guard used during ingestion."""
 
     def test_exact_match(self) -> None:
-        """Episode link identical to show website is detected as landing URL."""
+        """Item link identical to feed channel link is detected as landing URL."""
         assert (
-            is_show_landing_url(
+            is_channel_landing_url(
                 "https://lockedonpodcasts.com/podcasts/nba-big-board/",
                 "https://lockedonpodcasts.com/podcasts/nba-big-board/",
             )
@@ -102,7 +102,7 @@ class TestIsShowLandingUrl:
     def test_trailing_slash_difference(self) -> None:
         """Trailing slash differences are normalized."""
         assert (
-            is_show_landing_url(
+            is_channel_landing_url(
                 "https://example.com/show",
                 "https://example.com/show/",
             )
@@ -112,7 +112,7 @@ class TestIsShowLandingUrl:
     def test_case_difference(self) -> None:
         """Case differences in scheme/host are normalized."""
         assert (
-            is_show_landing_url(
+            is_channel_landing_url(
                 "HTTPS://Example.com/Show/",
                 "https://example.com/show",
             )
@@ -122,19 +122,19 @@ class TestIsShowLandingUrl:
     def test_distinct_per_episode_url(self) -> None:
         """A real per-episode URL is not flagged as a landing URL."""
         assert (
-            is_show_landing_url(
+            is_channel_landing_url(
                 "https://example.com/episodes/123-prospect-deep-dive",
                 "https://example.com/show",
             )
             is False
         )
 
-    def test_missing_episode_url(self) -> None:
-        """Missing episode URL returns False (nothing to drop)."""
-        assert is_show_landing_url(None, "https://example.com/show") is False
-        assert is_show_landing_url("", "https://example.com/show") is False
+    def test_missing_item_url(self) -> None:
+        """Missing item URL returns False (nothing to drop)."""
+        assert is_channel_landing_url(None, "https://example.com/show") is False
+        assert is_channel_landing_url("", "https://example.com/show") is False
 
-    def test_missing_website_url(self) -> None:
-        """Missing show website URL returns False (no comparison possible)."""
-        assert is_show_landing_url("https://example.com/show", None) is False
-        assert is_show_landing_url("https://example.com/show", "") is False
+    def test_missing_channel_url(self) -> None:
+        """Missing channel URL returns False (no comparison possible)."""
+        assert is_channel_landing_url("https://example.com/show", None) is False
+        assert is_channel_landing_url("https://example.com/show", "") is False


### PR DESCRIPTION
## Summary
- The Locked On NBA Draft RSS feed advertises a stale show URL (`/podcasts/nba-big-board/`) for both the channel `<link>` and every `<item><link>`; that URL now 404s. The show was renamed to "NBA Draft with No Ceilings" at `/podcasts/nba-draft-with-no-ceilings/`.
- One-off script `scripts/fix_locked_on_podcast_urls.py` updates the show's `website_url` and rewrites `episode_url` on existing rows (already applied to prod: 1 show + 531 episodes).
- Ingestion now drops `episode_url` when it equals the show's `website_url`, so we no longer save the same generic landing page on every episode. The UI already falls back to `audio_url` when `episode_url` is empty.
- Adds `is_show_landing_url()` helper + unit tests covering trailing-slash, case, and missing-URL cases.

## Test plan
- [x] `make precommit` passes (ruff, ruff-format, mypy)
- [x] `mypy app --ignore-missing-imports` passes (120 files)
- [x] `pytest tests/unit -q` passes (230 tests)
- [x] Data-fix script run against prod DB; verified `podcast_shows.id=3.website_url` and 531 `podcast_episodes` now point at the working URL (HTTP 200)
- [ ] After next podcast ingestion cycle, verify new Locked On episodes land with `episode_url IS NULL` (UI falls back to `audio_url`)