### PR TITLE
Add request metadata middleware for bot-traffic diagnosis

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     debug: bool = False
     log_level: str = "INFO"
     access_log: bool = True
+    log_requests: bool = False
     sql_echo: bool = True
     auto_init_db: bool = True
 

--- a/app/main.py
+++ b/app/main.py
@@ -3,12 +3,13 @@
 from contextlib import asynccontextmanager
 import os
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.exc import DBAPIError
+from starlette.responses import Response
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from app.routes import admin, export, news, players, podcasts, share, stats, ui, videos
@@ -27,6 +28,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 setup_logging(level=settings.log_level, access_log=settings.access_log)
+
+access_logger = logging.getLogger("app.access")
 
 
 @asynccontextmanager
@@ -64,6 +67,37 @@ async def lifespan(app: FastAPI):
 # load in app details
 app = FastAPI(title="Mini Draft Guru", lifespan=lifespan)
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=["*"])  # type: ignore[arg-type]
+
+
+if settings.log_requests:
+
+    @app.middleware("http")
+    async def log_request_metadata(request: Request, call_next) -> Response:  # type: ignore[no-untyped-def]
+        # Skip noisy paths so the bot signal isn't drowned out.
+        path = request.url.path
+        if path == "/health" or path.startswith("/static/"):
+            return await call_next(request)
+
+        # Fly populates Fly-Client-IP with the real client; X-Forwarded-For is
+        # the fallback if anything else fronts the app later.
+        client_ip = (
+            request.headers.get("fly-client-ip")
+            or (request.headers.get("x-forwarded-for") or "").split(",")[0].strip()
+            or (request.client.host if request.client else "-")
+        )
+        ua = request.headers.get("user-agent", "-")
+        response = await call_next(request)
+        access_logger.info(
+            '%s "%s %s" %d ua="%s"',
+            client_ip,
+            request.method,
+            path,
+            response.status_code,
+            ua,
+        )
+        return response
+
+
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 app.state.templates = Jinja2Templates(directory="app/templates")
 app.include_router(export.router)


### PR DESCRIPTION
## Summary
- Adds a `LOG_REQUESTS` env flag (default off). When enabled, registers a thin `@app.middleware("http")` that emits one line per inbound request via the `app.access` logger: `<ip> "METHOD path" status ua="<ua>"`.
- IP is resolved in this order: `Fly-Client-IP` → first hop of `X-Forwarded-For` → `request.client.host`. Skips `/health` and `/static/*` to keep volume manageable.

## Motivation
GA4 is showing a large block of direct, mostly-single-page Singapore traffic and `ACCESS_LOG=false` in prod means no inbound request metadata is currently captured. Without UA/IP we can't tell scrapers (GPTBot, ClaudeBot, etc.) from real visitors. This flag is meant to be flipped on briefly, captured, then flipped back off.

## Usage
```
fly secrets set LOG_REQUESTS=true -a draft-app-prod   # turn on (triggers redeploy)
fly logs -a draft-app-prod | grep 'app.access'        # capture
fly secrets unset LOG_REQUESTS -a draft-app-prod      # turn off
```

## Test plan
- [x] `make precommit` (ruff + mypy)
- [x] `mypy app --ignore-missing-imports` (120 files, clean)
- [x] `pytest tests/unit -q` (230 passed)
- [ ] After deploy: confirm `app.access` lines appear when flag is on, disappear when off
- [ ] Spot-check a few logged IPs against `whois`/reverse-DNS to identify scraper networks