### PR TITLE
Serve sitemap.xml and robots.txt for crawler discoverability

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,18 @@ from sqlalchemy.exc import DBAPIError
 from starlette.responses import Response
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
-from app.routes import admin, export, news, players, podcasts, share, stats, ui, videos
+from app.routes import (
+    admin,
+    export,
+    news,
+    players,
+    podcasts,
+    seo,
+    share,
+    stats,
+    ui,
+    videos,
+)
 from app.utils.db_async import (
     init_db,
     dispose_engine,
@@ -107,6 +118,7 @@ app.include_router(videos.router)
 app.include_router(players.router)
 app.include_router(share.router)
 app.include_router(stats.router)
+app.include_router(seo.router)
 app.include_router(ui.router)
 app.include_router(admin.router)
 

--- a/app/routes/seo.py
+++ b/app/routes/seo.py
@@ -1,0 +1,76 @@
+"""SEO routes: ``robots.txt`` and ``sitemap.xml``."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import PlainTextResponse, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from app.schemas.players_master import PlayerMaster
+from app.utils.db_async import get_session
+
+router = APIRouter()
+
+
+# (path, changefreq, priority) for the public HTML pages worth surfacing.
+_STATIC_PAGES: tuple[tuple[str, str, str], ...] = (
+    ("/", "daily", "1.0"),
+    ("/news", "hourly", "0.9"),
+    ("/podcasts", "daily", "0.8"),
+    ("/film-room", "daily", "0.7"),
+    ("/terms", "yearly", "0.1"),
+    ("/privacy", "yearly", "0.1"),
+    ("/cookies", "yearly", "0.1"),
+)
+
+
+def _site_base(request: Request) -> str:
+    return str(request.base_url).rstrip("/")
+
+
+@router.get("/sitemap.xml", include_in_schema=False)
+async def sitemap_xml(
+    request: Request,
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    base = _site_base(request)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    stmt = (
+        select(PlayerMaster.slug, PlayerMaster.updated_at)  # type: ignore[call-overload]
+        .where(PlayerMaster.is_stub == False)  # noqa: E712
+        .where(PlayerMaster.slug.isnot(None))  # type: ignore[union-attr]
+        .where(PlayerMaster.display_name.isnot(None))  # type: ignore[union-attr]
+        .order_by(PlayerMaster.updated_at.desc())  # type: ignore[attr-defined]
+    )
+    result = await db.execute(stmt)
+
+    parts: list[str] = ['<?xml version="1.0" encoding="UTF-8"?>']
+    parts.append('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">')
+
+    for path, changefreq, priority in _STATIC_PAGES:
+        parts.append(
+            f"<url><loc>{base}{path}</loc>"
+            f"<lastmod>{today}</lastmod>"
+            f"<changefreq>{changefreq}</changefreq>"
+            f"<priority>{priority}</priority></url>"
+        )
+
+    for slug, updated_at in result.all():
+        lastmod = updated_at.strftime("%Y-%m-%d") if updated_at else today
+        parts.append(
+            f"<url><loc>{base}/players/{slug}</loc>"
+            f"<lastmod>{lastmod}</lastmod>"
+            f"<changefreq>weekly</changefreq>"
+            f"<priority>0.6</priority></url>"
+        )
+
+    parts.append("</urlset>")
+    return Response(content="".join(parts), media_type="application/xml")
+
+
+@router.get("/robots.txt", include_in_schema=False, response_class=PlainTextResponse)
+async def robots_txt(request: Request) -> str:
+    base = _site_base(request)
+    return f"User-agent: *\nDisallow: /admin\n\nSitemap: {base}/sitemap.xml\n"

--- a/tests/integration/test_seo.py
+++ b/tests/integration/test_seo.py
@@ -1,0 +1,62 @@
+"""Integration tests for sitemap.xml and robots.txt."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.players_master import PlayerMaster
+
+
+@pytest.mark.asyncio
+async def test_robots_txt_serves_directives_and_sitemap_link(
+    app_client: AsyncClient,
+) -> None:
+    """robots.txt returns plain text with disallow rules and a sitemap pointer."""
+    response = await app_client.get("/robots.txt")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    body = response.text
+    assert "User-agent: *" in body
+    assert "Disallow: /admin" in body
+    assert "Sitemap:" in body
+    assert "/sitemap.xml" in body
+
+
+@pytest.mark.asyncio
+async def test_sitemap_includes_static_pages_and_real_players(
+    app_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """sitemap.xml lists each static page and each non-stub player slug."""
+    real_player = PlayerMaster(
+        display_name="Sitemap Real Player",
+        first_name="Sitemap",
+        last_name="Real",
+        is_stub=False,
+    )
+    stub_player = PlayerMaster(
+        display_name="Sitemap Stub Player",
+        first_name="Sitemap",
+        last_name="Stub",
+        is_stub=True,
+    )
+    db_session.add_all([real_player, stub_player])
+    await db_session.commit()
+    await db_session.refresh(real_player)
+    await db_session.refresh(stub_player)
+
+    response = await app_client.get("/sitemap.xml")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/xml")
+    body = response.text
+    assert body.startswith('<?xml version="1.0"')
+    assert "<urlset" in body
+    # Static pages are included
+    for path in ("/news", "/podcasts", "/film-room", "/terms"):
+        assert f"{path}</loc>" in body, f"missing static path {path}"
+    # Real player appears, stub does not
+    assert f"/players/{real_player.slug}" in body
+    assert f"/players/{stub_player.slug}" not in body


### PR DESCRIPTION
## Summary
- Adds `/sitemap.xml` — a dynamic XML sitemap listing each public static page (`/`, `/news`, `/podcasts`, `/film-room`, legal pages) plus every non-stub player with a slug. `<lastmod>` is sourced from `PlayerMaster.updated_at` so well-behaved crawlers can conditional-fetch only what changed.
- Adds `/robots.txt` — allow all, `Disallow: /admin`, points at the sitemap.
- Base URL is derived from `request.base_url`, so the canonical `https://draftguru.com` origin works automatically behind Fly's proxy (we already have `ProxyHeadersMiddleware` rewriting the scheme).

## Motivation
The `LOG_REQUESTS=true` capture surfaced GPTBot hammering `/news` at ~1.9 req/s sustained — classic crawler behavior when there's no sitemap pointing at canonical URLs. A proper sitemap should:
- Quiet the noise from GPTBot/ClaudeBot/etc. by giving them efficient discovery
- Improve indexing of individual player pages by Google/Bing/AI search engines (right now bots only seem to know about `/news`)
- Keep stub players (`is_stub=True`) out of the map so half-built pages don't get indexed

## Test plan
- [x] `make precommit` (ruff + mypy)
- [x] `mypy app --ignore-missing-imports` (clean)
- [x] `pytest tests/unit -q` (230 passed)
- [x] `pytest tests/integration/test_seo.py -q` (2 passed against Neon test branch)
- [ ] After deploy: `curl https://draftguru.com/robots.txt` and `curl https://draftguru.com/sitemap.xml | head` look right
- [ ] Submit `https://draftguru.com/sitemap.xml` to Google Search Console and Bing Webmaster Tools
- [ ] Re-check `LOG_REQUESTS` capture in a few days — expect GPTBot's volume on `/news` to drop and player URLs to start appearing