### PR TITLE
Expand trending players with featured + compact tiers, retire Top Prospects

### DIFF
--- a/app/routes/ui.py
+++ b/app/routes/ui.py
@@ -8,7 +8,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.services.expanded_trending_service import get_expanded_trending_players
 from app.services.news_service import (
+    format_relative_time,
     get_author_counts,
     get_filtered_news_feed,
     get_hero_article,
@@ -61,15 +63,6 @@ FOOTER_LINKS = [
 ]
 
 
-# Curated list of top prospects to feature on homepage
-TOP_PROSPECT_SLUGS = [
-    "cooper-flagg",
-    "ace-bailey",
-    "dylan-harper",
-    "vj-edgecombe",
-    "kon-knueppel",
-]
-
 # Homepage news/feed constants
 HOME_NEWS_FEED_LIMIT = 100
 HOME_NEWS_SIDEBAR_LIMIT = 8
@@ -79,89 +72,71 @@ HOME_FILM_ROOM_LIMIT = 24
 @router.get("/", response_class=HTMLResponse)
 async def home(
     request: Request,
-    style: Optional[str] = Query(
-        None,
-        description="Preferred image style (falls back to default, then placeholder)",
-    ),
     db: AsyncSession = Depends(get_session),
 ):
-    """Render the Homepage with prospects, VS arena, and news feed."""
-    from sqlalchemy import select
-
-    from app.schemas.players_master import PlayerMaster
-
-    # Fetch curated top prospects from database by slug
-    result = await db.execute(
-        select(PlayerMaster).where(
-            PlayerMaster.slug.in_(TOP_PROSPECT_SLUGS)  # type: ignore[union-attr]
-        )
-    )
-    db_players_unordered = {p.slug: p for p in result.scalars().all()}
-    # Preserve the curated order
-    db_players = [
-        db_players_unordered[slug]
-        for slug in TOP_PROSPECT_SLUGS
-        if slug in db_players_unordered
-    ]
-
-    # Build player ID map for image URL generation and JS
-    player_id_map = {p.slug: (p.id, p.display_name) for p in db_players}
-
-    requested_style = style or settings.default_image_style
-
-    players = []
-    for p in db_players:
-        if p.id is None or not p.slug:
-            continue
-        img_url = get_player_image_url(
-            player_id=p.id,
-            slug=p.slug,
-            style=requested_style,
-        )
-        img_default_url = get_player_image_url(
-            player_id=p.id,
-            slug=p.slug,
-            style="default",
-        )
-        img_placeholder_url = get_placeholder_url(
-            p.display_name or "Player",
-            player_id=p.id,
-            width=320,
-            height=420,
-        )
-
-        players.append(
-            {
-                "id": p.id,
-                "name": p.display_name or "",
-                "slug": p.slug or "",
-                "position": "",  # Position data requires PlayerStatus join - to be added
-                "college": p.school or "",
-                "img": img_url,
-                "img_default": img_default_url,
-                "img_placeholder": img_placeholder_url,
-                "change": 0,  # No change data without consensus rankings
-                "measurables": {
-                    "ht": 80,  # Placeholder - will be populated from real data later
-                    "ws": 84,
-                    "vert": 36,
-                },
-            }
-        )
-
-    # Fetch trending players based on recent mentions
-    trending_raw = await get_trending_players(db, days=7, limit=10)
-    trending_players = [
+    """Render the Homepage with expanded trending players, VS arena, and news feed."""
+    # Fetch expanded trending payload (featured cards + compact tail).
+    expanded = await get_expanded_trending_players(db)
+    featured_trending = [
         {
-            "player_id": tp.player_id,
-            "display_name": tp.display_name,
-            "slug": tp.slug,
-            "school": tp.school or "",
-            "mention_count": tp.mention_count,
-            "trending_score": tp.trending_score,
-            "daily_counts": tp.daily_counts,
+            "player_id": fp.player_id,
+            "rank": fp.rank,
+            "display_name": fp.display_name,
+            "slug": fp.slug,
+            "photo_url": fp.photo_url,
+            "school": fp.school,
+            "position": fp.position,
+            "draft_year": fp.draft_year,
+            "mention_count": fp.mention_count,
+            "daily_counts": fp.daily_counts,
+            "spike_state": fp.spike_state,
+            "content_mix": fp.content_mix,
+            "dominant_news_tag": fp.dominant_news_tag,
+            "combine_grade": fp.combine_grade,
+            "latest_stats": {
+                "season": fp.latest_stats.season,
+                "ppg": fp.latest_stats.ppg,
+                "rpg": fp.latest_stats.rpg,
+                "apg": fp.latest_stats.apg,
+                "spg": fp.latest_stats.spg,
+                "bpg": fp.latest_stats.bpg,
+                "fg_pct": fp.latest_stats.fg_pct,
+                "three_p_pct": fp.latest_stats.three_p_pct,
+                "ft_pct": fp.latest_stats.ft_pct,
+            },
+            "recent_mentions": [
+                {
+                    "title": m.title,
+                    "url": m.url,
+                    "source_name": m.source_name,
+                    "content_type": m.content_type,
+                    "time": format_relative_time(m.published_at),
+                }
+                for m in fp.recent_mentions
+            ],
+            "latest_mention_time": (
+                format_relative_time(fp.latest_mention_at)
+                if fp.latest_mention_at is not None
+                else None
+            ),
         }
-        for tp in trending_raw
+        for fp in expanded.featured
+    ]
+    compact_trending = [
+        {
+            "player_id": cp.player_id,
+            "rank": cp.rank,
+            "display_name": cp.display_name,
+            "slug": cp.slug,
+            "photo_url": cp.photo_url,
+            "school": cp.school,
+            "position": cp.position,
+            "draft_year": cp.draft_year,
+            "mention_count": cp.mention_count,
+            "daily_counts": cp.daily_counts,
+            "dominant_news_tag": cp.dominant_news_tag,
+        }
+        for cp in expanded.compact
     ]
 
     # Fetch news feed from database (falls back to empty if no items yet)
@@ -283,16 +258,12 @@ async def home(
         for item in film_room_raw
     ]
 
-    # Build mappings for JS image URL generation
-    slug_to_id = {slug: player_id for slug, (player_id, _) in player_id_map.items()}
-    id_to_slug = {player_id: slug for slug, (player_id, _) in player_id_map.items()}
-
     return request.app.state.templates.TemplateResponse(
         "home.html",
         {
             "request": request,
-            "players": players,
-            "trending_players": trending_players,
+            "featured_trending": featured_trending,
+            "compact_trending": compact_trending,
             "feed_items": feed_items,
             "hero_article": hero_article_dict,
             "source_counts": source_counts,
@@ -303,10 +274,6 @@ async def home(
             "film_room_video_counts": film_room_video_counts,
             "footer_links": FOOTER_LINKS,
             "current_year": datetime.now().year,
-            "image_style": requested_style,  # Current image style for JS
-            "player_id_map": slug_to_id,  # slug -> player_id for JS image URLs
-            "id_to_slug_map": id_to_slug,  # player_id -> slug for JS image URLs
-            "s3_image_base_url": get_s3_image_base_url(),  # S3 base URL for images
         },
     )
 

--- a/app/services/combine_score_service.py
+++ b/app/services/combine_score_service.py
@@ -129,6 +129,31 @@ def grade_label(percentile: Optional[float]) -> str:
     return "Poor"
 
 
+def grade_letter(percentile: Optional[float]) -> Optional[str]:
+    """Map a percentile to a compact letter grade for UI pills (e.g. 'A-', 'B+').
+
+    Returns None when no percentile is available so the caller can hide the
+    pill rather than render a placeholder.
+    """
+    if percentile is None:
+        return None
+    if percentile >= 95:
+        return "A+"
+    if percentile >= 85:
+        return "A"
+    if percentile >= 75:
+        return "A-"
+    if percentile >= 65:
+        return "B+"
+    if percentile >= 50:
+        return "B"
+    if percentile >= 35:
+        return "B-"
+    if percentile >= 20:
+        return "C"
+    return "D"
+
+
 # ---------------------------------------------------------------------------
 # Public query functions
 # ---------------------------------------------------------------------------

--- a/app/services/expanded_trending_service.py
+++ b/app/services/expanded_trending_service.py
@@ -448,32 +448,50 @@ async def _load_combine_grades(
         cast(Any, Season.start_year).in_(sorted(draft_years_set))
     )
     season_rows = await db.execute(season_stmt)
-    season_by_year: dict[int, int] = {
+    season_id_by_year: dict[int, int] = {
         int(row["start_year"]): int(row["id"])
         for row in season_rows.mappings().all()
         if row["id"] is not None and row["start_year"] is not None
     }
-    if not season_by_year:
+    if not season_id_by_year:
         return {}
-
-    season_ids = list(set(season_by_year.values()))
 
     snap_stmt = select(MetricSnapshot.id, MetricSnapshot.season_id).where(  # type: ignore[call-overload]
         cast(Any, MetricSnapshot.source) == MetricSource.combine_score,
         cast(Any, MetricSnapshot.cohort) == CohortType.current_draft,
         cast(Any, MetricSnapshot.is_current).is_(True),
-        cast(Any, MetricSnapshot.season_id).in_(season_ids),
+        cast(Any, MetricSnapshot.season_id).in_(list(season_id_by_year.values())),
         cast(Any, MetricSnapshot.position_scope_parent).is_(None),
         cast(Any, MetricSnapshot.position_scope_fine).is_(None),
     )
     snap_rows = await db.execute(snap_stmt)
-    snapshot_ids: list[int] = []
+    snapshot_id_by_season: dict[int, int] = {}
     for row in snap_rows.mappings().all():
         sid = row["season_id"]
         if sid is None:
             continue
-        snapshot_ids.append(int(row["id"]))
-    if not snapshot_ids:
+        snapshot_id_by_season[int(sid)] = int(row["id"])
+    if not snapshot_id_by_season:
+        return {}
+
+    # Pin each player to *their* draft-year snapshot. Players without a
+    # draft_year (or whose draft_year has no current snapshot) drop out
+    # here and will not receive a grade — this is intentional. The pairing
+    # is also enforced post-query so a stale PMV row in a different season's
+    # snapshot can't leak into the wrong player's grade.
+    snapshot_for_player: dict[int, int] = {}
+    for pid, master in masters.items():
+        dy = master.get("draft_year")
+        if dy is None:
+            continue
+        season_id = season_id_by_year.get(int(dy))
+        if season_id is None:
+            continue
+        snapshot_id = snapshot_id_by_season.get(season_id)
+        if snapshot_id is None:
+            continue
+        snapshot_for_player[pid] = snapshot_id
+    if not snapshot_for_player:
         return {}
 
     defn_stmt = select(MetricDefinition.id).where(  # type: ignore[call-overload]
@@ -489,16 +507,25 @@ async def _load_combine_grades(
         PlayerMetricValue.snapshot_id,
         PlayerMetricValue.percentile,
     ).where(
-        cast(Any, PlayerMetricValue.player_id).in_(player_ids),
-        cast(Any, PlayerMetricValue.snapshot_id).in_(snapshot_ids),
+        cast(Any, PlayerMetricValue.player_id).in_(list(snapshot_for_player.keys())),
+        cast(Any, PlayerMetricValue.snapshot_id).in_(
+            list(set(snapshot_for_player.values()))
+        ),
         cast(Any, PlayerMetricValue.metric_definition_id) == overall_def_id,
     )
     pmv_rows = await db.execute(pmv_stmt)
 
     out: dict[int, str] = {}
     for row in pmv_rows.mappings().all():
-        pid = int(row["player_id"]) if row["player_id"] is not None else None
-        if pid is None:
+        raw_pid = row["player_id"]
+        raw_sid = row["snapshot_id"]
+        if raw_pid is None or raw_sid is None:
+            continue
+        pid = int(raw_pid)
+        sid = int(raw_sid)
+        # Enforce the pairing: this PMV row must come from the player's own
+        # draft-year snapshot, not just *any* snapshot in scope.
+        if snapshot_for_player.get(pid) != sid:
             continue
         pct = row["percentile"]
         letter = grade_letter(float(pct) if pct is not None else None)

--- a/app/services/expanded_trending_service.py
+++ b/app/services/expanded_trending_service.py
@@ -1,0 +1,748 @@
+"""Expanded trending-players service for the homepage.
+
+Builds on the base ``get_trending_players`` query and enriches each player
+with the supplementary signals required by the v2 trending card design:
+
+* generated S3 photo (eligibility gate + display)
+* canonical position + school
+* latest college production line (PPG required for featured eligibility)
+* combine grade letter (optional pill)
+* per-content-type mention mix (NEWS / PODCAST / VIDEO)
+* dominant ``NewsItemTag`` over the trailing window
+* up to N most-recent mention previews (title + source + relative time)
+* spike state (``hot`` / ``cooling``) derived from the daily-counts series
+
+The result is split into a featured tier (rich 2x2 cards) and a compact
+tier (smaller leaderboard rows) according to per-player eligibility.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional, cast
+
+from sqlalchemy import desc, func, literal, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.fields import CohortType, MetricSource
+from app.schemas.metrics import MetricDefinition, MetricSnapshot, PlayerMetricValue
+from app.schemas.news_items import NewsItem, NewsItemTag
+from app.schemas.news_sources import NewsSource
+from app.schemas.player_college_stats import PlayerCollegeStats
+from app.schemas.player_content_mentions import ContentType, PlayerContentMention
+from app.schemas.player_status import PlayerStatus
+from app.schemas.players_master import PlayerMaster
+from app.schemas.podcast_episodes import PodcastEpisode
+from app.schemas.podcast_shows import PodcastShow
+from app.schemas.positions import Position
+from app.schemas.seasons import Season
+from app.schemas.youtube_channels import YouTubeChannel
+from app.schemas.youtube_videos import YouTubeVideo
+from app.services.combine_score_service import grade_letter
+from app.services.image_assets_service import get_current_image_urls_for_players
+from app.services.news_service import get_trending_players
+
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+FEATURED_TARGET = 4
+"""Maximum number of featured cards to render (the 2x2 grid on wide screens)."""
+
+FEATURED_FLOOR = 2
+"""If fewer than this number qualify, hide the featured row entirely."""
+
+TRENDING_TOTAL_LIMIT = 10
+"""Total players surfaced across both tiers."""
+
+MIN_FEATURED_MENTIONS = 5
+"""A featured card needs at least this many mentions in the window."""
+
+TRENDING_WINDOW_DAYS = 7
+
+RECENT_MENTIONS_PER_PLAYER = 2
+
+HOT_RATIO = 1.5
+"""(last 2-day mention rate) / (prior 5-day rate) at or above this -> 'hot'."""
+
+COOLING_RATIO = 0.5
+"""... at or below this -> 'cooling'."""
+
+
+# ---------------------------------------------------------------------------
+# Public response shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class TrendingMentionPreview:
+    """One recent content mention surfaced beneath a featured card."""
+
+    title: str
+    url: str
+    source_name: str
+    content_type: str  # "news" | "podcast" | "video"
+    published_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class TrendingStatLine:
+    """Latest college production line for the featured stat strip."""
+
+    season: str
+    ppg: Optional[float]
+    rpg: Optional[float]
+    apg: Optional[float]
+    spg: Optional[float]
+    bpg: Optional[float]
+    fg_pct: Optional[float]
+    three_p_pct: Optional[float]
+    ft_pct: Optional[float]
+
+
+@dataclass(frozen=True, slots=True)
+class FeaturedTrendingPlayer:
+    """A trending player rendered as a rich featured card."""
+
+    player_id: int
+    rank: int
+    display_name: str
+    slug: str
+    photo_url: str
+    school: str
+    position: str
+    draft_year: Optional[int]
+    mention_count: int
+    daily_counts: list[int]
+    spike_state: Optional[str]  # "hot" | "cooling" | None
+    content_mix: dict[str, int]  # {"news": N, "podcast": N, "video": N}
+    dominant_news_tag: Optional[str]
+    combine_grade: Optional[str]
+    latest_stats: TrendingStatLine
+    recent_mentions: list[TrendingMentionPreview]
+    latest_mention_at: Optional[datetime]
+
+
+@dataclass(frozen=True, slots=True)
+class CompactTrendingPlayer:
+    """A trending player rendered as a smaller leaderboard row."""
+
+    player_id: int
+    rank: int
+    display_name: str
+    slug: str
+    photo_url: Optional[str]
+    school: Optional[str]
+    position: Optional[str]
+    draft_year: Optional[int]
+    mention_count: int
+    daily_counts: list[int]
+    dominant_news_tag: Optional[str]
+
+
+@dataclass(frozen=True, slots=True)
+class ExpandedTrendingPlayers:
+    """Two-tier homepage trending payload."""
+
+    featured: list[FeaturedTrendingPlayer] = field(default_factory=list)
+    compact: list[CompactTrendingPlayer] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.featured and not self.compact
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def get_expanded_trending_players(
+    db: AsyncSession,
+    *,
+    days: int = TRENDING_WINDOW_DAYS,
+    limit: int = TRENDING_TOTAL_LIMIT,
+    image_style: str = "default",
+) -> ExpandedTrendingPlayers:
+    """Return a featured + compact split of the most-trending players.
+
+    Walks the base trending list in mention-rank order, takes the first
+    ``FEATURED_TARGET`` fully-populated players as featured, and assigns the
+    rest to the compact tail. If fewer than ``FEATURED_FLOOR`` players qualify
+    for the featured row it is hidden entirely and all 10 render as compact.
+    """
+    base = await get_trending_players(db, days=days, limit=limit)
+    if not base:
+        return ExpandedTrendingPlayers()
+
+    player_ids = [tp.player_id for tp in base]
+
+    # Batched supplementary lookups. AsyncSession does not support concurrent
+    # queries on the same session, so these run sequentially.
+    photos = await get_current_image_urls_for_players(
+        db, player_ids=player_ids, style=image_style
+    )
+    statuses = await _load_player_statuses(db, player_ids)
+    masters = await _load_player_masters(db, player_ids)
+    college_stats = await _load_latest_college_stats(db, player_ids)
+    combine_grades = await _load_combine_grades(db, player_ids, masters)
+    content_mix = await _load_content_type_breakdown(db, player_ids, days)
+    dominant_tags = await _load_dominant_news_tags(db, player_ids, days)
+    recent_mentions = await _load_recent_mentions(
+        db, player_ids, days, limit_per_player=RECENT_MENTIONS_PER_PLAYER
+    )
+
+    classifications: list[tuple[int, Any, bool]] = []
+    for rank_idx, tp in enumerate(base, start=1):
+        master = masters.get(tp.player_id, {})
+        status = statuses.get(tp.player_id, {})
+        latest = college_stats.get(tp.player_id)
+        photo = photos.get(tp.player_id)
+
+        is_eligible = (
+            not master.get("is_stub", True)
+            and photo is not None
+            and status.get("position") is not None
+            and master.get("school") is not None
+            and latest is not None
+            and latest.ppg is not None
+            and tp.mention_count >= MIN_FEATURED_MENTIONS
+        )
+        classifications.append((rank_idx, tp, is_eligible))
+
+    featured_pairs: list[tuple[int, Any]] = []
+    compact_pairs: list[tuple[int, Any]] = []
+    for rank_idx, tp, eligible in classifications:
+        if eligible and len(featured_pairs) < FEATURED_TARGET:
+            featured_pairs.append((rank_idx, tp))
+        else:
+            compact_pairs.append((rank_idx, tp))
+
+    if len(featured_pairs) < FEATURED_FLOOR:
+        featured_pairs = []
+        compact_pairs = [(rank_idx, tp) for rank_idx, tp, _ in classifications]
+
+    featured: list[FeaturedTrendingPlayer] = []
+    for rank_idx, tp in featured_pairs:
+        master = masters[tp.player_id]
+        status = statuses[tp.player_id]
+        latest = college_stats[tp.player_id]
+        featured.append(
+            FeaturedTrendingPlayer(
+                player_id=tp.player_id,
+                rank=rank_idx,
+                display_name=tp.display_name,
+                slug=tp.slug,
+                photo_url=photos[tp.player_id],
+                school=master["school"],
+                position=status["position"],
+                draft_year=master.get("draft_year"),
+                mention_count=tp.mention_count,
+                daily_counts=list(tp.daily_counts),
+                spike_state=_compute_spike_state(tp.daily_counts),
+                content_mix=content_mix.get(
+                    tp.player_id, {"news": 0, "podcast": 0, "video": 0}
+                ),
+                dominant_news_tag=dominant_tags.get(tp.player_id),
+                combine_grade=combine_grades.get(tp.player_id),
+                latest_stats=latest,
+                recent_mentions=recent_mentions.get(tp.player_id, []),
+                latest_mention_at=tp.latest_mention_at,
+            )
+        )
+
+    compact: list[CompactTrendingPlayer] = []
+    for rank_idx, tp in compact_pairs:
+        master = masters.get(tp.player_id, {})
+        status = statuses.get(tp.player_id, {})
+        compact.append(
+            CompactTrendingPlayer(
+                player_id=tp.player_id,
+                rank=rank_idx,
+                display_name=tp.display_name,
+                slug=tp.slug,
+                photo_url=photos.get(tp.player_id),
+                school=master.get("school") or tp.school,
+                position=status.get("position"),
+                draft_year=master.get("draft_year"),
+                mention_count=tp.mention_count,
+                daily_counts=list(tp.daily_counts),
+                dominant_news_tag=dominant_tags.get(tp.player_id),
+            )
+        )
+
+    return ExpandedTrendingPlayers(featured=featured, compact=compact)
+
+
+# ---------------------------------------------------------------------------
+# Spike detection
+# ---------------------------------------------------------------------------
+
+
+def _compute_spike_state(daily_counts: list[int]) -> Optional[str]:
+    """Classify the trailing daily-counts series as 'hot', 'cooling', or None.
+
+    Compares the last 2-day mention rate against the prior 5-day rate. The
+    series is oldest-first with one entry per day in the trending window.
+    """
+    if not daily_counts or len(daily_counts) < 7:
+        return None
+
+    last_2 = daily_counts[-2:]
+    prior_5 = daily_counts[-7:-2]
+    last_2_rate = sum(last_2) / 2.0
+    prior_5_rate = sum(prior_5) / 5.0
+
+    if prior_5_rate == 0:
+        # Pure new-arrival case: only flag as hot if the trailing burst is real.
+        return "hot" if sum(last_2) >= 3 else None
+
+    ratio = last_2_rate / prior_5_rate
+    if ratio >= HOT_RATIO:
+        return "hot"
+    if ratio <= COOLING_RATIO:
+        return "cooling"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Batched lookups
+# ---------------------------------------------------------------------------
+
+
+async def _load_player_masters(
+    db: AsyncSession, player_ids: list[int]
+) -> dict[int, dict[str, Any]]:
+    if not player_ids:
+        return {}
+    stmt = select(  # type: ignore[call-overload]
+        PlayerMaster.id,
+        PlayerMaster.is_stub,
+        PlayerMaster.school,
+        PlayerMaster.draft_year,
+    ).where(cast(Any, PlayerMaster.id).in_(player_ids))
+    result = await db.execute(stmt)
+    return {
+        int(row["id"]): {
+            "is_stub": bool(row["is_stub"]),
+            "school": row["school"],
+            "draft_year": row["draft_year"],
+        }
+        for row in result.mappings().all()
+        if row["id"] is not None
+    }
+
+
+async def _load_player_statuses(
+    db: AsyncSession, player_ids: list[int]
+) -> dict[int, dict[str, Any]]:
+    """Return position label, height, weight per player (best-effort)."""
+    if not player_ids:
+        return {}
+    stmt = (
+        select(  # type: ignore[call-overload]
+            PlayerStatus.player_id,
+            PlayerStatus.raw_position,
+            PlayerStatus.height_in,
+            PlayerStatus.weight_lb,
+            cast(Any, Position.code).label("position_code"),
+        )
+        .select_from(PlayerStatus)
+        .outerjoin(Position, cast(Any, Position.id) == PlayerStatus.position_id)
+        .where(cast(Any, PlayerStatus.player_id).in_(player_ids))
+    )
+    result = await db.execute(stmt)
+    out: dict[int, dict[str, Any]] = {}
+    for row in result.mappings().all():
+        pid = int(row["player_id"]) if row["player_id"] is not None else None
+        if pid is None:
+            continue
+        position = row["position_code"] or row["raw_position"]
+        out[pid] = {
+            "position": position,
+            "height_in": row["height_in"],
+            "weight_lb": row["weight_lb"],
+        }
+    return out
+
+
+async def _load_latest_college_stats(
+    db: AsyncSession, player_ids: list[int]
+) -> dict[int, TrendingStatLine]:
+    """Return latest college season stat row per player (by season desc)."""
+    if not player_ids:
+        return {}
+
+    rn_col = (
+        func.row_number()
+        .over(
+            partition_by=cast(Any, PlayerCollegeStats.player_id),
+            order_by=desc(cast(Any, PlayerCollegeStats.season)),
+        )
+        .label("rn")
+    )
+    inner = (
+        select(  # type: ignore[call-overload, misc]
+            PlayerCollegeStats.player_id,
+            PlayerCollegeStats.season,
+            PlayerCollegeStats.ppg,
+            PlayerCollegeStats.rpg,
+            PlayerCollegeStats.apg,
+            PlayerCollegeStats.spg,
+            PlayerCollegeStats.bpg,
+            PlayerCollegeStats.fg_pct,
+            PlayerCollegeStats.three_p_pct,
+            PlayerCollegeStats.ft_pct,
+            rn_col,
+        )
+        .where(cast(Any, PlayerCollegeStats.player_id).in_(player_ids))
+        .subquery()
+    )
+    stmt = select(inner).where(inner.c.rn == 1)
+    result = await db.execute(stmt)
+    out: dict[int, TrendingStatLine] = {}
+    for row in result.mappings().all():
+        pid = int(row["player_id"]) if row["player_id"] is not None else None
+        if pid is None:
+            continue
+        out[pid] = TrendingStatLine(
+            season=str(row["season"]),
+            ppg=row["ppg"],
+            rpg=row["rpg"],
+            apg=row["apg"],
+            spg=row["spg"],
+            bpg=row["bpg"],
+            fg_pct=row["fg_pct"],
+            three_p_pct=row["three_p_pct"],
+            ft_pct=row["ft_pct"],
+        )
+    return out
+
+
+async def _load_combine_grades(
+    db: AsyncSession,
+    player_ids: list[int],
+    masters: dict[int, dict[str, Any]],
+) -> dict[int, str]:
+    """Return letter grades for each player who has a current combine snapshot.
+
+    Pulls the player's overall combine-score percentile from the snapshot
+    matching their draft year (mapped via ``Season.start_year``) and converts
+    it to a compact letter via ``grade_letter``. Players without a draft year
+    or matching snapshot simply omit the pill on the card.
+    """
+    if not player_ids:
+        return {}
+
+    draft_years_set: set[int] = set()
+    for m in masters.values():
+        dy = m.get("draft_year")
+        if dy is not None:
+            draft_years_set.add(int(dy))
+    if not draft_years_set:
+        return {}
+
+    season_stmt = select(Season.id, Season.start_year).where(  # type: ignore[call-overload]
+        cast(Any, Season.start_year).in_(sorted(draft_years_set))
+    )
+    season_rows = await db.execute(season_stmt)
+    season_by_year: dict[int, int] = {
+        int(row["start_year"]): int(row["id"])
+        for row in season_rows.mappings().all()
+        if row["id"] is not None and row["start_year"] is not None
+    }
+    if not season_by_year:
+        return {}
+
+    season_ids = list(set(season_by_year.values()))
+
+    snap_stmt = select(MetricSnapshot.id, MetricSnapshot.season_id).where(  # type: ignore[call-overload]
+        cast(Any, MetricSnapshot.source) == MetricSource.combine_score,
+        cast(Any, MetricSnapshot.cohort) == CohortType.current_draft,
+        cast(Any, MetricSnapshot.is_current).is_(True),
+        cast(Any, MetricSnapshot.season_id).in_(season_ids),
+        cast(Any, MetricSnapshot.position_scope_parent).is_(None),
+        cast(Any, MetricSnapshot.position_scope_fine).is_(None),
+    )
+    snap_rows = await db.execute(snap_stmt)
+    snapshot_ids: list[int] = []
+    for row in snap_rows.mappings().all():
+        sid = row["season_id"]
+        if sid is None:
+            continue
+        snapshot_ids.append(int(row["id"]))
+    if not snapshot_ids:
+        return {}
+
+    defn_stmt = select(MetricDefinition.id).where(  # type: ignore[call-overload]
+        cast(Any, MetricDefinition.metric_key) == "combine_score_overall"
+    )
+    defn_result = await db.execute(defn_stmt)
+    overall_def_id = defn_result.scalar_one_or_none()
+    if overall_def_id is None:
+        return {}
+
+    pmv_stmt = select(  # type: ignore[call-overload]
+        PlayerMetricValue.player_id,
+        PlayerMetricValue.snapshot_id,
+        PlayerMetricValue.percentile,
+    ).where(
+        cast(Any, PlayerMetricValue.player_id).in_(player_ids),
+        cast(Any, PlayerMetricValue.snapshot_id).in_(snapshot_ids),
+        cast(Any, PlayerMetricValue.metric_definition_id) == overall_def_id,
+    )
+    pmv_rows = await db.execute(pmv_stmt)
+
+    out: dict[int, str] = {}
+    for row in pmv_rows.mappings().all():
+        pid = int(row["player_id"]) if row["player_id"] is not None else None
+        if pid is None:
+            continue
+        pct = row["percentile"]
+        letter = grade_letter(float(pct) if pct is not None else None)
+        if letter is not None:
+            out[pid] = letter
+    return out
+
+
+async def _load_content_type_breakdown(
+    db: AsyncSession, player_ids: list[int], days: int
+) -> dict[int, dict[str, int]]:
+    """Return per-player counts of mentions by content type within the window."""
+    if not player_ids:
+        return {}
+    cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
+    stmt = (
+        select(  # type: ignore[call-overload]
+            PlayerContentMention.player_id,
+            PlayerContentMention.content_type,
+            func.count().label("c"),
+        )
+        .where(cast(Any, PlayerContentMention.player_id).in_(player_ids))
+        .where(cast(Any, PlayerContentMention.published_at) >= cutoff)
+        .group_by(PlayerContentMention.player_id, PlayerContentMention.content_type)
+    )
+    result = await db.execute(stmt)
+    out: dict[int, dict[str, int]] = {}
+    for row in result.mappings().all():
+        pid = int(row["player_id"]) if row["player_id"] is not None else None
+        if pid is None:
+            continue
+        bucket = out.setdefault(pid, {"news": 0, "podcast": 0, "video": 0})
+        ctype = row["content_type"]
+        if ctype == ContentType.NEWS:
+            bucket["news"] = int(row["c"])
+        elif ctype == ContentType.PODCAST:
+            bucket["podcast"] = int(row["c"])
+        elif ctype == ContentType.VIDEO:
+            bucket["video"] = int(row["c"])
+    return out
+
+
+async def _load_dominant_news_tags(
+    db: AsyncSession, player_ids: list[int], days: int
+) -> dict[int, str]:
+    """Return the most-frequent NewsItem.tag per player within the window.
+
+    News-only by design; podcast and video tags are intentionally excluded
+    since they live in different enums.
+    """
+    if not player_ids:
+        return {}
+    cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
+    stmt = (
+        select(  # type: ignore[call-overload]
+            PlayerContentMention.player_id,
+            NewsItem.tag,
+            func.count().label("c"),
+        )
+        .join(NewsItem, cast(Any, NewsItem.id) == PlayerContentMention.content_id)
+        .where(cast(Any, PlayerContentMention.player_id).in_(player_ids))
+        .where(cast(Any, PlayerContentMention.content_type) == ContentType.NEWS)
+        .where(cast(Any, PlayerContentMention.published_at) >= cutoff)
+        .group_by(PlayerContentMention.player_id, NewsItem.tag)
+    )
+    result = await db.execute(stmt)
+    counts_by_player: dict[int, dict[str, int]] = {}
+    for row in result.mappings().all():
+        pid = int(row["player_id"]) if row["player_id"] is not None else None
+        if pid is None:
+            continue
+        tag_value = _resolve_news_tag_value(row["tag"])
+        bucket = counts_by_player.setdefault(pid, {})
+        bucket[tag_value] = bucket.get(tag_value, 0) + int(row["c"])
+    out: dict[int, str] = {}
+    for pid, tag_counts in counts_by_player.items():
+        if not tag_counts:
+            continue
+        # Highest count wins; tie-break alphabetically for determinism.
+        best = max(tag_counts.items(), key=lambda kv: (kv[1], kv[0]))
+        out[pid] = best[0]
+    return out
+
+
+def _resolve_news_tag_value(raw: Any) -> str:
+    """Normalize a NewsItemTag (enum or stringly-typed) to its display value."""
+    if isinstance(raw, NewsItemTag):
+        return raw.value
+    if isinstance(raw, str):
+        try:
+            return NewsItemTag(raw).value
+        except ValueError:
+            try:
+                return NewsItemTag[raw].value
+            except KeyError:
+                return raw
+    return str(raw)
+
+
+async def _load_recent_mentions(
+    db: AsyncSession,
+    player_ids: list[int],
+    days: int,
+    *,
+    limit_per_player: int = RECENT_MENTIONS_PER_PLAYER,
+) -> dict[int, list[TrendingMentionPreview]]:
+    """Return the top-N most-recent mention previews per player.
+
+    Three separate top-N-per-player queries (news / podcast / video) are
+    unioned and re-trimmed to ``limit_per_player`` per player in Python. This
+    avoids a single mega-join across three polymorphic content tables.
+    """
+    if not player_ids:
+        return {}
+    cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
+
+    candidates_by_player: dict[int, list[TrendingMentionPreview]] = {}
+
+    def _accept(pid: int, preview: TrendingMentionPreview) -> None:
+        candidates_by_player.setdefault(pid, []).append(preview)
+
+    rn_partition = cast(Any, PlayerContentMention.player_id)
+    rn_order = desc(cast(Any, PlayerContentMention.published_at))
+
+    # --- News ---
+    rn_news = (
+        func.row_number().over(partition_by=rn_partition, order_by=rn_order).label("rn")
+    )
+    news_inner = (
+        select(
+            cast(Any, PlayerContentMention.player_id).label("player_id"),
+            cast(Any, NewsItem.title).label("title"),
+            cast(Any, NewsItem.url).label("url"),
+            cast(Any, NewsSource.display_name).label("source_name"),
+            cast(Any, PlayerContentMention.published_at).label("published_at"),
+            literal("news").label("content_type"),
+            rn_news,
+        )
+        .join(NewsItem, cast(Any, NewsItem.id) == PlayerContentMention.content_id)
+        .join(NewsSource, cast(Any, NewsSource.id) == NewsItem.source_id)
+        .where(cast(Any, PlayerContentMention.player_id).in_(player_ids))
+        .where(cast(Any, PlayerContentMention.content_type) == ContentType.NEWS)
+        .where(cast(Any, PlayerContentMention.published_at) >= cutoff)
+        .subquery()
+    )
+    news_stmt = select(news_inner).where(news_inner.c.rn <= limit_per_player)
+    news_rows = await db.execute(news_stmt)
+    for row in news_rows.mappings().all():
+        _accept(
+            int(row["player_id"]),
+            TrendingMentionPreview(
+                title=str(row["title"] or ""),
+                url=str(row["url"] or ""),
+                source_name=str(row["source_name"] or ""),
+                content_type="news",
+                published_at=row["published_at"],
+            ),
+        )
+
+    # --- Podcasts ---
+    rn_pod = (
+        func.row_number().over(partition_by=rn_partition, order_by=rn_order).label("rn")
+    )
+    pod_inner = (
+        select(
+            cast(Any, PlayerContentMention.player_id).label("player_id"),
+            cast(Any, PodcastEpisode.title).label("title"),
+            func.coalesce(
+                cast(Any, PodcastEpisode.episode_url),
+                cast(Any, PodcastEpisode.audio_url),
+            ).label("url"),
+            cast(Any, PodcastShow.display_name).label("source_name"),
+            cast(Any, PlayerContentMention.published_at).label("published_at"),
+            literal("podcast").label("content_type"),
+            rn_pod,
+        )
+        .join(
+            PodcastEpisode,
+            cast(Any, PodcastEpisode.id) == PlayerContentMention.content_id,
+        )
+        .join(PodcastShow, cast(Any, PodcastShow.id) == PodcastEpisode.show_id)
+        .where(cast(Any, PlayerContentMention.player_id).in_(player_ids))
+        .where(cast(Any, PlayerContentMention.content_type) == ContentType.PODCAST)
+        .where(cast(Any, PlayerContentMention.published_at) >= cutoff)
+        .subquery()
+    )
+    pod_stmt = select(pod_inner).where(pod_inner.c.rn <= limit_per_player)
+    pod_rows = await db.execute(pod_stmt)
+    for row in pod_rows.mappings().all():
+        _accept(
+            int(row["player_id"]),
+            TrendingMentionPreview(
+                title=str(row["title"] or ""),
+                url=str(row["url"] or ""),
+                source_name=str(row["source_name"] or ""),
+                content_type="podcast",
+                published_at=row["published_at"],
+            ),
+        )
+
+    # --- Videos ---
+    rn_vid = (
+        func.row_number().over(partition_by=rn_partition, order_by=rn_order).label("rn")
+    )
+    vid_inner = (
+        select(
+            cast(Any, PlayerContentMention.player_id).label("player_id"),
+            cast(Any, YouTubeVideo.title).label("title"),
+            cast(Any, YouTubeVideo.youtube_url).label("url"),
+            cast(Any, YouTubeChannel.display_name).label("source_name"),
+            cast(Any, PlayerContentMention.published_at).label("published_at"),
+            literal("video").label("content_type"),
+            rn_vid,
+        )
+        .join(
+            YouTubeVideo,
+            cast(Any, YouTubeVideo.id) == PlayerContentMention.content_id,
+        )
+        .join(
+            YouTubeChannel,
+            cast(Any, YouTubeChannel.id) == YouTubeVideo.channel_id,
+        )
+        .where(cast(Any, PlayerContentMention.player_id).in_(player_ids))
+        .where(cast(Any, PlayerContentMention.content_type) == ContentType.VIDEO)
+        .where(cast(Any, PlayerContentMention.published_at) >= cutoff)
+        .subquery()
+    )
+    vid_stmt = select(vid_inner).where(vid_inner.c.rn <= limit_per_player)
+    vid_rows = await db.execute(vid_stmt)
+    for row in vid_rows.mappings().all():
+        _accept(
+            int(row["player_id"]),
+            TrendingMentionPreview(
+                title=str(row["title"] or ""),
+                url=str(row["url"] or ""),
+                source_name=str(row["source_name"] or ""),
+                content_type="video",
+                published_at=row["published_at"],
+            ),
+        )
+
+    # Trim each player's pool to the most-recent ``limit_per_player`` after merging.
+    result: dict[int, list[TrendingMentionPreview]] = {}
+    for pid, previews in candidates_by_player.items():
+        previews.sort(key=lambda p: p.published_at, reverse=True)
+        result[pid] = previews[:limit_per_player]
+    return result

--- a/app/static/css/home.css
+++ b/app/static/css/home.css
@@ -45,238 +45,425 @@ tbody td {
 }
 
 /* ============================================================================
-   PROSPECT CARDS
-   Grid of player prospect cards with hover effects
-   ========================================================================= */
-.prospects-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1rem;
-}
-
-.prospect-card {
-  position: relative;
-  border-radius: 1rem;
-  overflow: hidden;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  outline: 2px solid rgba(99, 102, 241, 0.6);
-  transition: transform var(--transition-speed);
-}
-
-.prospect-card:hover {
-  transform: translateY(-2px);
-}
-
-.prospect-image-wrapper {
-  position: relative;
-  overflow: hidden;
-  aspect-ratio: 3 / 4;
-}
-
-.prospect-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: 50% 25%;
-  transition: filter var(--transition-speed);
-}
-
-.prospect-card:hover .prospect-image {
-  filter: brightness(1.05);
-}
-
-/* Badge for riser/faller status */
-.prospect-badge {
-  position: absolute;
-  top: 0.75rem;
-  right: 0.75rem;
-  font-size: 0.625rem;
-  font-weight: 600;
-  padding: 0.25rem 0.5rem;
-  border-radius: 9999px;
-}
-
-.prospect-badge.riser {
-  background: #d1fae5;
-  color: #065f46;
-}
-
-.prospect-badge.faller {
-  background: #ffe4e6;
-  color: #9f1239;
-}
-
-/* Pixel corner accents on hover */
-.prospect-card::before,
-.prospect-card::after {
-  content: "";
-  position: absolute;
-  width: 1rem;
-  height: 1rem;
-  opacity: 0;
-  transition: opacity var(--transition-speed);
-  z-index: 10;
-}
-
-.prospect-card::before {
-  top: -0.25rem;
-  left: -0.25rem;
-  background: linear-gradient(45deg, transparent 50%, var(--color-accent-indigo) 50%);
-}
-
-.prospect-card::after {
-  bottom: -0.25rem;
-  right: -0.25rem;
-  background: linear-gradient(225deg, transparent 50%, var(--color-accent-emerald) 50%);
-}
-
-.prospect-card:hover::before,
-.prospect-card:hover::after {
-  opacity: 1;
-}
-
-.prospect-info {
-  padding: 0.75rem;
-}
-
-.prospect-name {
-  font-weight: 600;
-  line-height: 1.25;
-  margin-bottom: 0.25rem;
-}
-
-.prospect-meta {
-  font-size: 0.75rem;
-  color: var(--color-slate-500);
-  margin-bottom: 0.5rem;
-}
-
-/* Stats grid for each prospect */
-.prospect-stats {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.5rem;
-  font-size: 0.6875rem;
-}
-
-.stat-pill {
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.25rem;
-  border: 1px solid var(--color-slate-200);
-  background: var(--color-slate-50);
-  color: var(--color-slate-700);
-  text-align: center;
-}
-
-.stat-pill .label {
-  font-size: 0.625rem;
-  color: var(--color-slate-500);
-  margin-right: 0.25rem;
-}
-
-.stat-pill .value {
-  font-weight: 500;
-  font-family: var(--font-mono);
-  font-variant-numeric: tabular-nums;
-}
-
-/* ============================================================================
-   TRENDING PLAYERS
-   Grid of trending player cards with thumbnails and sparklines
+   TRENDING PLAYERS V2 — featured cards + compact tail
+   See mockups/draftguru_trending_v2.html for the source-of-truth design.
    ========================================================================= */
 .trending-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
-.trending-card {
-  display: flex;
-  align-items: center;
-  gap: 0.625rem;
-  padding: 0.625rem 0.75rem;
-  border-radius: 0.5rem;
+.trending-grid--featured {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.trending-grid--compact {
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.tcard {
+  position: relative;
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
   border: 1px solid var(--color-slate-200);
   background: var(--color-white);
   text-decoration: none;
   color: inherit;
-  transition: transform var(--transition-speed), box-shadow var(--transition-speed);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+  transition: transform var(--transition-speed), box-shadow var(--transition-speed),
+    border-color var(--transition-speed);
+  overflow: hidden;
 }
 
-.trending-card:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+.tcard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.07);
   border-color: var(--color-accent-emerald);
 }
 
-/* Thumbnail */
-.trending-card__thumb {
-  flex-shrink: 0;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  object-fit: cover;
-  object-position: 50% 20%;
-  border: 1px solid var(--color-slate-200);
+.tcard__rank {
+  position: absolute;
+  top: 0.625rem;
+  right: 0.75rem;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+  color: var(--color-slate-600);
   background: var(--color-slate-100);
+  border: 1px solid var(--color-slate-200);
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
 }
 
-.trending-card__thumb--placeholder {
+.tcard__spike {
+  position: absolute;
+  top: 0.625rem;
+  left: 0.75rem;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.tcard__spike--hot {
+  color: #9f1239;
+  background: #ffe4e6;
+  border: 1px solid #fecdd3;
+}
+.tcard__spike--cooling {
+  color: var(--color-slate-600);
+  background: var(--color-slate-100);
+  border: 1px solid var(--color-slate-200);
+}
+
+.tcard__left {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tcard__photo {
+  width: 96px;
+  height: 96px;
+  border-radius: 0.5rem;
+  object-fit: cover;
+  object-position: 50% 20%;
+  background: var(--color-slate-100);
+  border: 1px solid var(--color-slate-200);
+}
+
+.tcard__photo--placeholder {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.875rem;
-  font-weight: 700;
-  color: var(--color-slate-500);
+  font-family: var(--font-heading);
+  font-size: 2rem;
+  color: var(--color-slate-400);
 }
 
-.trending-card__info {
+.tcard__combine {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.125rem 0.4rem;
+  border-radius: 0.25rem;
+  color: var(--color-slate-600);
+  background: var(--color-slate-100);
+  border: 1px solid var(--color-slate-200);
+  text-align: center;
+}
+.tcard__combine strong {
+  font-weight: 700;
+  color: var(--color-accent-emerald);
+}
+
+.tcard__body {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
   min-width: 0;
-  flex: 1;
+  padding-right: 3rem;
 }
 
-.trending-card__name {
-  font-weight: 600;
-  font-size: 0.8125rem;
+.tcard__name {
+  font-family: var(--font-heading);
+  font-size: 1.125rem;
+  letter-spacing: 0.01em;
+  line-height: 1.15;
+  color: var(--color-slate-900);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.trending-card__school {
+.tcard__meta {
+  font-family: var(--font-mono);
   font-size: 0.6875rem;
   color: var(--color-slate-500);
+  letter-spacing: 0.04em;
+  margin-top: 0.125rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-/* Visual wrapper: sparkline + count badge */
-.trending-card__visual {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex-shrink: 0;
+.tcard__meta .dot {
+  display: inline-block;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--color-slate-300);
+  vertical-align: middle;
+  margin: 0 0.4rem;
 }
 
-.trending-card__sparkline {
-  width: 64px;
-  height: 24px;
+.tcard__stats {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.625rem;
+  flex-wrap: wrap;
+}
+
+.tcard__stat {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  letter-spacing: 0.03em;
+  padding: 0.2rem 0.45rem;
+  border-radius: 0.25rem;
+  background: var(--color-slate-50);
+  border: 1px solid var(--color-slate-200);
+  color: var(--color-slate-700);
+  white-space: nowrap;
+}
+.tcard__stat .label {
+  color: var(--color-slate-500);
+  margin-right: 0.3rem;
+  font-size: 0.625rem;
+}
+.tcard__stat .value {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.tcard__buzz {
+  margin-top: 0.875rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.625rem 0.875rem;
+  align-items: center;
+}
+
+.tcard__buzzCount {
+  display: flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  font-family: var(--font-mono);
+}
+.tcard__buzzCount .num {
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--color-accent-emerald);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.tcard__buzzCount .lbl {
+  font-size: 0.625rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-slate-500);
+}
+
+.tcard__sparkline {
+  width: 100%;
+  max-width: 160px;
+  height: 28px;
   display: block;
 }
 
-.trending-card__count {
-  flex-shrink: 0;
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: var(--color-accent-emerald);
-  background: #d1fae5;
-  padding: 0.125rem 0.5rem;
+.tcard__mix {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tcard__mixBar {
+  flex: 1;
+  display: flex;
+  height: 6px;
   border-radius: 9999px;
+  overflow: hidden;
+  background: var(--color-slate-100);
+  border: 1px solid var(--color-slate-200);
+}
+.tcard__mixBar > span {
+  display: block;
+  height: 100%;
+}
+.tcard__mixBar .seg-news {
+  background: var(--color-accent-cyan);
+}
+.tcard__mixBar .seg-pod {
+  background: var(--color-accent-fuchsia);
+}
+.tcard__mixBar .seg-vid {
+  background: var(--color-accent-amber);
+}
+
+.tcard__mixLegend {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.04em;
+  color: var(--color-slate-500);
+  display: flex;
+  gap: 0.625rem;
+  white-space: nowrap;
+}
+.tcard__mixLegend .lg {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.tcard__mixLegend .sw {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  display: inline-block;
+}
+.tcard__mixLegend .sw--news {
+  background: var(--color-accent-cyan);
+}
+.tcard__mixLegend .sw--pod {
+  background: var(--color-accent-fuchsia);
+}
+.tcard__mixLegend .sw--vid {
+  background: var(--color-accent-amber);
+}
+
+.tcard__tagRow {
+  margin-top: 0.625rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tcard__tag {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.5rem;
+  border-radius: 9999px;
+  color: var(--color-slate-700);
+  background: var(--color-slate-100);
+  border: 1px solid var(--color-slate-200);
+}
+.tcard__tag--mock {
+  color: #1d4ed8;
+  background: #dbeafe;
+  border-color: #bfdbfe;
+}
+.tcard__tag--bigboard {
+  color: #6d28d9;
+  background: #ede9fe;
+  border-color: #ddd6fe;
+}
+.tcard__tag--film {
+  color: #b45309;
+  background: #fef3c7;
+  border-color: #fde68a;
+}
+.tcard__tag--scout {
+  color: #047857;
+  background: #d1fae5;
+  border-color: #a7f3d0;
+}
+.tcard__tag--intel {
+  color: #be185d;
+  background: #fce7f3;
+  border-color: #fbcfe8;
+}
+
+.tcard__lastSeen {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.04em;
+  color: var(--color-slate-500);
+}
+
+.tcard__mentions {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px dashed var(--color-slate-200);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.tmention {
+  display: grid;
+  grid-template-columns: 1.25rem 1fr auto;
+  gap: 0.5rem;
+  align-items: baseline;
+  font-size: 0.8125rem;
+  line-height: 1.3;
+}
+
+.tmention__icon {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-align: center;
+  padding-top: 0.125rem;
+  color: var(--color-slate-400);
+}
+.tmention__icon--news {
+  color: var(--color-accent-cyan);
+}
+.tmention__icon--pod {
+  color: var(--color-accent-fuchsia);
+}
+.tmention__icon--vid {
+  color: var(--color-accent-amber);
+}
+
+.tmention__title {
+  color: var(--color-slate-700);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tmention__title b {
+  color: var(--color-slate-900);
+  font-weight: 600;
+}
+
+.tmention__when {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.04em;
+  color: var(--color-slate-400);
+  white-space: nowrap;
+}
+
+/* Compact tier — smaller card, no stat strip / mention list */
+.tcard--compact {
+  grid-template-columns: 64px 1fr;
+  padding: 0.75rem;
+}
+.tcard--compact .tcard__photo {
+  width: 64px;
+  height: 64px;
+}
+.tcard--compact .tcard__name {
+  font-size: 0.9375rem;
+}
+.tcard--compact .tcard__body {
+  padding-right: 2.5rem;
+}
+.tcard--compact .tcard__buzz {
+  margin-top: 0.5rem;
+}
+.tcard--compact .tcard__sparkline {
+  max-width: 100px;
+  height: 22px;
+}
+.tcard--compact .tcard__buzzCount .num {
+  font-size: 1.125rem;
 }
 
 /* ============================================================================
@@ -450,19 +637,18 @@ tbody td {
    RESPONSIVE DESIGN - HOMEPAGE
    Mobile-first breakpoints for homepage components
    ========================================================================= */
-@media (max-width: 1024px) {
-  .trending-grid {
-    grid-template-columns: repeat(2, 1fr);
+@media (max-width: 860px) {
+  .trending-grid--featured {
+    grid-template-columns: 1fr;
+  }
+  .trending-grid--compact {
+    grid-template-columns: 1fr 1fr;
   }
 }
 
-@media (max-width: 768px) {
-  .trending-grid {
+@media (max-width: 540px) {
+  .trending-grid--compact {
     grid-template-columns: 1fr;
-  }
-
-  .prospects-grid {
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   }
 
   .vs-selectors {

--- a/app/static/js/home.js
+++ b/app/static/js/home.js
@@ -5,147 +5,6 @@
  * ============================================================================
  */
 
-/**
- * ============================================================================
- * IMAGE UTILS
- * Utility functions for generating player image URLs with style support
- * Uses S3 URLs with format: {base}/players/{id}_{slug}_{style}.png
- * ============================================================================
- */
-const ImageUtils = {
-  /**
-   * Generate player photo URL based on player ID, slug, and current style.
-   * Uses S3 URLs when S3_IMAGE_BASE_URL is configured.
-   * @param {number} playerId - Player database ID
-   * @param {string} displayName - Player display name (for placeholder)
-   * @param {string} [slug] - Player URL slug (optional, will lookup from ID_TO_SLUG_MAP)
-   * @returns {string} Image URL
-   */
-  getPhotoUrl(playerId, displayName, slug) {
-    const style = window.IMAGE_STYLE || 'default';
-    const s3Base = window.S3_IMAGE_BASE_URL;
-
-    if (playerId) {
-      // Resolve slug from map if not provided
-      const playerSlug = slug || (window.ID_TO_SLUG_MAP ? window.ID_TO_SLUG_MAP[playerId] : null);
-
-      if (s3Base && playerSlug) {
-        // Use S3 URL format: {base}/players/{id}_{slug}_{style}.png
-        return `${s3Base}/players/${playerId}_${playerSlug}_${style}.png`;
-      }
-
-      // Fallback to local static path - use consistent format with slug when available
-      if (playerSlug) {
-        return `/static/img/players/${playerId}_${playerSlug}_${style}.png`;
-      }
-
-      // Legacy fallback only when slug is unavailable
-      return `/static/img/players/${playerId}_${style}.jpg`;
-    }
-
-    // Fallback to placeholder
-    const name = displayName || 'Player';
-    return `https://placehold.co/200x200/edf2f7/1f2937?text=${encodeURIComponent(name)}`;
-  },
-
-  /**
-   * Get player ID from slug using the server-provided map
-   * @param {string} slug - Player slug
-   * @returns {number|null} Player ID or null if not found
-   */
-  getPlayerIdFromSlug(slug) {
-    return window.PLAYER_ID_MAP ? window.PLAYER_ID_MAP[slug] : null;
-  },
-
-  /**
-   * Get player slug from ID using the server-provided map
-   * @param {number} playerId - Player database ID
-   * @returns {string|null} Player slug or null if not found
-   */
-  getSlugFromPlayerId(playerId) {
-    return window.ID_TO_SLUG_MAP ? window.ID_TO_SLUG_MAP[playerId] : null;
-  }
-};
-
-/**
- * ============================================================================
- * PROSPECTS GRID MODULE
- * Renders the grid of top prospect cards
- * ============================================================================
- */
-const ProspectsModule = {
-  /**
-   * Initialize the prospects grid
-   */
-  init() {
-    const grid = document.getElementById('prospectsGrid');
-    if (!grid || !window.PLAYERS) return;
-
-    grid.innerHTML = this.renderProspects();
-  },
-
-  /**
-   * Render all prospect cards
-   * @returns {string} HTML string
-   */
-  renderProspects() {
-    const esc = DraftGuru.escapeHtml.bind(DraftGuru);
-    return window.PLAYERS.map((player) => {
-      const badge = player.change !== 0
-        ? this.renderBadge(player.change)
-        : '';
-
-	      return `
-	        <a href="/players/${esc(player.slug)}" class="prospect-card" style="text-decoration: none; color: inherit;">
-	          <div class="prospect-image-wrapper">
-	            <img
-	              src="${esc(player.img)}"
-	              alt="${esc(player.name)}"
-	              class="prospect-image"
-	              onerror="if(!this.dataset.dgFallback){this.dataset.dgFallback='1';this.src='${esc(player.img_default)}';}else{this.onerror=null;this.src='${esc(player.img_placeholder)}';}"
-	            />
-	            ${badge}
-	          </div>
-	          <div class="prospect-info">
-	            <h4 class="prospect-name">${esc(player.name)}</h4>
-            <p class="prospect-meta">${esc(player.position)} • ${esc(player.college)}</p>
-            <div class="prospect-stats">
-              ${this.renderStatPill('HT', `${player.measurables.ht}"`)}
-              ${this.renderStatPill('WS', `${player.measurables.ws}"`)}
-              ${this.renderStatPill('VRT', `${player.measurables.vert}"`)}
-            </div>
-          </div>
-        </a>
-      `;
-    }).join('');
-  },
-
-  /**
-   * Render riser/faller badge
-   * @param {number} change - Position change value
-   * @returns {string} HTML string
-   */
-  renderBadge(change) {
-    const badgeClass = change > 0 ? 'riser' : 'faller';
-    const badgeText = change > 0 ? 'Riser' : 'Faller';
-    return `<span class="prospect-badge ${badgeClass}">${badgeText}</span>`;
-  },
-
-  /**
-   * Render a single stat pill
-   * @param {string} label - Stat label
-   * @param {string} value - Stat value
-   * @returns {string} HTML string
-   */
-  renderStatPill(label, value) {
-    return `
-      <div class="stat-pill">
-        <span class="label">${label}</span>
-        <span class="value">${value}</span>
-      </div>
-    `;
-  }
-};
 
 /**
  * ============================================================================
@@ -834,98 +693,245 @@ const NewsGridModule = {
 
 /**
  * ============================================================================
- * TRENDING MODULE
- * Renders the trending players section based on recent mention volume
+ * TRENDING MODULE (v2)
+ * Renders the two-tier trending section: featured 2x2 cards + compact tail.
+ * Backed by window.FEATURED_TRENDING and window.COMPACT_TRENDING server-side
+ * payloads built by app/services/expanded_trending_service.py.
  * ============================================================================
  */
 const TrendingModule = {
-  /**
-   * Initialize the trending players section
-   */
+  TAG_CLASS_BY_VALUE: {
+    'Mock Draft': 'tcard__tag--mock',
+    'Big Board': 'tcard__tag--bigboard',
+    'Tier Update': 'tcard__tag--bigboard',
+    'Film Study': 'tcard__tag--film',
+    'Skill Theme': 'tcard__tag--film',
+    'Scouting Report': 'tcard__tag--scout',
+    'Game Recap': 'tcard__tag--scout',
+    'Draft Intel': 'tcard__tag--intel',
+    'Team Fit': 'tcard__tag--intel',
+    'Statistical Analysis': 'tcard__tag--bigboard',
+  },
+
   init() {
-    const data = window.TRENDING_PLAYERS;
-    if (!data || data.length === 0) return;
+    const featured = Array.isArray(window.FEATURED_TRENDING) ? window.FEATURED_TRENDING : [];
+    const compact = Array.isArray(window.COMPACT_TRENDING) ? window.COMPACT_TRENDING : [];
+    if (featured.length === 0 && compact.length === 0) return;
 
     const section = document.getElementById('trendingSection');
     const divider = document.getElementById('trendingDivider');
-    const grid = document.getElementById('trendingGrid');
-    if (!section || !grid) return;
+    const featuredGrid = document.getElementById('featuredTrendingGrid');
+    const compactGrid = document.getElementById('compactTrendingGrid');
+    if (!section || !featuredGrid || !compactGrid) return;
 
     section.style.display = '';
     if (divider) divider.style.display = '';
 
-    grid.innerHTML = data.map(player => this.renderCard(player)).join('');
+    if (featured.length > 0) {
+      featuredGrid.innerHTML = featured.map((p) => this.renderFeatured(p)).join('');
+      featuredGrid.style.display = '';
+    }
+    if (compact.length > 0) {
+      compactGrid.innerHTML = compact.map((p) => this.renderCompact(p)).join('');
+      compactGrid.style.display = '';
+    }
   },
 
-  /**
-   * Render a single trending player card
-   * @param {Object} player - Trending player data
-   * @returns {string} HTML string
-   */
-  renderCard(player) {
+  renderFeatured(p) {
     const esc = DraftGuru.escapeHtml.bind(DraftGuru);
-    const school = player.school
-      ? `<span class="trending-card__school">${esc(player.school)}</span>`
-      : '';
-    const thumbnail = this.renderThumbnail(player);
-    const sparkline = this.renderSparkline(player.daily_counts || []);
-
     return `
-      <a href="/players/${esc(player.slug)}" class="trending-card">
-        ${thumbnail}
-        <div class="trending-card__info">
-          <span class="trending-card__name">${esc(player.display_name)}</span>
-          ${school}
+      <a href="/players/${esc(p.slug)}" class="tcard">
+        ${this.renderSpike(p.spike_state)}
+        <span class="tcard__rank">#${p.rank}</span>
+
+        <div class="tcard__left">
+          ${this.renderPhoto(p, 96)}
+          ${this.renderCombinePill(p.combine_grade)}
         </div>
-        <div class="trending-card__visual">
-          ${sparkline}
-          <span class="trending-card__count">${player.mention_count}</span>
+
+        <div class="tcard__body">
+          <div class="tcard__name">${esc(p.display_name)}</div>
+          <div class="tcard__meta">${this.renderMeta(p)}</div>
+
+          ${this.renderStatStrip(p.latest_stats)}
+
+          <div class="tcard__buzz">
+            <div class="tcard__buzzCount">
+              <span class="num">${p.mention_count}</span>
+              <span class="lbl">mentions</span>
+            </div>
+            ${this.renderSparkline(p.daily_counts || [], 160, 28)}
+            ${this.renderMixBar(p.content_mix)}
+          </div>
+
+          <div class="tcard__tagRow">
+            ${this.renderTag(p.dominant_news_tag)}
+            ${p.latest_mention_time ? `<span class="tcard__lastSeen">last seen ${esc(p.latest_mention_time)} ago</span>` : ''}
+          </div>
+
+          ${this.renderMentions(p.recent_mentions || [])}
         </div>
       </a>
     `;
   },
 
-  /**
-   * Render a small circular player thumbnail
-   * @param {Object} player - Trending player data
-   * @returns {string} HTML string
-   */
-  renderThumbnail(player) {
+  renderCompact(p) {
     const esc = DraftGuru.escapeHtml.bind(DraftGuru);
-    const imgUrl = ImageUtils.getPhotoUrl(player.player_id, player.display_name, player.slug);
-    const initial = (player.display_name || '?').charAt(0).toUpperCase();
+    const meta = [p.position, p.school, p.draft_year]
+      .filter((part) => part !== null && part !== undefined && String(part).length > 0)
+      .map((part) => esc(String(part)))
+      .join('<span class="dot"></span>');
+
     return `
-      <img
-        src="${esc(imgUrl)}"
-        alt="${esc(player.display_name)}"
-        class="trending-card__thumb"
-        onerror="this.onerror=null;this.replaceWith(Object.assign(document.createElement('span'),{className:'trending-card__thumb trending-card__thumb--placeholder',textContent:'${initial}'}))"
-      />
+      <a href="/players/${esc(p.slug)}" class="tcard tcard--compact">
+        <span class="tcard__rank">#${p.rank}</span>
+        <div class="tcard__left">
+          ${this.renderPhoto(p, 64)}
+        </div>
+        <div class="tcard__body">
+          <div class="tcard__name">${esc(p.display_name)}</div>
+          <div class="tcard__meta">${meta}</div>
+          <div class="tcard__buzz">
+            <div class="tcard__buzzCount"><span class="num">${p.mention_count}</span><span class="lbl">mentions</span></div>
+            ${this.renderSparkline(p.daily_counts || [], 100, 22)}
+          </div>
+          ${p.dominant_news_tag ? `<div class="tcard__tagRow">${this.renderTag(p.dominant_news_tag)}</div>` : ''}
+        </div>
+      </a>
     `;
   },
 
-  /**
-   * Render an inline SVG sparkline from daily mention counts
-   * @param {number[]} counts - Array of daily counts (oldest-first)
-   * @returns {string} SVG HTML string
-   */
-  renderSparkline(counts) {
-    if (!counts || counts.length === 0) return '';
+  renderPhoto(p, size) {
+    const esc = DraftGuru.escapeHtml.bind(DraftGuru);
+    const initial = (p.display_name || '?').charAt(0).toUpperCase();
+    if (p.photo_url) {
+      return `
+        <img
+          src="${esc(p.photo_url)}"
+          alt="${esc(p.display_name)}"
+          class="tcard__photo"
+          onerror="this.onerror=null;this.replaceWith(Object.assign(document.createElement('span'),{className:'tcard__photo tcard__photo--placeholder',textContent:'${initial}'}))"
+        />
+      `;
+    }
+    return `<span class="tcard__photo tcard__photo--placeholder">${initial}</span>`;
+  },
 
-    const width = 64;
-    const height = 24;
+  renderCombinePill(grade) {
+    if (!grade) return '';
+    const esc = DraftGuru.escapeHtml.bind(DraftGuru);
+    return `<div class="tcard__combine">Combine&nbsp;<strong>${esc(grade)}</strong></div>`;
+  },
+
+  renderMeta(p) {
+    const esc = DraftGuru.escapeHtml.bind(DraftGuru);
+    const parts = [p.position, p.school, p.draft_year]
+      .filter((part) => part !== null && part !== undefined && String(part).length > 0)
+      .map((part) => esc(String(part)));
+    return parts.join('<span class="dot"></span>');
+  },
+
+  renderStatStrip(stats) {
+    if (!stats) return '';
+    const pills = [];
+    if (stats.ppg !== null && stats.ppg !== undefined) {
+      pills.push(this.renderStatPill('PPG', stats.ppg.toFixed(1)));
+    }
+    if (stats.rpg !== null && stats.rpg !== undefined) {
+      pills.push(this.renderStatPill('RPG', stats.rpg.toFixed(1)));
+    }
+    if (stats.apg !== null && stats.apg !== undefined) {
+      pills.push(this.renderStatPill('APG', stats.apg.toFixed(1)));
+    }
+    if (stats.three_p_pct !== null && stats.three_p_pct !== undefined) {
+      pills.push(this.renderStatPill('3P%', stats.three_p_pct.toFixed(1)));
+    }
+    if (pills.length === 0) return '';
+    return `<div class="tcard__stats">${pills.join('')}</div>`;
+  },
+
+  renderStatPill(label, value) {
+    const esc = DraftGuru.escapeHtml.bind(DraftGuru);
+    return `<span class="tcard__stat"><span class="label">${esc(label)}</span><span class="value">${esc(value)}</span></span>`;
+  },
+
+  renderMixBar(mix) {
+    if (!mix) return '';
+    const news = mix.news || 0;
+    const podcast = mix.podcast || 0;
+    const video = mix.video || 0;
+    const total = news + podcast + video;
+    if (total === 0) return '';
+    const pct = (n) => ((n / total) * 100).toFixed(1);
+    return `
+      <div class="tcard__mix">
+        <div class="tcard__mixBar" title="News ${news} · Podcasts ${podcast} · Video ${video}">
+          ${news > 0 ? `<span class="seg-news" style="width: ${pct(news)}%"></span>` : ''}
+          ${podcast > 0 ? `<span class="seg-pod" style="width: ${pct(podcast)}%"></span>` : ''}
+          ${video > 0 ? `<span class="seg-vid" style="width: ${pct(video)}%"></span>` : ''}
+        </div>
+        <div class="tcard__mixLegend">
+          <span class="lg"><span class="sw sw--news"></span>${news}</span>
+          <span class="lg"><span class="sw sw--pod"></span>${podcast}</span>
+          <span class="lg"><span class="sw sw--vid"></span>${video}</span>
+        </div>
+      </div>
+    `;
+  },
+
+  renderTag(tagValue) {
+    if (!tagValue) return '';
+    const esc = DraftGuru.escapeHtml.bind(DraftGuru);
+    const cls = this.TAG_CLASS_BY_VALUE[tagValue] || '';
+    const label = `Mostly ${tagValue}`;
+    return `<span class="tcard__tag ${cls}">${esc(label)}</span>`;
+  },
+
+  renderSpike(state) {
+    if (state === 'hot') {
+      return '<span class="tcard__spike tcard__spike--hot">▲ HOT</span>';
+    }
+    if (state === 'cooling') {
+      return '<span class="tcard__spike tcard__spike--cooling">▼ Cooling</span>';
+    }
+    return '';
+  },
+
+  renderMentions(mentions) {
+    if (!mentions || mentions.length === 0) return '';
+    const esc = DraftGuru.escapeHtml.bind(DraftGuru);
+    const iconMap = { news: 'N', podcast: 'P', video: 'V' };
+    const iconClassMap = {
+      news: 'tmention__icon--news',
+      podcast: 'tmention__icon--pod',
+      video: 'tmention__icon--vid',
+    };
+    const rows = mentions.map((m) => {
+      const icon = iconMap[m.content_type] || '·';
+      const iconClass = iconClassMap[m.content_type] || '';
+      return `
+        <div class="tmention">
+          <span class="tmention__icon ${iconClass}">${icon}</span>
+          <span class="tmention__title"><b>${esc(m.source_name || '')}</b> — ${esc(m.title || '')}</span>
+          <span class="tmention__when">${esc(m.time || '')}</span>
+        </div>
+      `;
+    }).join('');
+    return `<div class="tcard__mentions">${rows}</div>`;
+  },
+
+  renderSparkline(counts, width, height) {
+    if (!counts || counts.length === 0) return '';
     const padding = 2;
     const maxVal = Math.max(...counts, 1);
     const step = (width - padding * 2) / Math.max(counts.length - 1, 1);
-
     const points = counts.map((v, i) => {
       const x = padding + i * step;
       const y = height - padding - ((v / maxVal) * (height - padding * 2));
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     }).join(' ');
-
     return `
-      <svg class="trending-card__sparkline" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">
+      <svg class="tcard__sparkline" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">
         <polyline
           points="${points}"
           fill="none"
@@ -937,7 +943,6 @@ const TrendingModule = {
       </svg>
     `;
   },
-
 };
 
 /**
@@ -1096,8 +1101,6 @@ function shareVSArenaTweet() {
  * ============================================================================
  */
 document.addEventListener('DOMContentLoaded', () => {
-  ProspectsModule.init();
-
   // Initialize shared H2H module for VS Arena
   H2HComparison.init({
     playerAFixed: false,

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -131,32 +131,22 @@
 
   <!-- ==========================================================================
        TRENDING PLAYERS
-       Players with the most recent article mentions
+       Featured cards (rich 2x2) plus compact tail leaderboard, replacing the
+       static "Top Prospects" grid. Populated by TrendingModule in home.js.
        ========================================================================== -->
   <section class="section" id="trendingSection" style="display: none;">
-    <h3 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-emerald);">
-      Trending Players
-    </h3>
+    <div class="section-header-row">
+      <h3 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-emerald);">
+        Trending Players
+      </h3>
+      <span class="section-subtitle">Last 7 days · weighted by recency</span>
+    </div>
 
-    <div id="trendingGrid" class="trending-grid"></div>
+    <div id="featuredTrendingGrid" class="trending-grid trending-grid--featured" style="display: none;"></div>
+    <div id="compactTrendingGrid" class="trending-grid trending-grid--compact" style="display: none;"></div>
   </section>
 
   <div class="section-divider" id="trendingDivider" style="display: none;"></div>
-
-  <!-- ==========================================================================
-       TOP PROSPECTS
-       Grid of top prospect player cards with stats
-       ========================================================================== -->
-  <section class="section">
-    <h3 class="section-header mono-font uppercase" style="border-left-color: var(--color-accent-indigo);">
-      Top Prospects
-    </h3>
-
-    <!-- Prospects grid - populated by JavaScript -->
-    <div id="prospectsGrid" class="prospects-grid"></div>
-  </section>
-
-  <div class="section-divider"></div>
 
   <!-- ==========================================================================
        VS ARENA (PLAYER COMPARISON)
@@ -274,19 +264,14 @@
 {% block extra_js %}
 <script>
   // Server-side data injection
-  window.PLAYERS = {{ players | tojson | safe }};
-  window.TRENDING_PLAYERS = {{ trending_players | tojson | safe }};
+  window.FEATURED_TRENDING = {{ featured_trending | tojson | safe }};
+  window.COMPACT_TRENDING = {{ compact_trending | tojson | safe }};
   window.FEED_ITEMS = {{ feed_items | tojson | safe }};
   // Hero article and sidebar data for news section
   window.HERO_ARTICLE = {{ hero_article | tojson | safe }};
   window.SOURCE_COUNTS = {{ source_counts | tojson | safe }};
   window.AUTHOR_COUNTS = {{ author_counts | tojson | safe }};
   window.SIDEBAR_LIMIT = {{ sidebar_limit | tojson | safe }};
-  // Image style and player ID mapping for dynamic image URL generation
-  window.IMAGE_STYLE = {{ image_style | tojson | safe }};
-  window.PLAYER_ID_MAP = {{ player_id_map | tojson | safe }};
-  window.ID_TO_SLUG_MAP = {{ id_to_slug_map | tojson | safe }};
-  window.S3_IMAGE_BASE_URL = {{ s3_image_base_url | tojson | safe }};
   // Podcast episodes for homepage section
   window.PODCAST_EPISODES = {{ podcast_episodes | tojson | safe }};
   window.FILM_ROOM_VIDEOS = {{ film_room_videos | tojson | safe }};

--- a/mockups/draftguru_trending_v2.html
+++ b/mockups/draftguru_trending_v2.html
@@ -1,0 +1,910 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DraftGuru — Trending Players (Expanded Card)</title>
+
+  <link href="https://fonts.googleapis.com/css2?family=Russo+One&family=Azeret+Mono:wght@400;600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --font-heading: 'Russo One', system-ui, sans-serif;
+      --font-mono: 'Azeret Mono', ui-monospace, monospace;
+      --font-body: system-ui, -apple-system, sans-serif;
+
+      --color-primary: #4A7FB8;
+      --color-accent-emerald: #10b981;
+      --color-accent-rose: #f43f5e;
+      --color-accent-indigo: #6366f1;
+      --color-accent-cyan: #06b6d4;
+      --color-accent-amber: #f59e0b;
+      --color-accent-fuchsia: #d946ef;
+
+      --color-white: #ffffff;
+      --color-slate-50: #f8fafc;
+      --color-slate-100: #f1f5f9;
+      --color-slate-200: #e2e8f0;
+      --color-slate-300: #cbd5e1;
+      --color-slate-400: #94a3b8;
+      --color-slate-500: #64748b;
+      --color-slate-600: #475569;
+      --color-slate-700: #334155;
+      --color-slate-800: #1e293b;
+      --color-slate-900: #0f172a;
+
+      --transition-speed: 0.2s;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: var(--font-body);
+      color: var(--color-slate-900);
+      background: linear-gradient(to bottom, var(--color-white), var(--color-slate-50));
+      min-height: 100vh;
+      line-height: 1.5;
+      padding: 2.5rem 1rem 4rem;
+    }
+
+    .home-container {
+      max-width: 1280px;
+      margin-inline: auto;
+    }
+
+    .mockup-banner {
+      font-family: var(--font-mono);
+      font-size: 0.6875rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--color-slate-500);
+      border: 1px dashed var(--color-slate-300);
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      margin-bottom: 2rem;
+      background: var(--color-white);
+    }
+
+    .section { margin-bottom: 3rem; }
+
+    .section-header-row {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    .section-header {
+      font-family: var(--font-mono);
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-size: 1.125rem;
+      padding-left: 0.5rem;
+      border-left: 4px solid var(--color-accent-emerald);
+    }
+
+    .section-subtitle {
+      font-size: 0.8125rem;
+      color: var(--color-slate-500);
+    }
+
+    /* ============================================================================
+       TRENDING GRID (expanded)
+       ============================================================================ */
+    .trending-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 1rem;
+    }
+
+    @media (max-width: 860px) {
+      .trending-grid { grid-template-columns: 1fr; }
+    }
+
+    /* ============================================================================
+       TRENDING CARD
+       ============================================================================ */
+    .tcard {
+      position: relative;
+      display: grid;
+      grid-template-columns: 96px 1fr;
+      gap: 1rem;
+      padding: 1rem;
+      border-radius: 0.75rem;
+      border: 1px solid var(--color-slate-200);
+      background: var(--color-white);
+      text-decoration: none;
+      color: inherit;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+      transition: transform var(--transition-speed), box-shadow var(--transition-speed), border-color var(--transition-speed);
+      overflow: hidden;
+    }
+
+    .tcard:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.07);
+      border-color: var(--color-accent-emerald);
+    }
+
+    /* Subtle scanline overlay to match the retro aesthetic */
+    .tcard::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(15, 23, 42, 0.0) 0px,
+        rgba(15, 23, 42, 0.0) 2px,
+        rgba(15, 23, 42, 0.015) 3px
+      );
+      opacity: 0;
+      transition: opacity var(--transition-speed);
+    }
+    .tcard:hover::after { opacity: 1; }
+
+    /* Rank pill (top-right) */
+    .tcard__rank {
+      position: absolute;
+      top: 0.625rem;
+      right: 0.75rem;
+      font-family: var(--font-mono);
+      font-weight: 700;
+      font-size: 0.6875rem;
+      letter-spacing: 0.04em;
+      color: var(--color-slate-600);
+      background: var(--color-slate-100);
+      border: 1px solid var(--color-slate-200);
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+    }
+
+    /* Spike badge — overlays rank pill area when applicable */
+    .tcard__spike {
+      position: absolute;
+      top: 0.625rem;
+      left: 0.75rem;
+      font-family: var(--font-mono);
+      font-weight: 700;
+      font-size: 0.6875rem;
+      letter-spacing: 0.04em;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+    .tcard__spike--hot {
+      color: #9f1239;
+      background: #ffe4e6;
+      border: 1px solid #fecdd3;
+    }
+    .tcard__spike--cooling {
+      color: var(--color-slate-600);
+      background: var(--color-slate-100);
+      border: 1px solid var(--color-slate-200);
+    }
+
+    /* ----- Left column: identity ------------------------------------------------ */
+    .tcard__left {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .tcard__photo {
+      width: 96px;
+      height: 96px;
+      border-radius: 0.5rem;
+      object-fit: cover;
+      object-position: 50% 20%;
+      background: var(--color-slate-100);
+      border: 1px solid var(--color-slate-200);
+    }
+
+    .tcard__photo--placeholder {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-family: var(--font-heading);
+      font-size: 2rem;
+      color: var(--color-slate-400);
+    }
+
+    .tcard__combine {
+      font-family: var(--font-mono);
+      font-size: 0.625rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      padding: 0.125rem 0.4rem;
+      border-radius: 0.25rem;
+      color: var(--color-slate-600);
+      background: var(--color-slate-100);
+      border: 1px solid var(--color-slate-200);
+      text-align: center;
+    }
+    .tcard__combine strong {
+      font-weight: 700;
+      color: var(--color-accent-emerald);
+    }
+
+    /* ----- Right column: content ------------------------------------------------ */
+    .tcard__body {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      padding-right: 3rem; /* leave room for rank pill */
+    }
+
+    .tcard__name {
+      font-family: var(--font-heading);
+      font-size: 1.125rem;
+      letter-spacing: 0.01em;
+      line-height: 1.15;
+      color: var(--color-slate-900);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .tcard__meta {
+      font-family: var(--font-mono);
+      font-size: 0.6875rem;
+      color: var(--color-slate-500);
+      letter-spacing: 0.04em;
+      margin-top: 0.125rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .tcard__meta .dot {
+      display: inline-block;
+      width: 3px;
+      height: 3px;
+      border-radius: 50%;
+      background: var(--color-slate-300);
+      vertical-align: middle;
+      margin: 0 0.4rem;
+    }
+
+    /* Stat line: latest college season */
+    .tcard__stats {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 0.625rem;
+      flex-wrap: wrap;
+    }
+
+    .tcard__stat {
+      font-family: var(--font-mono);
+      font-size: 0.6875rem;
+      letter-spacing: 0.03em;
+      padding: 0.2rem 0.45rem;
+      border-radius: 0.25rem;
+      background: var(--color-slate-50);
+      border: 1px solid var(--color-slate-200);
+      color: var(--color-slate-700);
+      white-space: nowrap;
+    }
+    .tcard__stat .label {
+      color: var(--color-slate-500);
+      margin-right: 0.3rem;
+      font-size: 0.625rem;
+    }
+    .tcard__stat .value {
+      font-weight: 600;
+      font-variant-numeric: tabular-nums;
+    }
+
+    /* Buzz row: sparkline + total + content-type mix */
+    .tcard__buzz {
+      margin-top: 0.875rem;
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 0.625rem 0.875rem;
+      align-items: center;
+    }
+
+    .tcard__buzzCount {
+      display: flex;
+      align-items: baseline;
+      gap: 0.375rem;
+      font-family: var(--font-mono);
+    }
+    .tcard__buzzCount .num {
+      font-size: 1.375rem;
+      font-weight: 700;
+      color: var(--color-accent-emerald);
+      font-variant-numeric: tabular-nums;
+      line-height: 1;
+    }
+    .tcard__buzzCount .lbl {
+      font-size: 0.625rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--color-slate-500);
+    }
+
+    .tcard__sparkline {
+      width: 100%;
+      max-width: 160px;
+      height: 28px;
+      display: block;
+    }
+
+    .tcard__mix {
+      grid-column: 1 / -1;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .tcard__mixBar {
+      flex: 1;
+      display: flex;
+      height: 6px;
+      border-radius: 9999px;
+      overflow: hidden;
+      background: var(--color-slate-100);
+      border: 1px solid var(--color-slate-200);
+    }
+    .tcard__mixBar > span { display: block; height: 100%; }
+    .tcard__mixBar .seg-news { background: var(--color-accent-cyan); }
+    .tcard__mixBar .seg-pod  { background: var(--color-accent-fuchsia); }
+    .tcard__mixBar .seg-vid  { background: var(--color-accent-amber); }
+
+    .tcard__mixLegend {
+      font-family: var(--font-mono);
+      font-size: 0.625rem;
+      letter-spacing: 0.04em;
+      color: var(--color-slate-500);
+      display: flex;
+      gap: 0.625rem;
+      white-space: nowrap;
+    }
+    .tcard__mixLegend .lg { display: inline-flex; align-items: center; gap: 0.25rem; }
+    .tcard__mixLegend .sw {
+      width: 8px; height: 8px; border-radius: 2px; display: inline-block;
+    }
+    .tcard__mixLegend .sw--news { background: var(--color-accent-cyan); }
+    .tcard__mixLegend .sw--pod  { background: var(--color-accent-fuchsia); }
+    .tcard__mixLegend .sw--vid  { background: var(--color-accent-amber); }
+
+    /* Tag chip ("Mostly Mock Draft" etc.) */
+    .tcard__tagRow {
+      margin-top: 0.625rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+    .tcard__tag {
+      font-family: var(--font-mono);
+      font-size: 0.625rem;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      padding: 0.2rem 0.5rem;
+      border-radius: 9999px;
+      color: var(--color-slate-700);
+      background: var(--color-slate-100);
+      border: 1px solid var(--color-slate-200);
+    }
+    .tcard__tag--mock { color: #1d4ed8; background: #dbeafe; border-color: #bfdbfe; }
+    .tcard__tag--bigboard { color: #6d28d9; background: #ede9fe; border-color: #ddd6fe; }
+    .tcard__tag--film { color: #b45309; background: #fef3c7; border-color: #fde68a; }
+    .tcard__tag--scout { color: #047857; background: #d1fae5; border-color: #a7f3d0; }
+    .tcard__tag--intel { color: #be185d; background: #fce7f3; border-color: #fbcfe8; }
+
+    .tcard__lastSeen {
+      font-family: var(--font-mono);
+      font-size: 0.625rem;
+      letter-spacing: 0.04em;
+      color: var(--color-slate-500);
+    }
+
+    /* Recent mention list */
+    .tcard__mentions {
+      margin-top: 0.75rem;
+      padding-top: 0.75rem;
+      border-top: 1px dashed var(--color-slate-200);
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    .tmention {
+      display: grid;
+      grid-template-columns: 1.25rem 1fr auto;
+      gap: 0.5rem;
+      align-items: baseline;
+      font-size: 0.8125rem;
+      line-height: 1.3;
+    }
+
+    .tmention__icon {
+      font-family: var(--font-mono);
+      font-size: 0.625rem;
+      font-weight: 700;
+      text-align: center;
+      padding-top: 0.125rem;
+      color: var(--color-slate-400);
+    }
+    .tmention__icon--news { color: var(--color-accent-cyan); }
+    .tmention__icon--pod  { color: var(--color-accent-fuchsia); }
+    .tmention__icon--vid  { color: var(--color-accent-amber); }
+
+    .tmention__title {
+      color: var(--color-slate-700);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .tmention__title b {
+      color: var(--color-slate-900);
+      font-weight: 600;
+    }
+
+    .tmention__when {
+      font-family: var(--font-mono);
+      font-size: 0.625rem;
+      letter-spacing: 0.04em;
+      color: var(--color-slate-400);
+      white-space: nowrap;
+    }
+
+    /* Compact card variant for ranks 5-10 (no mention list, smaller photo) */
+    .trending-grid--compact {
+      margin-top: 1rem;
+      grid-template-columns: repeat(3, 1fr);
+    }
+    @media (max-width: 860px) {
+      .trending-grid--compact { grid-template-columns: 1fr 1fr; }
+    }
+    @media (max-width: 540px) {
+      .trending-grid--compact { grid-template-columns: 1fr; }
+    }
+    .tcard--compact { grid-template-columns: 64px 1fr; padding: 0.75rem; }
+    .tcard--compact .tcard__photo { width: 64px; height: 64px; }
+    .tcard--compact .tcard__name { font-size: 0.9375rem; }
+    .tcard--compact .tcard__body { padding-right: 2.5rem; }
+    .tcard--compact .tcard__mentions { display: none; }
+    .tcard--compact .tcard__stats { display: none; }
+    .tcard--compact .tcard__combine { display: none; }
+    .tcard--compact .tcard__buzz { margin-top: 0.5rem; }
+    .tcard--compact .tcard__sparkline { max-width: 100px; height: 22px; }
+    .tcard--compact .tcard__buzzCount .num { font-size: 1.125rem; }
+  </style>
+</head>
+<body>
+  <main class="home-container">
+    <div class="mockup-banner">
+      Mockup · Trending Players v2 · replaces "Popular Prospects".
+      Featured (top 4, 2×2 grid) requires: non-stub · real photo · position · school · latest college PPG · ≥ 5 mentions.
+      Combine grade, class, RPG/APG/3P%, and Hot/Cooling badge are optional — rendered when present, hidden silently when not.
+      Note #4 (VJ Edgecombe) is demoted to the compact tail because no real photo is on file yet; #5 (Khaman Maluach) gets promoted into the featured slot in his place.
+    </div>
+
+    <!-- ==========================================================================
+         TRENDING PLAYERS — featured (ranks 1-4)
+         ========================================================================== -->
+    <section class="section">
+      <div class="section-header-row">
+        <h3 class="section-header">Trending Players</h3>
+        <span class="section-subtitle">Last 7 days · weighted by recency</span>
+      </div>
+
+      <div class="trending-grid">
+
+        <!-- ===== Card 1 ========================================================= -->
+        <a href="#" class="tcard">
+          <span class="tcard__spike tcard__spike--hot">▲ HOT</span>
+          <span class="tcard__rank">#1</span>
+
+          <div class="tcard__left">
+            <img class="tcard__photo" src="https://placehold.co/96x96/e2e8f0/64748b?text=AJ" alt="Cooper Flagg">
+            <div class="tcard__combine">Combine&nbsp;<strong>A−</strong></div>
+          </div>
+
+          <div class="tcard__body">
+            <div class="tcard__name">Cooper Flagg</div>
+            <div class="tcard__meta">PF · Duke<span class="dot"></span>2026</div>
+
+            <div class="tcard__stats">
+              <span class="tcard__stat"><span class="label">PPG</span><span class="value">19.2</span></span>
+              <span class="tcard__stat"><span class="label">RPG</span><span class="value">7.8</span></span>
+              <span class="tcard__stat"><span class="label">APG</span><span class="value">4.1</span></span>
+              <span class="tcard__stat"><span class="label">3P%</span><span class="value">38.4</span></span>
+            </div>
+
+            <div class="tcard__buzz">
+              <div class="tcard__buzzCount">
+                <span class="num">42</span>
+                <span class="lbl">mentions</span>
+              </div>
+              <svg class="tcard__sparkline" viewBox="0 0 160 28" preserveAspectRatio="none">
+                <polyline points="2,22 28,18 54,20 80,12 106,14 132,6 158,2"
+                          fill="none" stroke="var(--color-accent-emerald)" stroke-width="1.75"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+
+              <div class="tcard__mix">
+                <div class="tcard__mixBar" title="News 26 · Podcasts 11 · Video 5">
+                  <span class="seg-news" style="width: 62%"></span>
+                  <span class="seg-pod"  style="width: 26%"></span>
+                  <span class="seg-vid"  style="width: 12%"></span>
+                </div>
+                <div class="tcard__mixLegend">
+                  <span class="lg"><span class="sw sw--news"></span>26</span>
+                  <span class="lg"><span class="sw sw--pod"></span>11</span>
+                  <span class="lg"><span class="sw sw--vid"></span>5</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="tcard__tagRow">
+              <span class="tcard__tag tcard__tag--mock">Mostly Mock Draft</span>
+              <span class="tcard__lastSeen">last seen 2h ago</span>
+            </div>
+
+            <div class="tcard__mentions">
+              <div class="tmention">
+                <span class="tmention__icon tmention__icon--news">N</span>
+                <span class="tmention__title"><b>The Athletic</b> — Cooper Flagg locks down the No. 1 slot in latest mock</span>
+                <span class="tmention__when">2h</span>
+              </div>
+              <div class="tmention">
+                <span class="tmention__icon tmention__icon--pod">P</span>
+                <span class="tmention__title"><b>No Ceilings Pod</b> — Flagg's defensive ceiling, revisited</span>
+                <span class="tmention__when">1d</span>
+              </div>
+            </div>
+          </div>
+        </a>
+
+        <!-- ===== Card 2 ========================================================= -->
+        <a href="#" class="tcard">
+          <span class="tcard__spike tcard__spike--hot">▲ HOT</span>
+          <span class="tcard__rank">#2</span>
+
+          <div class="tcard__left">
+            <img class="tcard__photo" src="https://placehold.co/96x96/e2e8f0/64748b?text=AJ" alt="Ace Bailey">
+            <div class="tcard__combine">Combine&nbsp;<strong>B+</strong></div>
+          </div>
+
+          <div class="tcard__body">
+            <div class="tcard__name">Ace Bailey</div>
+            <div class="tcard__meta">SF · Rutgers<span class="dot"></span>2026</div>
+
+            <div class="tcard__stats">
+              <span class="tcard__stat"><span class="label">PPG</span><span class="value">17.4</span></span>
+              <span class="tcard__stat"><span class="label">RPG</span><span class="value">5.9</span></span>
+              <span class="tcard__stat"><span class="label">FG%</span><span class="value">46.1</span></span>
+              <span class="tcard__stat"><span class="label">3PA</span><span class="value">5.2</span></span>
+            </div>
+
+            <div class="tcard__buzz">
+              <div class="tcard__buzzCount">
+                <span class="num">31</span>
+                <span class="lbl">mentions</span>
+              </div>
+              <svg class="tcard__sparkline" viewBox="0 0 160 28" preserveAspectRatio="none">
+                <polyline points="2,18 28,20 54,12 80,14 106,8 132,10 158,4"
+                          fill="none" stroke="var(--color-accent-emerald)" stroke-width="1.75"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+
+              <div class="tcard__mix">
+                <div class="tcard__mixBar" title="News 12 · Podcasts 9 · Video 10">
+                  <span class="seg-news" style="width: 39%"></span>
+                  <span class="seg-pod"  style="width: 29%"></span>
+                  <span class="seg-vid"  style="width: 32%"></span>
+                </div>
+                <div class="tcard__mixLegend">
+                  <span class="lg"><span class="sw sw--news"></span>12</span>
+                  <span class="lg"><span class="sw sw--pod"></span>9</span>
+                  <span class="lg"><span class="sw sw--vid"></span>10</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="tcard__tagRow">
+              <span class="tcard__tag tcard__tag--film">Mostly Film Study</span>
+              <span class="tcard__lastSeen">last seen 5h ago</span>
+            </div>
+
+            <div class="tcard__mentions">
+              <div class="tmention">
+                <span class="tmention__icon tmention__icon--vid">V</span>
+                <span class="tmention__title"><b>Swish Theory</b> — Ace Bailey shot diet breakdown</span>
+                <span class="tmention__when">5h</span>
+              </div>
+              <div class="tmention">
+                <span class="tmention__icon tmention__icon--news">N</span>
+                <span class="tmention__title"><b>ESPN</b> — What the Bailey 41-pt outburst means for his stock</span>
+                <span class="tmention__when">2d</span>
+              </div>
+            </div>
+          </div>
+        </a>
+
+        <!-- ===== Card 3 ========================================================= -->
+        <a href="#" class="tcard">
+          <span class="tcard__rank">#3</span>
+
+          <div class="tcard__left">
+            <img class="tcard__photo" src="https://placehold.co/96x96/e2e8f0/64748b?text=DH" alt="Dylan Harper">
+            <div class="tcard__combine">Combine&nbsp;<strong>A</strong></div>
+          </div>
+
+          <div class="tcard__body">
+            <div class="tcard__name">Dylan Harper</div>
+            <div class="tcard__meta">PG · Rutgers<span class="dot"></span>2026</div>
+
+            <div class="tcard__stats">
+              <span class="tcard__stat"><span class="label">PPG</span><span class="value">21.6</span></span>
+              <span class="tcard__stat"><span class="label">APG</span><span class="value">6.2</span></span>
+              <span class="tcard__stat"><span class="label">FG%</span><span class="value">49.0</span></span>
+              <span class="tcard__stat"><span class="label">FT%</span><span class="value">81.4</span></span>
+            </div>
+
+            <div class="tcard__buzz">
+              <div class="tcard__buzzCount">
+                <span class="num">24</span>
+                <span class="lbl">mentions</span>
+              </div>
+              <svg class="tcard__sparkline" viewBox="0 0 160 28" preserveAspectRatio="none">
+                <polyline points="2,8 28,10 54,14 80,16 106,18 132,20 158,22"
+                          fill="none" stroke="var(--color-slate-400)" stroke-width="1.75"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+
+              <div class="tcard__mix">
+                <div class="tcard__mixBar" title="News 11 · Podcasts 10 · Video 3">
+                  <span class="seg-news" style="width: 46%"></span>
+                  <span class="seg-pod"  style="width: 41%"></span>
+                  <span class="seg-vid"  style="width: 13%"></span>
+                </div>
+                <div class="tcard__mixLegend">
+                  <span class="lg"><span class="sw sw--news"></span>11</span>
+                  <span class="lg"><span class="sw sw--pod"></span>10</span>
+                  <span class="lg"><span class="sw sw--vid"></span>3</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="tcard__tagRow">
+              <span class="tcard__tag tcard__tag--bigboard">Mostly Big Board</span>
+              <span class="tcard__lastSeen">last seen 12h ago</span>
+            </div>
+
+            <div class="tcard__mentions">
+              <div class="tmention">
+                <span class="tmention__icon tmention__icon--pod">P</span>
+                <span class="tmention__title"><b>The Stepien</b> — Top of the board: Harper vs. Flagg</span>
+                <span class="tmention__when">12h</span>
+              </div>
+              <div class="tmention">
+                <span class="tmention__icon tmention__icon--news">N</span>
+                <span class="tmention__title"><b>Yahoo</b> — Updated Top 60: Harper holds at 3</span>
+                <span class="tmention__when">3d</span>
+              </div>
+            </div>
+          </div>
+        </a>
+
+        <!-- ===== Card 4 (rank #5 — promoted past demoted #4) =================== -->
+        <a href="#" class="tcard">
+          <span class="tcard__rank">#5</span>
+
+          <div class="tcard__left">
+            <img class="tcard__photo" src="https://placehold.co/96x96/e2e8f0/64748b?text=KM" alt="Khaman Maluach">
+            <div class="tcard__combine">Combine&nbsp;<strong>A</strong></div>
+          </div>
+
+          <div class="tcard__body">
+            <div class="tcard__name">Khaman Maluach</div>
+            <div class="tcard__meta">C · Duke<span class="dot"></span>2026</div>
+
+            <div class="tcard__stats">
+              <span class="tcard__stat"><span class="label">PPG</span><span class="value">9.6</span></span>
+              <span class="tcard__stat"><span class="label">RPG</span><span class="value">6.4</span></span>
+              <span class="tcard__stat"><span class="label">BPG</span><span class="value">1.6</span></span>
+              <span class="tcard__stat"><span class="label">FG%</span><span class="value">71.2</span></span>
+            </div>
+
+            <div class="tcard__buzz">
+              <div class="tcard__buzzCount">
+                <span class="num">15</span>
+                <span class="lbl">mentions</span>
+              </div>
+              <svg class="tcard__sparkline" viewBox="0 0 160 28" preserveAspectRatio="none">
+                <polyline points="2,20 28,18 54,16 80,14 106,12 132,10 158,4"
+                          fill="none" stroke="var(--color-accent-emerald)" stroke-width="1.75"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+
+              <div class="tcard__mix">
+                <div class="tcard__mixBar" title="News 6 · Podcasts 3 · Video 6">
+                  <span class="seg-news" style="width: 40%"></span>
+                  <span class="seg-pod"  style="width: 20%"></span>
+                  <span class="seg-vid"  style="width: 40%"></span>
+                </div>
+                <div class="tcard__mixLegend">
+                  <span class="lg"><span class="sw sw--news"></span>6</span>
+                  <span class="lg"><span class="sw sw--pod"></span>3</span>
+                  <span class="lg"><span class="sw sw--vid"></span>6</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="tcard__tagRow">
+              <span class="tcard__tag tcard__tag--intel">Mostly Draft Intel</span>
+              <span class="tcard__lastSeen">last seen 6h ago</span>
+            </div>
+
+            <div class="tcard__mentions">
+              <div class="tmention">
+                <span class="tmention__icon tmention__icon--news">N</span>
+                <span class="tmention__title"><b>HoopsHype</b> — Maluach measurements draw scout intrigue</span>
+                <span class="tmention__when">6h</span>
+              </div>
+              <div class="tmention">
+                <span class="tmention__icon tmention__icon--vid">V</span>
+                <span class="tmention__title"><b>Swish Theory</b> — Pick-and-roll finishing read deep dive</span>
+                <span class="tmention__when">2d</span>
+              </div>
+            </div>
+          </div>
+        </a>
+
+      </div>
+
+      <!-- ==========================================================================
+           TRENDING PLAYERS — compact tail (ranks 5-10)
+           ========================================================================== -->
+      <div class="trending-grid trending-grid--compact">
+
+        <!-- Demoted from featured: missing latest college stats row -->
+        <a href="#" class="tcard tcard--compact">
+          <span class="tcard__rank">#4</span>
+          <div class="tcard__left">
+            <span class="tcard__photo tcard__photo--placeholder">VE</span>
+          </div>
+          <div class="tcard__body">
+            <div class="tcard__name">VJ Edgecombe</div>
+            <div class="tcard__meta">SG · Baylor<span class="dot"></span>2026</div>
+            <div class="tcard__buzz">
+              <div class="tcard__buzzCount"><span class="num">18</span><span class="lbl">mentions</span></div>
+              <svg class="tcard__sparkline" viewBox="0 0 100 22" preserveAspectRatio="none">
+                <polyline points="2,4 18,8 34,10 50,14 66,16 82,18 98,20"
+                          fill="none" stroke="var(--color-accent-rose)" stroke-width="1.5"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </div>
+            <div class="tcard__tagRow">
+              <span class="tcard__tag tcard__tag--scout">Mostly Scouting</span>
+            </div>
+          </div>
+        </a>
+
+        <a href="#" class="tcard tcard--compact">
+          <span class="tcard__rank">#6</span>
+          <div class="tcard__left">
+            <img class="tcard__photo" src="https://placehold.co/64x64/e2e8f0/64748b?text=TJ" alt="Tre Johnson">
+          </div>
+          <div class="tcard__body">
+            <div class="tcard__name">Tre Johnson</div>
+            <div class="tcard__meta">SG · Texas<span class="dot"></span>2026</div>
+            <div class="tcard__buzz">
+              <div class="tcard__buzzCount"><span class="num">13</span><span class="lbl">mentions</span></div>
+              <svg class="tcard__sparkline" viewBox="0 0 100 22" preserveAspectRatio="none">
+                <polyline points="2,12 18,14 34,10 50,8 66,12 82,6 98,8"
+                          fill="none" stroke="var(--color-accent-emerald)" stroke-width="1.5"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </div>
+            <div class="tcard__tagRow">
+              <span class="tcard__tag tcard__tag--mock">Mostly Mock Draft</span>
+            </div>
+          </div>
+        </a>
+
+        <a href="#" class="tcard tcard--compact">
+          <span class="tcard__rank">#7</span>
+          <div class="tcard__left">
+            <img class="tcard__photo" src="https://placehold.co/64x64/e2e8f0/64748b?text=LK" alt="Liam McNeeley">
+          </div>
+          <div class="tcard__body">
+            <div class="tcard__name">Liam McNeeley</div>
+            <div class="tcard__meta">SF · UConn<span class="dot"></span>2026</div>
+            <div class="tcard__buzz">
+              <div class="tcard__buzzCount"><span class="num">11</span><span class="lbl">mentions</span></div>
+              <svg class="tcard__sparkline" viewBox="0 0 100 22" preserveAspectRatio="none">
+                <polyline points="2,8 18,10 34,12 50,14 66,12 82,16 98,18"
+                          fill="none" stroke="var(--color-slate-400)" stroke-width="1.5"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </div>
+            <div class="tcard__tagRow">
+              <span class="tcard__tag tcard__tag--scout">Mostly Scouting</span>
+            </div>
+          </div>
+        </a>
+
+        <a href="#" class="tcard tcard--compact">
+          <span class="tcard__rank">#8</span>
+          <div class="tcard__left">
+            <img class="tcard__photo" src="https://placehold.co/64x64/e2e8f0/64748b?text=BB" alt="Boogie Fland">
+          </div>
+          <div class="tcard__body">
+            <div class="tcard__name">Boogie Fland</div>
+            <div class="tcard__meta">PG · Arkansas<span class="dot"></span>2026</div>
+            <div class="tcard__buzz">
+              <div class="tcard__buzzCount"><span class="num">9</span><span class="lbl">mentions</span></div>
+              <svg class="tcard__sparkline" viewBox="0 0 100 22" preserveAspectRatio="none">
+                <polyline points="2,18 18,16 34,18 50,14 66,10 82,8 98,6"
+                          fill="none" stroke="var(--color-accent-emerald)" stroke-width="1.5"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </div>
+            <div class="tcard__tagRow">
+              <span class="tcard__tag tcard__tag--film">Mostly Film Study</span>
+            </div>
+          </div>
+        </a>
+
+        <a href="#" class="tcard tcard--compact">
+          <span class="tcard__rank">#9</span>
+          <div class="tcard__left">
+            <img class="tcard__photo" src="https://placehold.co/64x64/e2e8f0/64748b?text=KH" alt="Kasparas Jakucionis">
+          </div>
+          <div class="tcard__body">
+            <div class="tcard__name">Kasparas Jakucionis</div>
+            <div class="tcard__meta">PG · Illinois<span class="dot"></span>2026</div>
+            <div class="tcard__buzz">
+              <div class="tcard__buzzCount"><span class="num">8</span><span class="lbl">mentions</span></div>
+              <svg class="tcard__sparkline" viewBox="0 0 100 22" preserveAspectRatio="none">
+                <polyline points="2,12 18,12 34,14 50,10 66,12 82,10 98,8"
+                          fill="none" stroke="var(--color-slate-400)" stroke-width="1.5"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </div>
+            <div class="tcard__tagRow">
+              <span class="tcard__tag tcard__tag--bigboard">Mostly Big Board</span>
+            </div>
+          </div>
+        </a>
+
+        <a href="#" class="tcard tcard--compact">
+          <span class="tcard__rank">#10</span>
+          <div class="tcard__left">
+            <img class="tcard__photo" src="https://placehold.co/64x64/e2e8f0/64748b?text=DR" alt="Derik Queen">
+          </div>
+          <div class="tcard__body">
+            <div class="tcard__name">Derik Queen</div>
+            <div class="tcard__meta">C · Maryland<span class="dot"></span>2026</div>
+            <div class="tcard__buzz">
+              <div class="tcard__buzzCount"><span class="num">7</span><span class="lbl">mentions</span></div>
+              <svg class="tcard__sparkline" viewBox="0 0 100 22" preserveAspectRatio="none">
+                <polyline points="2,14 18,12 34,16 50,12 66,14 82,12 98,10"
+                          fill="none" stroke="var(--color-slate-400)" stroke-width="1.5"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </div>
+            <div class="tcard__tagRow">
+              <span class="tcard__tag tcard__tag--mock">Mostly Mock Draft</span>
+            </div>
+          </div>
+        </a>
+
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/tests/integration/test_expanded_trending.py
+++ b/tests/integration/test_expanded_trending.py
@@ -1,0 +1,420 @@
+"""Integration tests for the expanded trending-players service.
+
+These tests exercise the eligibility gates and tier-split logic that
+``get_expanded_trending_players`` layers on top of the base trending feed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.fields import CohortType
+from app.schemas.image_snapshots import PlayerImageAsset, PlayerImageSnapshot
+from app.schemas.news_items import NewsItemTag
+from app.schemas.news_sources import NewsSource
+from app.schemas.player_college_stats import PlayerCollegeStats
+from app.schemas.player_content_mentions import (
+    ContentType,
+    MentionSource,
+    PlayerContentMention,
+)
+from app.schemas.player_status import PlayerStatus
+from app.schemas.players_master import PlayerMaster
+from app.schemas.positions import Position
+from app.services.expanded_trending_service import (
+    FEATURED_TARGET,
+    MIN_FEATURED_MENTIONS,
+    get_expanded_trending_players,
+)
+from tests.integration.conftest import make_article, make_player
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers
+# ---------------------------------------------------------------------------
+
+
+async def _ensure_position(db: AsyncSession, code: str) -> Position:
+    existing = await db.execute(
+        select(Position).where(Position.code == code)  # type: ignore[arg-type]
+    )
+    pos = existing.scalars().first()
+    if pos is not None:
+        return pos
+    pos = Position(code=code)
+    db.add(pos)
+    await db.flush()
+    return pos
+
+
+async def _ensure_image_snapshot(db: AsyncSession) -> PlayerImageSnapshot:
+    existing = await db.execute(
+        select(PlayerImageSnapshot).where(
+            PlayerImageSnapshot.run_key == "test_run",  # type: ignore[arg-type]
+            PlayerImageSnapshot.style == "default",  # type: ignore[arg-type]
+        )
+    )
+    snap = existing.scalars().first()
+    if snap is not None:
+        return snap
+    snap = PlayerImageSnapshot(
+        run_key="test_run",
+        version=1,
+        is_current=True,
+        style="default",
+        cohort=CohortType.current_draft,
+        image_size="1K",
+        system_prompt="test prompt",
+    )
+    db.add(snap)
+    await db.flush()
+    return snap
+
+
+async def _seed_player(
+    db: AsyncSession,
+    news_source: NewsSource,
+    *,
+    first_name: str,
+    last_name: str = "Player",
+    school: Optional[str] = "Test University",
+    position_code: Optional[str] = "PG",
+    ppg: Optional[float] = 18.0,
+    is_stub: bool = False,
+    mention_count: int = MIN_FEATURED_MENTIONS + 1,
+    has_photo: bool = True,
+    article_tag: NewsItemTag = NewsItemTag.MOCK_DRAFT,
+) -> PlayerMaster:
+    """Seed a player with knobs to break individual eligibility gates."""
+    player = make_player(first_name, last_name, school=school)
+    player.is_stub = is_stub
+    db.add(player)
+    await db.flush()
+    pid = player.id
+    assert pid is not None
+
+    if position_code is not None:
+        position = await _ensure_position(db, position_code)
+        db.add(PlayerStatus(player_id=pid, position_id=position.id))
+
+    if ppg is not None:
+        db.add(
+            PlayerCollegeStats(
+                player_id=pid,
+                season="2024-25",
+                games=30,
+                mpg=32.0,
+                ppg=ppg,
+                rpg=5.5,
+                apg=3.4,
+                fg_pct=46.2,
+                three_p_pct=37.5,
+                ft_pct=78.0,
+            )
+        )
+
+    if has_photo:
+        snap = await _ensure_image_snapshot(db)
+        db.add(
+            PlayerImageAsset(
+                snapshot_id=snap.id,
+                player_id=pid,
+                s3_key=f"players/{pid}_{first_name.lower()}_default.png",
+                public_url=f"https://cdn.test/{pid}.png",
+                user_prompt="test",
+            )
+        )
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    for i in range(mention_count):
+        article = make_article(
+            news_source.id,  # type: ignore[arg-type]
+            f"art-{pid}-{i}",
+            hours_ago=i,
+        )
+        article.tag = article_tag
+        db.add(article)
+        await db.flush()
+        db.add(
+            PlayerContentMention(
+                content_type=ContentType.NEWS,
+                content_id=article.id,  # type: ignore[arg-type]
+                player_id=pid,
+                published_at=article.published_at,
+                source=MentionSource.AI,
+                created_at=now,
+            )
+        )
+
+    await db.flush()
+    return player
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestGetExpandedTrendingPlayers:
+    """Eligibility gates and tier-split logic."""
+
+    async def test_empty_when_no_trending_data(
+        self, db_session: AsyncSession
+    ) -> None:
+        """No mentions in the window -> empty featured + compact lists."""
+        result = await get_expanded_trending_players(db_session)
+        assert result.featured == []
+        assert result.compact == []
+        assert result.is_empty
+
+    async def test_fully_populated_player_lands_in_featured(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """A player satisfying every required gate must show up as featured."""
+        await _seed_player(
+            db_session, news_source, first_name="Cooper", last_name="Flagg"
+        )
+        # Need at least FEATURED_FLOOR (2) eligible to keep the featured row.
+        await _seed_player(
+            db_session, news_source, first_name="Dylan", last_name="Harper"
+        )
+        await db_session.commit()
+
+        result = await get_expanded_trending_players(db_session)
+        assert len(result.featured) == 2
+        assert {p.display_name for p in result.featured} == {
+            "Cooper Flagg",
+            "Dylan Harper",
+        }
+        flagg = next(p for p in result.featured if p.display_name == "Cooper Flagg")
+        assert flagg.position == "PG"
+        assert flagg.school == "Test University"
+        assert flagg.photo_url.startswith("https://cdn.test/")
+        assert flagg.latest_stats.ppg == pytest.approx(18.0)
+        assert flagg.dominant_news_tag == NewsItemTag.MOCK_DRAFT.value
+        assert flagg.content_mix["news"] >= MIN_FEATURED_MENTIONS
+
+    async def test_missing_photo_demotes_to_compact(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """No PlayerImageAsset row -> player must not be featured."""
+        await _seed_player(
+            db_session,
+            news_source,
+            first_name="NoPhoto",
+            has_photo=False,
+        )
+        # Two eligible companions so the floor rule doesn't override.
+        await _seed_player(
+            db_session, news_source, first_name="Eligible", last_name="One"
+        )
+        await _seed_player(
+            db_session, news_source, first_name="Eligible", last_name="Two"
+        )
+        await db_session.commit()
+
+        result = await get_expanded_trending_players(db_session)
+        featured_names = {p.display_name for p in result.featured}
+        compact_names = {p.display_name for p in result.compact}
+        assert "NoPhoto Player" not in featured_names
+        assert "NoPhoto Player" in compact_names
+
+    async def test_missing_college_ppg_demotes_to_compact(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """No latest college-stats row with PPG -> demoted."""
+        await _seed_player(
+            db_session,
+            news_source,
+            first_name="NoStats",
+            ppg=None,  # skip seeding the college stats row entirely
+        )
+        await _seed_player(
+            db_session, news_source, first_name="Eligible", last_name="One"
+        )
+        await _seed_player(
+            db_session, news_source, first_name="Eligible", last_name="Two"
+        )
+        await db_session.commit()
+
+        result = await get_expanded_trending_players(db_session)
+        compact_names = {p.display_name for p in result.compact}
+        assert "NoStats Player" in compact_names
+
+    async def test_missing_position_demotes_to_compact(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """No PlayerStatus / position row -> demoted."""
+        await _seed_player(
+            db_session,
+            news_source,
+            first_name="NoPos",
+            position_code=None,
+        )
+        await _seed_player(
+            db_session, news_source, first_name="Eligible", last_name="One"
+        )
+        await _seed_player(
+            db_session, news_source, first_name="Eligible", last_name="Two"
+        )
+        await db_session.commit()
+
+        result = await get_expanded_trending_players(db_session)
+        compact_names = {p.display_name for p in result.compact}
+        assert "NoPos Player" in compact_names
+
+    async def test_missing_school_demotes_to_compact(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """Empty school field on PlayerMaster -> demoted."""
+        await _seed_player(
+            db_session, news_source, first_name="NoSchool", school=None
+        )
+        await _seed_player(
+            db_session, news_source, first_name="Eligible", last_name="One"
+        )
+        await _seed_player(
+            db_session, news_source, first_name="Eligible", last_name="Two"
+        )
+        await db_session.commit()
+
+        result = await get_expanded_trending_players(db_session)
+        compact_names = {p.display_name for p in result.compact}
+        assert "NoSchool Player" in compact_names
+
+    async def test_stub_player_demotes_to_compact(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """is_stub=True -> demoted regardless of other fields."""
+        # is_stub players also need a real last_name to pass the base
+        # high-quality filter inside get_trending_players.
+        await _seed_player(
+            db_session, news_source, first_name="Stubbed", last_name="Stub", is_stub=True
+        )
+        await _seed_player(
+            db_session, news_source, first_name="Eligible", last_name="One"
+        )
+        await _seed_player(
+            db_session, news_source, first_name="Eligible", last_name="Two"
+        )
+        await db_session.commit()
+
+        result = await get_expanded_trending_players(db_session)
+        featured_names = {p.display_name for p in result.featured}
+        assert "Stubbed Stub" not in featured_names
+
+    async def test_insufficient_mentions_demotes_to_compact(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """Below MIN_FEATURED_MENTIONS -> demoted even if everything else is fine."""
+        await _seed_player(
+            db_session,
+            news_source,
+            first_name="QuietBuzz",
+            mention_count=MIN_FEATURED_MENTIONS - 1,
+        )
+        await _seed_player(
+            db_session, news_source, first_name="Eligible", last_name="One"
+        )
+        await _seed_player(
+            db_session, news_source, first_name="Eligible", last_name="Two"
+        )
+        await db_session.commit()
+
+        result = await get_expanded_trending_players(db_session)
+        featured_names = {p.display_name for p in result.featured}
+        compact_names = {p.display_name for p in result.compact}
+        assert "QuietBuzz Player" not in featured_names
+        assert "QuietBuzz Player" in compact_names
+
+    async def test_floor_rule_demotes_all_when_too_few_qualify(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """Fewer than FEATURED_FLOOR eligible -> hide featured row entirely."""
+        # One eligible player; one obviously demoted player to keep some volume.
+        await _seed_player(
+            db_session, news_source, first_name="OnlyOne", last_name="Eligible"
+        )
+        await _seed_player(
+            db_session,
+            news_source,
+            first_name="NoPhoto",
+            last_name="Player",
+            has_photo=False,
+        )
+        await db_session.commit()
+
+        result = await get_expanded_trending_players(db_session)
+        assert result.featured == []
+        compact_names = {p.display_name for p in result.compact}
+        assert "OnlyOne Eligible" in compact_names
+        assert "NoPhoto Player" in compact_names
+
+    async def test_featured_caps_at_target_with_overflow_in_compact(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """If 6 players qualify, only FEATURED_TARGET land in featured."""
+        eligible_count = FEATURED_TARGET + 2
+        # Stagger mention counts so trending order is deterministic.
+        for i in range(eligible_count):
+            await _seed_player(
+                db_session,
+                news_source,
+                first_name=f"P{i}",
+                last_name="Eligible",
+                mention_count=MIN_FEATURED_MENTIONS + (eligible_count - i),
+            )
+        await db_session.commit()
+
+        result = await get_expanded_trending_players(db_session)
+        assert len(result.featured) == FEATURED_TARGET
+        # Featured rank pills should reflect actual mention rank (1..N).
+        assert [p.rank for p in result.featured] == list(range(1, FEATURED_TARGET + 1))
+        # Overflow lands in compact at their actual ranks.
+        compact_ranks = sorted(p.rank for p in result.compact)
+        assert compact_ranks[: 2] == [FEATURED_TARGET + 1, FEATURED_TARGET + 2]
+
+    async def test_featured_skips_demoted_player_to_keep_target_count(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """A sparse player at rank 2 should be passed over and a later player promoted.
+
+        Demonstrates the design where featured cards keep their actual mention
+        rank pills (e.g. #1, #3, #4, #5 if #2 was demoted).
+        """
+        # Rank 1 and 3+ eligible, rank 2 missing photo.
+        await _seed_player(
+            db_session,
+            news_source,
+            first_name="Rank1",
+            last_name="Eligible",
+            mention_count=10,
+        )
+        await _seed_player(
+            db_session,
+            news_source,
+            first_name="Rank2",
+            last_name="NoPhoto",
+            mention_count=8,
+            has_photo=False,
+        )
+        await _seed_player(
+            db_session,
+            news_source,
+            first_name="Rank3",
+            last_name="Eligible",
+            mention_count=7,
+        )
+        await db_session.commit()
+
+        result = await get_expanded_trending_players(db_session)
+        featured_ranks = sorted(p.rank for p in result.featured)
+        assert featured_ranks == [1, 3]
+        compact_ranks = sorted(p.rank for p in result.compact)
+        assert compact_ranks == [2]

--- a/tests/integration/test_expanded_trending.py
+++ b/tests/integration/test_expanded_trending.py
@@ -6,15 +6,21 @@ These tests exercise the eligibility gates and tier-split logic that
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Optional
 
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.fields import CohortType
+from app.models.fields import (
+    CohortType,
+    MetricCategory,
+    MetricSource,
+    MetricStatistic,
+)
 from app.schemas.image_snapshots import PlayerImageAsset, PlayerImageSnapshot
+from app.schemas.metrics import MetricDefinition, MetricSnapshot, PlayerMetricValue
 from app.schemas.news_items import NewsItemTag
 from app.schemas.news_sources import NewsSource
 from app.schemas.player_college_stats import PlayerCollegeStats
@@ -26,6 +32,7 @@ from app.schemas.player_content_mentions import (
 from app.schemas.player_status import PlayerStatus
 from app.schemas.players_master import PlayerMaster
 from app.schemas.positions import Position
+from app.schemas.seasons import Season
 from app.services.expanded_trending_service import (
     FEATURED_TARGET,
     MIN_FEATURED_MENTIONS,
@@ -89,10 +96,12 @@ async def _seed_player(
     mention_count: int = MIN_FEATURED_MENTIONS + 1,
     has_photo: bool = True,
     article_tag: NewsItemTag = NewsItemTag.MOCK_DRAFT,
+    draft_year: Optional[int] = 2025,
 ) -> PlayerMaster:
     """Seed a player with knobs to break individual eligibility gates."""
     player = make_player(first_name, last_name, school=school)
     player.is_stub = is_stub
+    player.draft_year = draft_year
     db.add(player)
     await db.flush()
     pid = player.id
@@ -153,6 +162,71 @@ async def _seed_player(
 
     await db.flush()
     return player
+
+
+async def _seed_combine_overall_definition(db: AsyncSession) -> MetricDefinition:
+    existing = await db.execute(
+        select(MetricDefinition).where(
+            MetricDefinition.metric_key == "combine_score_overall"  # type: ignore[arg-type]
+        )
+    )
+    defn = existing.scalars().first()
+    if defn is not None:
+        return defn
+    defn = MetricDefinition(
+        metric_key="combine_score_overall",
+        display_name="Combine Score (Overall)",
+        source=MetricSource.combine_score,
+        statistic=MetricStatistic.percentile,
+        category=MetricCategory.combine_overall,
+    )
+    db.add(defn)
+    await db.flush()
+    return defn
+
+
+async def _seed_season_and_snapshot(
+    db: AsyncSession, *, start_year: int, end_year: int
+) -> tuple[Season, MetricSnapshot]:
+    season = Season(
+        code=f"{start_year}-{str(end_year)[-2:]}",
+        start_year=start_year,
+        end_year=end_year,
+    )
+    db.add(season)
+    await db.flush()
+
+    snapshot = MetricSnapshot(
+        run_key=f"combine_test_{start_year}",
+        cohort=CohortType.current_draft,
+        season_id=season.id,
+        source=MetricSource.combine_score,
+        population_size=10,
+        version=1,
+        is_current=True,
+    )
+    db.add(snapshot)
+    await db.flush()
+    return season, snapshot
+
+
+async def _seed_pmv(
+    db: AsyncSession,
+    *,
+    player_id: int,
+    snapshot_id: int,
+    metric_definition_id: int,
+    percentile: float,
+) -> None:
+    db.add(
+        PlayerMetricValue(
+            player_id=player_id,
+            snapshot_id=snapshot_id,
+            metric_definition_id=metric_definition_id,
+            percentile=percentile,
+        )
+    )
+    await db.flush()
 
 
 # ---------------------------------------------------------------------------
@@ -418,3 +492,108 @@ class TestGetExpandedTrendingPlayers:
         assert featured_ranks == [1, 3]
         compact_ranks = sorted(p.rank for p in result.compact)
         assert compact_ranks == [2]
+
+    async def test_combine_grade_is_scoped_to_player_draft_year_snapshot(
+        self, db_session: AsyncSession, news_source: NewsSource
+    ) -> None:
+        """Each player's combine grade must come from *their* draft-year snapshot.
+
+        Regression test for a bug where ``_load_combine_grades`` queried
+        ``PlayerMetricValue`` with ``snapshot_id IN (all_snapshots)`` and
+        ``player_id IN (all_players)`` without enforcing the (player, snapshot)
+        pairing — so a stale row from the wrong season could leak into a
+        player's grade, and a player without a draft year could pick up a
+        grade from any snapshot they had a row in.
+        """
+        # Two seasons with their own current combine snapshots.
+        _, snap_2024 = await _seed_season_and_snapshot(
+            db_session, start_year=2024, end_year=2025
+        )
+        _, snap_2025 = await _seed_season_and_snapshot(
+            db_session, start_year=2025, end_year=2026
+        )
+        defn = await _seed_combine_overall_definition(db_session)
+
+        # Player A drafts in 2024 → should get the 2024 grade only.
+        player_a = await _seed_player(
+            db_session,
+            news_source,
+            first_name="DraftA",
+            last_name="Player",
+            draft_year=2024,
+        )
+        # Player B drafts in 2025 → should get the 2025 grade only.
+        player_b = await _seed_player(
+            db_session,
+            news_source,
+            first_name="DraftB",
+            last_name="Player",
+            draft_year=2025,
+        )
+        # Player C has no draft year → must NOT get a grade even if a stale
+        # PMV row exists in some snapshot.
+        player_c = await _seed_player(
+            db_session,
+            news_source,
+            first_name="NoYear",
+            last_name="Player",
+            draft_year=None,
+        )
+
+        assert player_a.id is not None
+        assert player_b.id is not None
+        assert player_c.id is not None
+        assert snap_2024.id is not None
+        assert snap_2025.id is not None
+        assert defn.id is not None
+
+        # Player A: correct row in 2024 (percentile 92 → A) AND a stale row
+        # in 2025 (percentile 30 → C). The stale row must not be picked up.
+        await _seed_pmv(
+            db_session,
+            player_id=player_a.id,
+            snapshot_id=snap_2024.id,
+            metric_definition_id=defn.id,
+            percentile=92.0,
+        )
+        await _seed_pmv(
+            db_session,
+            player_id=player_a.id,
+            snapshot_id=snap_2025.id,
+            metric_definition_id=defn.id,
+            percentile=30.0,
+        )
+        # Player B: only their correct 2025 row.
+        await _seed_pmv(
+            db_session,
+            player_id=player_b.id,
+            snapshot_id=snap_2025.id,
+            metric_definition_id=defn.id,
+            percentile=55.0,
+        )
+        # Player C: a stale row in 2024 — must be ignored since C has no draft year.
+        await _seed_pmv(
+            db_session,
+            player_id=player_c.id,
+            snapshot_id=snap_2024.id,
+            metric_definition_id=defn.id,
+            percentile=99.0,
+        )
+        await db_session.commit()
+
+        result = await get_expanded_trending_players(db_session)
+        by_name = {p.display_name: p for p in result.featured}
+        assert "DraftA Player" in by_name, "Player A should be featured"
+        assert "DraftB Player" in by_name, "Player B should be featured"
+        assert "NoYear Player" in by_name, "Player C should still be featured"
+
+        # 92.0 → "A" (>= 85), 55.0 → "B" (>= 50). See grade_letter().
+        # The 30.0 stale row for Player A in the 2025 snapshot would map to
+        # "B-" (>= 35) — its absence here proves the fix is working.
+        assert by_name["DraftA Player"].combine_grade == "A"
+        assert by_name["DraftB Player"].combine_grade == "B"
+
+        # Player C is featured (other gates pass) but must not pick up a grade
+        # since they have no draft year, even though a stale PMV row exists
+        # for them in the 2024 snapshot. Combine grade is optional, not a gate.
+        assert by_name["NoYear Player"].combine_grade is None

--- a/tests/unit/test_expanded_trending_spike.py
+++ b/tests/unit/test_expanded_trending_spike.py
@@ -1,0 +1,57 @@
+"""Unit tests for the trailing-window spike classifier."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.expanded_trending_service import _compute_spike_state
+
+
+class TestComputeSpikeState:
+    """Verify Hot / Cooling / neutral classifications."""
+
+    def test_returns_none_for_empty_series(self) -> None:
+        assert _compute_spike_state([]) is None
+
+    def test_returns_none_for_short_series(self) -> None:
+        # Service expects a 7-day series (one entry per day in window).
+        assert _compute_spike_state([1, 2, 3]) is None
+
+    def test_returns_hot_when_recent_rate_exceeds_prior_by_50pct(self) -> None:
+        # Prior 5 days avg = 1; last 2 days avg = 2 -> ratio 2.0
+        counts = [1, 1, 1, 1, 1, 2, 2]
+        assert _compute_spike_state(counts) == "hot"
+
+    def test_returns_cooling_when_recent_rate_drops_below_half(self) -> None:
+        # Prior 5 days avg = 4; last 2 days avg = 1 -> ratio 0.25
+        counts = [4, 4, 4, 4, 4, 1, 1]
+        assert _compute_spike_state(counts) == "cooling"
+
+    def test_returns_none_when_change_is_modest(self) -> None:
+        counts = [3, 3, 3, 3, 3, 3, 4]  # ratio ~1.17
+        assert _compute_spike_state(counts) is None
+
+    def test_handles_zero_prior_history_with_strong_recent_burst(self) -> None:
+        # No prior activity, but a clear burst in the last 2 days.
+        counts = [0, 0, 0, 0, 0, 2, 2]
+        assert _compute_spike_state(counts) == "hot"
+
+    def test_handles_zero_prior_history_without_meaningful_burst(self) -> None:
+        # No prior activity and only a single mention recently -> stay neutral.
+        counts = [0, 0, 0, 0, 0, 1, 1]
+        assert _compute_spike_state(counts) is None
+
+    def test_zero_everywhere_is_neutral(self) -> None:
+        assert _compute_spike_state([0, 0, 0, 0, 0, 0, 0]) is None
+
+    @pytest.mark.parametrize(
+        "counts,expected",
+        [
+            ([2, 2, 2, 2, 2, 3, 3], "hot"),  # ratio 1.5 exactly -> hot
+            ([2, 2, 2, 2, 2, 1, 1], "cooling"),  # ratio 0.5 exactly -> cooling
+        ],
+    )
+    def test_thresholds_are_inclusive(
+        self, counts: list[int], expected: str
+    ) -> None:
+        assert _compute_spike_state(counts) == expected

--- a/tests/visual/test_homepage.py
+++ b/tests/visual/test_homepage.py
@@ -29,8 +29,10 @@ class TestHomepageStructure:
         """Verify homepage loads and key sections are visible."""
         goto("/")
 
-        # Verify Top Prospects section exists
-        expect(page.locator("#prospectsGrid")).to_be_visible()
+        # Trending Players replaces the old Top Prospects grid. The section
+        # is hidden by default (display: none) and only revealed by
+        # TrendingModule when at least one player is in the payload.
+        expect(page.locator("#trendingSection")).to_be_attached()
 
         # Verify VS Arena section exists
         expect(page.locator(".h2h-card")).to_be_visible()


### PR DESCRIPTION
## Summary

Replaces the static curated **Top Prospects** grid on the homepage with an expanded **Trending Players** section that consolidates the buzz-tracking signals we already collect into a single, more informative surface.

- **Featured tier** (top 4, 2×2 on desktop): rich cards with photo, position · school · class, latest college stat strip (PPG / RPG / APG / 3P%), combine grade letter (when available), 7-day mention sparkline, content-type mix bar (NEWS / PODCAST / VIDEO), dominant `NewsItemTag` chip, hot/cooling spike badge, and the 2 most-recent mention previews (title + source + relative time).
- **Compact tail** (next 6, 3-up grid): smaller leaderboard rows with name, sparkline, mention count, and dominant tag chip.
- **Source-of-truth design**: `mockups/draftguru_trending_v2.html` (also added in this PR).

## Featured-card eligibility (all required)

1. `is_stub = false`
2. Real photo on file (`PlayerImageAsset` row exists for the player)
3. Position present (from `PlayerStatus` joined to `Position`, falling back to `raw_position`)
4. School present on `PlayerMaster`
5. Latest `PlayerCollegeStats` row exists with non-null PPG
6. ≥ 5 mentions in the trailing 7-day window

The first 4 fully-populated players (in mention-rank order) become featured; the rest fill the compact tail. Featured cards keep their actual mention-rank pills, so `#1, #2, #3, #5` is a valid result if `#4` got demoted. If fewer than 2 players qualify the featured row is hidden entirely and all 10 trending players render as compact — that's the current state in the offseason and the correct degradation behavior.

## Changes by area

**Backend** (`app/services/expanded_trending_service.py` — new, ~745 lines)
- `get_expanded_trending_players()` walks the existing `get_trending_players()` feed and enriches each player with batched lookups: photo asset, status, college stats, combine snapshot, content-type breakdown, dominant news tag, recent mentions across all 3 content types.
- Spike state derived from `daily_counts`: `last 2-day rate / prior 5-day rate ≥ 1.5 → hot`, `≤ 0.5 → cooling`.
- Compact `grade_letter()` helper added alongside `grade_label()` for the optional combine pill.
- All tunables (`FEATURED_TARGET=4`, `FEATURED_FLOOR=2`, `MIN_FEATURED_MENTIONS=5`, `HOT_RATIO`, `COOLING_RATIO`) are module-level constants.

**Route** (`app/routes/ui.py`)
- Drops `TOP_PROSPECT_SLUGS`, the curated player loop, the `slug ↔ id` maps, and the `style` query parameter.
- Builds `featured_trending` and `compact_trending` payloads and applies `format_relative_time` to mention preview timestamps.

**Frontend** (`app/templates/home.html`, `app/static/js/home.js`, `app/static/css/home.css`)
- Removes the Top Prospects section, restructures Trending to host two grids (`#featuredTrendingGrid` + `#compactTrendingGrid`).
- Deletes `ImageUtils` and `ProspectsModule`; rewrites `TrendingModule` against the new payloads.
- Replaces `.prospect-card` and `.trending-card` styles with the v2 `.tcard` / `.tcard--compact` rules from the mockup.
- Drops obsolete window injections: `IMAGE_STYLE`, `PLAYER_ID_MAP`, `ID_TO_SLUG_MAP`, `S3_IMAGE_BASE_URL`, `PLAYERS`, `TRENDING_PLAYERS`.
- Responsive: featured collapses to 1-up below 860px; compact goes 3 → 2 → 1 across breakpoints.

## Decisions worth flagging

- **Tag chip is news-only** by design. Podcast / video tags live in different enums and unifying them would be a real product decision. The cross-content-type signal still shows up via the mix bar.
- **Combine season selection** uses `Season.start_year == player.draft_year`; if no current snapshot exists for that season the pill simply hides.
- **Real-photo gate** queries `player_image_assets` directly. Reference images on `PlayerMaster.reference_image_s3_key` and `PlayerImageAsset.reference_image_url` explicitly do not count.
- **Polymorphic mention previews**: three separate top-N-per-player queries (news / podcast / video) using `ROW_NUMBER() OVER (PARTITION BY player_id …)`, merged client-side and trimmed to 2 per player. Avoids a brittle mega-join across three tables that share no FK.

## Test plan

- [x] `make precommit` (ruff + ruff-format + mypy on staged files) — passes on every commit
- [x] `mypy app --ignore-missing-imports` — clean across 121 source files
- [x] `pytest tests/unit -q` — 240 passed (includes 10 new spike-classifier unit tests)
- [x] `pytest tests/integration/test_trending.py tests/integration/test_expanded_trending.py tests/integration/test_players.py tests/integration/test_news.py -q` — 38 passed (includes 11 new featured-eligibility integration tests covering each gate, the floor rule, and the featured-cap-with-demotion-skip)
- [x] `make visual` (`tests/visual/test_homepage.py`) — 10 passed; updated to assert on `#trendingSection` instead of the deleted `#prospectsGrid`
- [x] Manual: rendered the live homepage at desktop viewport with current production data — floor rule correctly hides featured tier (no players hit ≥5 mentions in offseason), 10 compact cards render in the 3-column grid with rank pills, sparklines, and tag chips