### PR TITLE
Add per-source relevance filter for news ingestion

### DIFF
--- a/alembic/versions/m2n3o4p5q6r7_add_news_source_is_draft_focused.py
+++ b/alembic/versions/m2n3o4p5q6r7_add_news_source_is_draft_focused.py
@@ -1,7 +1,7 @@
 """Add is_draft_focused flag to news_sources.
 
 Revision ID: m2n3o4p5q6r7
-Revises: l1m2n3o4p5q6
+Revises: 35d4c25324b3
 Create Date: 2026-05-09
 """
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op  # type: ignore[attr-defined]
 
 revision: str = "m2n3o4p5q6r7"
-down_revision: Union[str, None] = "l1m2n3o4p5q6"
+down_revision: Union[str, None] = "35d4c25324b3"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/m2n3o4p5q6r7_add_news_source_is_draft_focused.py
+++ b/alembic/versions/m2n3o4p5q6r7_add_news_source_is_draft_focused.py
@@ -1,0 +1,32 @@
+"""Add is_draft_focused flag to news_sources.
+
+Revision ID: m2n3o4p5q6r7
+Revises: l1m2n3o4p5q6
+Create Date: 2026-05-09
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "m2n3o4p5q6r7"
+down_revision: Union[str, None] = "l1m2n3o4p5q6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "news_sources",
+        sa.Column(
+            "is_draft_focused",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("news_sources", "is_draft_focused")

--- a/app/models/news.py
+++ b/app/models/news.py
@@ -41,6 +41,7 @@ class NewsSourceRead(SQLModel):
     display_name: str
     feed_type: str
     feed_url: str
+    is_draft_focused: bool = True
     is_active: bool
     fetch_interval_minutes: int
     last_fetched_at: Optional[str] = None  # ISO format string
@@ -53,6 +54,7 @@ class NewsSourceCreate(SQLModel):
     display_name: str
     feed_url: str
     feed_type: str = "rss"
+    is_draft_focused: bool = True
     fetch_interval_minutes: int = 30
 
 
@@ -62,5 +64,6 @@ class IngestionResult(SQLModel):
     sources_processed: int
     items_added: int
     items_skipped: int
+    items_filtered: int = 0
     mentions_added: int = 0
     errors: list[str]

--- a/app/routes/admin/news_sources.py
+++ b/app/routes/admin/news_sources.py
@@ -56,11 +56,14 @@ async def list_news_sources(
         parts: list[str] = []
         added = request.query_params.get("added")
         sources_count = request.query_params.get("sources")
+        filtered = request.query_params.get("filtered")
         mentions = request.query_params.get("mentions")
         if sources_count:
             parts.append(f"{sources_count} source(s)")
         if added:
             parts.append(f"{added} item(s) added")
+        if filtered:
+            parts.append(f"{filtered} filtered")
         if mentions:
             parts.append(f"{mentions} mention(s)")
         if parts:
@@ -102,6 +105,7 @@ async def ingest_news(
                 f"/admin/news-sources?success=ingested"
                 f"&added={result.items_added}"
                 f"&sources={result.sources_processed}"
+                f"&filtered={result.items_filtered}"
                 f"&mentions={result.mentions_added}"
             ),
             status_code=303,
@@ -148,6 +152,7 @@ async def create_news_source(
     feed_type: str = Form(...),
     feed_url: str = Form(...),
     is_active: str | None = Form(default=None),
+    is_draft_focused: str | None = Form(default=None),
     fetch_interval_minutes: int = Form(default=30),
     db: AsyncSession = Depends(get_session),
 ) -> Response:
@@ -202,6 +207,8 @@ async def create_news_source(
             feed_url=feed_url,
             is_active=is_active is not None
             and is_active not in {"0", "", "false", "False"},
+            is_draft_focused=is_draft_focused is not None
+            and is_draft_focused not in {"0", "", "false", "False"},
             fetch_interval_minutes=fetch_interval_minutes,
         )
         db.add(source)
@@ -256,6 +263,7 @@ async def update_news_source(
     feed_type: str = Form(...),
     feed_url: str = Form(...),
     is_active: str | None = Form(default=None),
+    is_draft_focused: str | None = Form(default=None),
     fetch_interval_minutes: int = Form(default=30),
     db: AsyncSession = Depends(get_session),
 ) -> Response:
@@ -327,6 +335,16 @@ async def update_news_source(
             "false",
             "False",
         }
+        source.is_draft_focused = (
+            is_draft_focused is not None
+            and is_draft_focused
+            not in {
+                "0",
+                "",
+                "false",
+                "False",
+            }
+        )
         source.fetch_interval_minutes = fetch_interval_minutes
         source.updated_at = datetime.now(UTC).replace(tzinfo=None)
 

--- a/app/routes/news.py
+++ b/app/routes/news.py
@@ -78,6 +78,7 @@ async def list_sources(
             display_name=source.display_name,
             feed_type=source.feed_type.value,
             feed_url=source.feed_url,
+            is_draft_focused=source.is_draft_focused,
             is_active=source.is_active,
             fetch_interval_minutes=source.fetch_interval_minutes,
             last_fetched_at=(
@@ -129,6 +130,7 @@ async def create_source(
             feed_type=feed_type,
             feed_url=source_data.feed_url,
             fetch_interval_minutes=source_data.fetch_interval_minutes,
+            is_draft_focused=source_data.is_draft_focused,
             is_active=True,
             created_at=datetime.now(UTC).replace(tzinfo=None),
             updated_at=datetime.now(UTC).replace(tzinfo=None),
@@ -142,6 +144,7 @@ async def create_source(
         display_name=source.display_name,
         feed_type=source.feed_type.value,
         feed_url=source.feed_url,
+        is_draft_focused=source.is_draft_focused,
         is_active=source.is_active,
         fetch_interval_minutes=source.fetch_interval_minutes,
         last_fetched_at=None,

--- a/app/schemas/news_sources.py
+++ b/app/schemas/news_sources.py
@@ -28,6 +28,11 @@ class NewsSource(SQLModel, table=True):  # type: ignore[call-arg]
     display_name: str  # e.g., "Floor and Ceiling"
     feed_type: FeedType = Field(default=FeedType.RSS)
     feed_url: str = Field(unique=True)  # RSS URL or API endpoint
+    is_draft_focused: bool = Field(
+        default=True,
+        sa_column_kwargs={"server_default": "true"},
+        description="When True, all items ingested without relevance checks",
+    )
     is_active: bool = Field(default=True, index=True)
     fetch_interval_minutes: int = Field(default=30)
     last_fetched_at: Optional[datetime] = Field(default=None)

--- a/app/services/news_ingestion_service.py
+++ b/app/services/news_ingestion_service.py
@@ -31,6 +31,7 @@ from app.schemas.players_master import PlayerMaster  # noqa: F401 - needed for F
 from app.services.news_service import get_active_sources
 from app.services.news_summarization_service import news_summarization_service
 from app.services.player_mention_service import resolve_player_names_as_map
+from app.utils.draft_relevance import check_keyword_relevance
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +56,7 @@ class NewsSourceSnapshot:
     name: str
     feed_type: FeedType
     feed_url: str
+    is_draft_focused: bool
 
 
 async def run_ingestion_cycle(db: AsyncSession) -> IngestionResult:
@@ -82,6 +84,7 @@ async def run_ingestion_cycle(db: AsyncSession) -> IngestionResult:
                     name=active_source.name,
                     feed_type=active_source.feed_type,
                     feed_url=active_source.feed_url,
+                    is_draft_focused=active_source.is_draft_focused,
                 )
             )
 
@@ -90,15 +93,17 @@ async def run_ingestion_cycle(db: AsyncSession) -> IngestionResult:
 
     total_added = 0
     total_skipped = 0
+    total_filtered = 0
     total_mentions = 0
     errors: list[str] = []
 
     for source in sources:
         try:
             if source.feed_type == FeedType.RSS:
-                added, skipped, mentions = await ingest_rss_source(db, source)
+                added, skipped, filtered, mentions = await ingest_rss_source(db, source)
                 total_added += added
                 total_skipped += skipped
+                total_filtered += filtered
                 total_mentions += mentions
             # Future: elif source.feed_type == FeedType.API: ...
             else:
@@ -113,13 +118,15 @@ async def run_ingestion_cycle(db: AsyncSession) -> IngestionResult:
 
     logger.info(
         f"Ingestion complete: {total_added} added, {total_skipped} skipped, "
-        f"{total_mentions} mentions, {len(errors)} error(s)"
+        f"{total_filtered} filtered, {total_mentions} mentions, "
+        f"{len(errors)} error(s)"
     )
 
     return IngestionResult(
         sources_processed=len(sources),
         items_added=total_added,
         items_skipped=total_skipped,
+        items_filtered=total_filtered,
         mentions_added=total_mentions,
         errors=errors,
     )
@@ -128,18 +135,20 @@ async def run_ingestion_cycle(db: AsyncSession) -> IngestionResult:
 async def ingest_rss_source(
     db: AsyncSession,
     source: NewsSourceSnapshot,
-) -> tuple[int, int, int]:
+) -> tuple[int, int, int, int]:
     """Fetch and process an RSS feed source.
 
     Parses the RSS feed, generates AI summaries, and inserts new items
-    with deduplication based on external_id.
+    with deduplication based on external_id.  Mixed-topic feeds (those
+    with ``is_draft_focused=False``) pass through a two-tier relevance
+    gate (keyword match → Gemini fallback) before AI analysis.
 
     Args:
         db: Async database session
         source: NewsSource record to ingest
 
     Returns:
-        Tuple of (items_added, items_skipped, mentions_added)
+        Tuple of (items_added, items_skipped, items_filtered, mentions_added)
     """
     logger.info(f"→ {source.name}")
 
@@ -148,6 +157,7 @@ async def ingest_rss_source(
 
     items_added = 0
     items_skipped = 0
+    items_filtered = 0
 
     seen_ids: set[str] = set()
     candidates: list[dict] = []
@@ -197,6 +207,17 @@ async def ingest_rss_source(
         image_url = entry.get("image_url")
         author = entry.get("author")
         published_at = entry.get("published_at", datetime.now(UTC).replace(tzinfo=None))
+
+        # Relevance gate for mixed-topic feeds: keyword pre-filter → Gemini fallback
+        if not source.is_draft_focused:
+            if not check_keyword_relevance(title, description):
+                is_relevant = await news_summarization_service.check_draft_relevance(
+                    title, description
+                )
+                if not is_relevant:
+                    items_filtered += 1
+                    logger.debug(f"  Filtered (not relevant): {title[:60]}")
+                    continue
 
         # Generate AI summary, tag, and player mentions
         mentioned_players: list[str] = []
@@ -257,9 +278,9 @@ async def ingest_rss_source(
 
     logger.info(
         f"  ✓ {source.name}: {items_added} added, {items_skipped} skipped, "
-        f"{mentions_added} mentions"
+        f"{items_filtered} filtered, {mentions_added} mentions"
     )
-    return items_added, items_skipped, mentions_added
+    return items_added, items_skipped, items_filtered, mentions_added
 
 
 async def _persist_player_mentions(

--- a/app/services/news_summarization_service.py
+++ b/app/services/news_summarization_service.py
@@ -4,6 +4,7 @@ Uses Gemini to generate compelling summaries and classify articles
 into tags (Riser, Faller, Analysis, Highlight).
 """
 
+import asyncio
 import json
 import logging
 from typing import Optional
@@ -17,6 +18,8 @@ from app.schemas.news_items import NewsItemTag
 
 logger = logging.getLogger(__name__)
 
+_GEMINI_TIMEOUT_SECONDS = 30
+
 
 class ArticleAnalysis(BaseModel):
     """Structured output from AI article analysis."""
@@ -24,6 +27,16 @@ class ArticleAnalysis(BaseModel):
     summary: str  # 1-2 sentence compelling byline
     tag: NewsItemTag  # Classification tag for the article type
     mentioned_players: list[str] = []  # Names of NBA draft prospects mentioned
+
+
+RELEVANCE_CHECK_PROMPT = """You are a sports content filter for DraftGuru, an NBA Draft analytics site.
+
+Determine whether this article is about or substantially discusses the NBA Draft, draft prospects, or college basketball players projected for the draft.
+
+Answer with valid JSON only:
+{"is_draft_relevant": true}
+or
+{"is_draft_relevant": false}"""
 
 
 # System prompt for article analysis
@@ -84,6 +97,46 @@ class NewsSummarizationService:
                 )
             self._client = genai.Client(api_key=api_key)
         return self._client
+
+    async def check_draft_relevance(self, title: str, description: str) -> bool:
+        """Check whether an article is relevant to the NBA Draft.
+
+        Lightweight Gemini call used for non-draft-focused sources after the
+        keyword pre-filter has already declined to short-circuit.
+
+        Args:
+            title: Article title.
+            description: Article description/excerpt.
+
+        Returns:
+            True when draft-relevant, False otherwise (including on error).
+        """
+        user_prompt = f"Title: {title}\n\nDescription: {description}"
+
+        try:
+            response = await asyncio.wait_for(
+                self.client.aio.models.generate_content(
+                    model="gemini-3-flash-preview",
+                    contents=types.Content(
+                        role="user",
+                        parts=[types.Part.from_text(text=user_prompt)],
+                    ),
+                    config=types.GenerateContentConfig(
+                        system_instruction=[
+                            types.Part.from_text(text=RELEVANCE_CHECK_PROMPT)
+                        ],
+                        temperature=0.1,
+                    ),
+                ),
+                timeout=_GEMINI_TIMEOUT_SECONDS,
+            )
+
+            response_text = response.text if response.text else ""
+            return _parse_relevance_response(response_text)
+
+        except Exception as e:
+            logger.error(f"Relevance check failed for '{title[:50]}': {e}")
+            return False
 
     async def analyze_article(
         self,
@@ -207,6 +260,34 @@ class NewsSummarizationService:
         return ArticleAnalysis(
             summary=summary, tag=tag, mentioned_players=mentioned_players
         )
+
+
+def _parse_relevance_response(response_text: str) -> bool:
+    """Parse a Gemini relevance response into a boolean.
+
+    Args:
+        response_text: Raw text response from Gemini.
+
+    Returns:
+        True when the JSON payload sets ``is_draft_relevant`` to a truthy
+        value, False otherwise (including unparsable input).
+    """
+    text = response_text.strip()
+    if text.startswith("```json"):
+        text = text[7:]
+    if text.startswith("```"):
+        text = text[3:]
+    if text.endswith("```"):
+        text = text[:-3]
+    text = text.strip()
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning(f"Failed to parse relevance JSON: {text[:100]}")
+        return False
+
+    return bool(data.get("is_draft_relevant", False))
 
 
 # Singleton instance for convenience

--- a/app/services/news_summarization_service.py
+++ b/app/services/news_summarization_service.py
@@ -265,12 +265,17 @@ class NewsSummarizationService:
 def _parse_relevance_response(response_text: str) -> bool:
     """Parse a Gemini relevance response into a boolean.
 
+    Strict — only the boolean ``True`` (or the case-insensitive string
+    ``"true"`` that models occasionally emit) admits an article. Quoted
+    ``"false"`` and other truthy non-True values fall back to False so
+    the gate fails closed instead of admitting irrelevant items.
+
     Args:
         response_text: Raw text response from Gemini.
 
     Returns:
-        True when the JSON payload sets ``is_draft_relevant`` to a truthy
-        value, False otherwise (including unparsable input).
+        True only for an explicit affirmative; False otherwise (including
+        on parse error).
     """
     text = response_text.strip()
     if text.startswith("```json"):
@@ -287,7 +292,12 @@ def _parse_relevance_response(response_text: str) -> bool:
         logger.warning(f"Failed to parse relevance JSON: {text[:100]}")
         return False
 
-    return bool(data.get("is_draft_relevant", False))
+    raw = data.get("is_draft_relevant")
+    if raw is True:
+        return True
+    if isinstance(raw, str) and raw.strip().lower() == "true":
+        return True
+    return False
 
 
 # Singleton instance for convenience

--- a/app/services/podcast_ingestion_service.py
+++ b/app/services/podcast_ingestion_service.py
@@ -33,6 +33,19 @@ from app.schemas.players_master import PlayerMaster  # noqa: F401 - needed for F
 from app.services.player_mention_service import resolve_player_names_as_map
 from app.services.podcast_service import get_active_shows
 from app.services.podcast_summarization_service import podcast_summarization_service
+from app.utils.draft_relevance import (
+    DRAFT_RELEVANCE_KEYWORDS,
+    check_keyword_relevance,
+)
+
+__all__ = [
+    "DRAFT_RELEVANCE_KEYWORDS",
+    "check_keyword_relevance",
+    "ingest_podcast_show",
+    "run_ingestion_cycle",
+    "fetch_podcast_rss_feed",
+    "is_channel_landing_url",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -47,25 +60,6 @@ _TRANSIENT_DB_ERROR_MARKERS = (
     "connection was closed",
     "closed in the middle of operation",
 )
-
-DRAFT_RELEVANCE_KEYWORDS = [
-    "nba draft",
-    "mock draft",
-    "draft prospect",
-    "draft board",
-    "draft pick",
-    "draft lottery",
-    "draft combine",
-    "combine",
-    "prospect",
-    "big board",
-    "draft class",
-    "draft night",
-    "lottery pick",
-    "top pick",
-    "draft stock",
-    "draft order",
-]
 
 
 @dataclass(frozen=True, slots=True)
@@ -316,23 +310,6 @@ def is_channel_landing_url(episode_url: str | None, channel_url: str | None) -> 
     if not episode_url or not channel_url:
         return False
     return _normalize_url(episode_url) == _normalize_url(channel_url)
-
-
-def check_keyword_relevance(title: str, description: str) -> bool:
-    """Check if episode title or description contains draft-related keywords.
-
-    Pure function — no API calls. Used as the first-pass relevance filter
-    before the Gemini relevance check.
-
-    Args:
-        title: Episode title
-        description: Episode description
-
-    Returns:
-        True if any draft keyword is found in title or description
-    """
-    text = f"{title} {description}".lower()
-    return any(keyword in text for keyword in DRAFT_RELEVANCE_KEYWORDS)
 
 
 async def fetch_podcast_rss_feed(url: str) -> list[dict[str, Any]]:

--- a/app/templates/admin/news-sources/form.html
+++ b/app/templates/admin/news-sources/form.html
@@ -90,6 +90,19 @@
     <div class="admin-form__checkbox-field">
       <input
         class="admin-form__checkbox"
+        id="is_draft_focused"
+        name="is_draft_focused"
+        type="checkbox"
+        value="1"
+        {% if not source or source.is_draft_focused %}checked{% endif %}
+      />
+      <label class="admin-form__checkbox-label" for="is_draft_focused">Draft Focused</label>
+      <span class="admin-form__help">When checked, all items are ingested without relevance filtering. Uncheck for mixed-topic feeds (e.g., Silver Bulletin) so non-draft articles are dropped.</span>
+    </div>
+
+    <div class="admin-form__checkbox-field">
+      <input
+        class="admin-form__checkbox"
         id="is_active"
         name="is_active"
         type="checkbox"

--- a/app/templates/admin/news-sources/index.html
+++ b/app/templates/admin/news-sources/index.html
@@ -31,6 +31,7 @@
         <th>Name</th>
         <th>Type</th>
         <th>Status</th>
+        <th>Filtering</th>
         <th>Interval</th>
         <th>Last Fetched</th>
         <th>Actions</th>
@@ -51,6 +52,13 @@
           <span class="admin-badge admin-badge--active">Active</span>
           {% else %}
           <span class="admin-badge admin-badge--inactive">Inactive</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if source.is_draft_focused %}
+          <span class="admin-badge admin-badge--inactive">All-In</span>
+          {% else %}
+          <span class="admin-badge admin-badge--active">Filtered</span>
           {% endif %}
         </td>
         <td>{{ source.fetch_interval_minutes }} min</td>

--- a/app/utils/draft_relevance.py
+++ b/app/utils/draft_relevance.py
@@ -1,0 +1,45 @@
+"""Shared draft-relevance helpers for content ingestion.
+
+Used by news, podcast, and video ingestion to short-circuit a Gemini
+relevance check when a title or description already contains an obvious
+draft-related keyword.
+"""
+
+from __future__ import annotations
+
+DRAFT_RELEVANCE_KEYWORDS: tuple[str, ...] = (
+    "nba draft",
+    "mock draft",
+    "draft prospect",
+    "draft board",
+    "draft pick",
+    "draft lottery",
+    "draft combine",
+    "combine",
+    "prospect",
+    "big board",
+    "draft class",
+    "draft night",
+    "lottery pick",
+    "top pick",
+    "draft stock",
+    "draft order",
+)
+
+
+def check_keyword_relevance(title: str, description: str) -> bool:
+    """Return True if title or description contains any draft-related keyword.
+
+    Pure substring match against ``DRAFT_RELEVANCE_KEYWORDS``. Used as the
+    first-pass filter before falling back to a Gemini relevance call for
+    mixed-topic feeds.
+
+    Args:
+        title: Item title.
+        description: Item description.
+
+    Returns:
+        True if any draft keyword is found in either field.
+    """
+    text = f"{title} {description}".lower()
+    return any(keyword in text for keyword in DRAFT_RELEVANCE_KEYWORDS)

--- a/tests/integration/test_admin_crud_news_sources.py
+++ b/tests/integration/test_admin_crud_news_sources.py
@@ -192,6 +192,68 @@ class TestNewsSourcesCreate:
         )
         assert result.scalar_one() == "new-source"
 
+    async def test_create_with_is_draft_focused_unchecked(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_user_id: int,
+    ):
+        """Unchecked is_draft_focused persists False (mixed-topic feed)."""
+        _ = admin_user_id
+        await login_staff(app_client, email=ADMIN_EMAIL, password=ADMIN_PASSWORD)
+
+        response = await app_client.post(
+            "/admin/news-sources",
+            data={
+                "name": "silver-bulletin",
+                "display_name": "Silver Bulletin",
+                "feed_type": "rss",
+                "feed_url": "https://example.com/silver.xml",
+                "is_active": "1",
+                "fetch_interval_minutes": "60",
+                # is_draft_focused intentionally omitted (unchecked checkbox)
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code in {302, 303}
+
+        result = await db_session.execute(
+            text(
+                "SELECT is_draft_focused FROM news_sources WHERE name = 'silver-bulletin'"
+            )
+        )
+        assert result.scalar_one() is False
+
+    async def test_create_with_is_draft_focused_checked(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_user_id: int,
+    ):
+        """Checked is_draft_focused persists True (default for draft-only feeds)."""
+        _ = admin_user_id
+        await login_staff(app_client, email=ADMIN_EMAIL, password=ADMIN_PASSWORD)
+
+        response = await app_client.post(
+            "/admin/news-sources",
+            data={
+                "name": "draft-only",
+                "display_name": "Draft Only",
+                "feed_type": "rss",
+                "feed_url": "https://example.com/draft-only.xml",
+                "is_active": "1",
+                "is_draft_focused": "1",
+                "fetch_interval_minutes": "60",
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code in {302, 303}
+
+        result = await db_session.execute(
+            text("SELECT is_draft_focused FROM news_sources WHERE name = 'draft-only'")
+        )
+        assert result.scalar_one() is True
+
     async def test_create_duplicate_url_error(
         self,
         app_client: AsyncClient,
@@ -285,6 +347,38 @@ class TestNewsSourcesEdit:
         row = result.one()
         assert row[0] == "updated-source"
         assert row[1] == 45
+
+    async def test_update_toggles_is_draft_focused_off(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_user_id: int,
+        sample_source_id: int,
+    ):
+        """Submitting without is_draft_focused flips an existing source to False."""
+        _ = admin_user_id
+        await login_staff(app_client, email=ADMIN_EMAIL, password=ADMIN_PASSWORD)
+
+        response = await app_client.post(
+            f"/admin/news-sources/{sample_source_id}",
+            data={
+                "name": "test-source",
+                "display_name": "Test Source",
+                "feed_type": "rss",
+                "feed_url": "https://example.com/test-feed.xml",
+                "is_active": "1",
+                "fetch_interval_minutes": "30",
+                # is_draft_focused intentionally omitted
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code in {302, 303}
+
+        result = await db_session.execute(
+            text("SELECT is_draft_focused FROM news_sources WHERE id = :id"),
+            {"id": sample_source_id},
+        )
+        assert result.scalar_one() is False
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_news.py
+++ b/tests/integration/test_news.py
@@ -245,6 +245,7 @@ class TestListSources:
         assert source["feed_url"] == "https://example.com/feed"
         assert source["is_active"] is True
         assert source["fetch_interval_minutes"] == 30
+        assert source["is_draft_focused"] is True
 
 
 @pytest.mark.asyncio
@@ -286,7 +287,25 @@ class TestCreateSource:
         assert data["feed_type"] == "rss"
         assert data["is_active"] is True
         assert data["fetch_interval_minutes"] == 60
+        assert data["is_draft_focused"] is True  # default
         assert "id" in data
+
+    async def test_creates_mixed_topic_source(self, admin_client: AsyncClient):
+        """POST /api/news/sources persists is_draft_focused=False for mixed feeds."""
+        response = await admin_client.post(
+            "/api/news/sources",
+            json={
+                "name": "Silver Bulletin",
+                "display_name": "Silver Bulletin",
+                "feed_url": "https://silver.example.com/feed",
+                "feed_type": "rss",
+                "is_draft_focused": False,
+                "fetch_interval_minutes": 60,
+            },
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["is_draft_focused"] is False
 
     async def test_rejects_duplicate_feed_url(
         self,

--- a/tests/integration/test_news_ingestion_relevance.py
+++ b/tests/integration/test_news_ingestion_relevance.py
@@ -1,0 +1,280 @@
+"""Integration tests for the news ingestion relevance gate."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.news_items import NewsItem, NewsItemTag
+from app.schemas.news_sources import FeedType, NewsSource
+from app.services import news_ingestion_service
+from app.services.news_ingestion_service import (
+    NewsSourceSnapshot,
+    ingest_rss_source,
+)
+from app.services.news_summarization_service import ArticleAnalysis
+
+
+def _entry(guid: str, title: str, description: str = "") -> dict[str, Any]:
+    """Build a normalized RSS entry dict matching fetch_rss_feed output."""
+    return {
+        "title": title,
+        "description": description,
+        "link": f"https://example.com/{guid}",
+        "guid": guid,
+        "author": None,
+        "image_url": None,
+        "published_at": datetime.now(timezone.utc).replace(tzinfo=None),
+    }
+
+
+def _stub_analysis(*_args: Any, **_kwargs: Any) -> ArticleAnalysis:
+    return ArticleAnalysis(
+        summary="A summary",
+        tag=NewsItemTag.SCOUTING_REPORT,
+        mentioned_players=[],
+    )
+
+
+async def _make_source(
+    db_session: AsyncSession,
+    *,
+    name: str,
+    feed_url: str,
+    is_draft_focused: bool,
+) -> NewsSource:
+    source = NewsSource(
+        name=name,
+        display_name=name,
+        feed_type=FeedType.RSS,
+        feed_url=feed_url,
+        is_active=True,
+        fetch_interval_minutes=30,
+        is_draft_focused=is_draft_focused,
+    )
+    db_session.add(source)
+    await db_session.flush()
+    await db_session.commit()
+    assert source.id is not None
+    return source
+
+
+def _snapshot(source: NewsSource) -> NewsSourceSnapshot:
+    assert source.id is not None
+    return NewsSourceSnapshot(
+        id=source.id,
+        name=source.name,
+        feed_type=source.feed_type,
+        feed_url=source.feed_url,
+        is_draft_focused=source.is_draft_focused,
+    )
+
+
+@pytest.mark.asyncio
+class TestIngestionRelevanceGate:
+    """Tests for the per-source relevance gate in news ingestion."""
+
+    async def test_draft_focused_skips_relevance_check(
+        self,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """is_draft_focused=True skips the relevance gate entirely."""
+        source = await _make_source(
+            db_session,
+            name="draft-focused",
+            feed_url="https://example.com/df.xml",
+            is_draft_focused=True,
+        )
+
+        relevance_calls: list[tuple[str, str]] = []
+
+        async def fake_relevance(title: str, description: str) -> bool:
+            relevance_calls.append((title, description))
+            return False
+
+        async def fake_fetch(_url: str) -> list[dict[str, Any]]:
+            return [_entry("g-1", "Random topic with no draft keywords")]
+
+        monkeypatch.setattr(
+            news_ingestion_service,
+            "fetch_rss_feed",
+            fake_fetch,
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "check_draft_relevance",
+            fake_relevance,
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "analyze_article",
+            _stub_analysis,
+        )
+
+        added, skipped, filtered, mentions = await ingest_rss_source(
+            db_session, _snapshot(source)
+        )
+
+        assert relevance_calls == []
+        assert added == 1
+        assert filtered == 0
+        rows = (
+            (
+                await db_session.execute(
+                    select(NewsItem).where(NewsItem.source_id == source.id)  # type: ignore[arg-type]
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+
+    async def test_keyword_match_short_circuits_gemini(
+        self,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Keyword pre-filter alone is enough to admit an article."""
+        source = await _make_source(
+            db_session,
+            name="silver-bulletin-kw",
+            feed_url="https://example.com/sb-kw.xml",
+            is_draft_focused=False,
+        )
+
+        relevance_calls: list[tuple[str, str]] = []
+
+        async def fake_relevance(title: str, description: str) -> bool:
+            relevance_calls.append((title, description))
+            return False
+
+        async def fake_fetch(_url: str) -> list[dict[str, Any]]:
+            return [_entry("g-2", "2025 Mock Draft Update", "Latest tier moves")]
+
+        monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "check_draft_relevance",
+            fake_relevance,
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "analyze_article",
+            _stub_analysis,
+        )
+
+        added, _skipped, filtered, _mentions = await ingest_rss_source(
+            db_session, _snapshot(source)
+        )
+
+        assert relevance_calls == []  # keyword hit short-circuited Gemini
+        assert added == 1
+        assert filtered == 0
+
+    async def test_gemini_says_relevant_admits_article(
+        self,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No keyword hit + Gemini-relevant ⇒ article is admitted."""
+        source = await _make_source(
+            db_session,
+            name="silver-bulletin-pos",
+            feed_url="https://example.com/sb-pos.xml",
+            is_draft_focused=False,
+        )
+
+        async def fake_relevance(_title: str, _desc: str) -> bool:
+            return True
+
+        async def fake_fetch(_url: str) -> list[dict[str, Any]]:
+            return [_entry("g-3", "An ambiguous title", "no obvious keywords here")]
+
+        monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "check_draft_relevance",
+            fake_relevance,
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "analyze_article",
+            _stub_analysis,
+        )
+
+        added, _skipped, filtered, _mentions = await ingest_rss_source(
+            db_session, _snapshot(source)
+        )
+
+        assert added == 1
+        assert filtered == 0
+
+    async def test_gemini_says_irrelevant_filters_article(
+        self,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No keyword hit + Gemini-not-relevant ⇒ article is filtered out.
+
+        Filtered items don't reach the DB and aren't counted as added.
+        """
+        source = await _make_source(
+            db_session,
+            name="silver-bulletin-neg",
+            feed_url="https://example.com/sb-neg.xml",
+            is_draft_focused=False,
+        )
+
+        analyze_calls: list[tuple[str, str]] = []
+
+        async def fake_relevance(_title: str, _desc: str) -> bool:
+            return False
+
+        async def fake_analyze(title: str, description: str) -> ArticleAnalysis:
+            analyze_calls.append((title, description))
+            return _stub_analysis()
+
+        async def fake_fetch(_url: str) -> list[dict[str, Any]]:
+            return [
+                _entry("g-4-keep", "Mock Draft Madness", "On-topic content"),
+                _entry("g-4-drop", "Election polling deep dive", "polling models"),
+            ]
+
+        monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "check_draft_relevance",
+            fake_relevance,
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "analyze_article",
+            fake_analyze,
+        )
+
+        added, _skipped, filtered, _mentions = await ingest_rss_source(
+            db_session, _snapshot(source)
+        )
+
+        assert added == 1
+        assert filtered == 1
+        # Only the keyword-matched article should hit analyze_article
+        assert len(analyze_calls) == 1
+        assert analyze_calls[0][0] == "Mock Draft Madness"
+
+        rows = (
+            (
+                await db_session.execute(
+                    select(NewsItem).where(NewsItem.source_id == source.id)  # type: ignore[arg-type]
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].external_id == "g-4-keep"

--- a/tests/unit/test_draft_relevance.py
+++ b/tests/unit/test_draft_relevance.py
@@ -1,0 +1,53 @@
+"""Unit tests for the shared draft-relevance keyword filter."""
+
+from app.utils.draft_relevance import check_keyword_relevance
+
+
+class TestCheckKeywordRelevance:
+    """Tests for the shared keyword pre-filter used by all ingestion services."""
+
+    def test_match_title_nba_draft(self) -> None:
+        """Title containing 'nba draft' is relevant."""
+        assert check_keyword_relevance("2025 NBA Draft Preview", "") is True
+
+    def test_match_title_mock_draft(self) -> None:
+        """Title containing 'mock draft' is relevant."""
+        assert check_keyword_relevance("Our Latest Mock Draft", "") is True
+
+    def test_match_description_combine(self) -> None:
+        """Description containing 'combine' is relevant."""
+        assert (
+            check_keyword_relevance(
+                "Sports Update", "Previewing the upcoming combine results"
+            )
+            is True
+        )
+
+    def test_match_description_prospect(self) -> None:
+        """Description containing 'prospect' is relevant."""
+        assert (
+            check_keyword_relevance(
+                "Basketball Talk", "Breaking down the top prospect in college hoops"
+            )
+            is True
+        )
+
+    def test_no_match(self) -> None:
+        """Unrelated content is not relevant."""
+        assert (
+            check_keyword_relevance(
+                "Election Polls Tighten",
+                "Pollsters revisit their state-by-state models",
+            )
+            is False
+        )
+
+    def test_case_insensitive(self) -> None:
+        """Keyword matching is case insensitive."""
+        assert check_keyword_relevance("NBA DRAFT Analysis", "") is True
+        assert check_keyword_relevance("nba draft analysis", "") is True
+        assert check_keyword_relevance("Nba Draft Analysis", "") is True
+
+    def test_empty_inputs(self) -> None:
+        """Empty title and description are not relevant."""
+        assert check_keyword_relevance("", "") is False

--- a/tests/unit/test_news_summarization.py
+++ b/tests/unit/test_news_summarization.py
@@ -84,7 +84,19 @@ class TestParseRelevanceResponse:
         text = '```json\n{"is_draft_relevant": true}\n```'
         assert _parse_relevance_response(text) is True
 
-    def test_truthy_non_bool(self) -> None:
-        """Truthy non-bool values are coerced via bool()."""
-        assert _parse_relevance_response('{"is_draft_relevant": 1}') is True
+    def test_quoted_string_true_admits(self) -> None:
+        """Models sometimes emit a quoted "true"; treat it as relevant."""
+        assert _parse_relevance_response('{"is_draft_relevant": "true"}') is True
+        assert _parse_relevance_response('{"is_draft_relevant": "TRUE"}') is True
+        assert _parse_relevance_response('{"is_draft_relevant": " True "}') is True
+
+    def test_quoted_string_false_fails_closed(self) -> None:
+        """Quoted "false" is the bug guard — Python truthy bool() would admit it."""
+        assert _parse_relevance_response('{"is_draft_relevant": "false"}') is False
+        assert _parse_relevance_response('{"is_draft_relevant": "no"}') is False
+
+    def test_non_true_values_fail_closed(self) -> None:
+        """Numeric or other non-bool values are not affirmative."""
+        assert _parse_relevance_response('{"is_draft_relevant": 1}') is False
         assert _parse_relevance_response('{"is_draft_relevant": 0}') is False
+        assert _parse_relevance_response('{"is_draft_relevant": null}') is False

--- a/tests/unit/test_news_summarization.py
+++ b/tests/unit/test_news_summarization.py
@@ -1,7 +1,10 @@
 """Unit tests for the news summarization service parse logic."""
 
 from app.schemas.news_items import NewsItemTag
-from app.services.news_summarization_service import NewsSummarizationService
+from app.services.news_summarization_service import (
+    NewsSummarizationService,
+    _parse_relevance_response,
+)
 
 
 class TestParseResponse:
@@ -55,3 +58,33 @@ class TestParseResponse:
         response = '```json\n{"summary": "Test.", "tag": "Big Board", "mentioned_players": ["Cooper Flagg"]}\n```'
         result = self.service._parse_response(response)
         assert result.mentioned_players == ["Cooper Flagg"]
+
+
+class TestParseRelevanceResponse:
+    """Tests for _parse_relevance_response (Gemini relevance gate parser)."""
+
+    def test_true(self) -> None:
+        """Draft-relevant payload returns True."""
+        assert _parse_relevance_response('{"is_draft_relevant": true}') is True
+
+    def test_false(self) -> None:
+        """Non-relevant payload returns False."""
+        assert _parse_relevance_response('{"is_draft_relevant": false}') is False
+
+    def test_missing_key(self) -> None:
+        """Missing key defaults to False."""
+        assert _parse_relevance_response('{"other_key": true}') is False
+
+    def test_invalid_json(self) -> None:
+        """Invalid JSON returns False rather than raising."""
+        assert _parse_relevance_response("not json") is False
+
+    def test_markdown_code_block(self) -> None:
+        """Response wrapped in markdown fences is parsed correctly."""
+        text = '```json\n{"is_draft_relevant": true}\n```'
+        assert _parse_relevance_response(text) is True
+
+    def test_truthy_non_bool(self) -> None:
+        """Truthy non-bool values are coerced via bool()."""
+        assert _parse_relevance_response('{"is_draft_relevant": 1}') is True
+        assert _parse_relevance_response('{"is_draft_relevant": 0}') is False


### PR DESCRIPTION
## Summary
- Adds a per-source relevance gate to news ingestion so mixed-topic feeds (e.g., Silver Bulletin) can be onboarded without polluting the news feed with non-draft articles. Mirrors the pattern already in place for podcasts and YouTube.
- Two-tier filter on sources where `NewsSource.is_draft_focused = false`: cheap keyword pre-filter (shared util) → Gemini `check_draft_relevance` fallback. Filtered items skip AI analysis and never reach the DB.
- Lifts `DRAFT_RELEVANCE_KEYWORDS` + `check_keyword_relevance` out of `podcast_ingestion_service` into `app/utils/draft_relevance.py` so news, podcast, and video ingestion share one matcher.
- New `is_draft_focused` flag defaults to `True` (existing sources unchanged) and is editable via the news-sources admin form. Filtered count surfaces in the ingest banner and in `IngestionResult`.
- Alembic migration `m2n3o4p5q6r7` adds the column with `server_default=true` so existing rows backfill cleanly.

## Test plan
- [x] `pytest tests/unit -q` (253 passed)
- [x] `pytest tests/integration -q` (285 passed; one unrelated `test_expanded_trending` flake passes in isolation)
- [x] `make precommit` — ruff, ruff-format, mypy, transaction-policy hook all pass
- [x] `mypy app --ignore-missing-imports` — clean across 122 files
- [ ] After merge: add Silver Bulletin source via `/admin/news-sources/new` with "Draft Focused" unchecked; trigger an ingest and confirm filtered count > 0 and only draft-relevant items land