### PR TITLE
Per-source news relevance gate + Silver Bulletin filter

### DIFF
--- a/app/services/news_ingestion_service.py
+++ b/app/services/news_ingestion_service.py
@@ -31,6 +31,7 @@ from app.schemas.players_master import PlayerMaster  # noqa: F401 - needed for F
 from app.services.news_service import get_active_sources
 from app.services.news_summarization_service import news_summarization_service
 from app.services.player_mention_service import resolve_player_names_as_map
+from app.services.publisher_filters import apply_publisher_filters
 from app.utils.draft_relevance import check_keyword_relevance
 
 logger = logging.getLogger(__name__)
@@ -186,6 +187,14 @@ async def ingest_rss_source(
         entry for entry in candidates if entry.get("guid", "") not in existing_ids
     ]
     items_skipped += len(candidates) - len(new_entries)
+
+    # Publisher-specific exclusions (e.g., Silver Bulletin honors a no-methodology
+    # / no-models-and-forecasts editorial restriction). Runs before the relevance
+    # gate so we never spend Gemini calls on excluded posts.
+    new_entries, publisher_filtered = await apply_publisher_filters(
+        source.feed_url, new_entries
+    )
+    items_filtered += publisher_filtered
 
     # Phase 1: network/AI work (no DB connections/transactions held).
     fetched_at = datetime.now(UTC).replace(tzinfo=None)

--- a/app/services/publisher_filters.py
+++ b/app/services/publisher_filters.py
@@ -1,0 +1,153 @@
+"""Publisher-specific exclusion filters for news ingestion.
+
+Some publishers grant limited reuse rights. These filters honor those
+restrictions at the ingestion layer, before any AI relevance scoring
+runs — failing conservatively (when in doubt, exclude). Currently only
+Silver Bulletin (natesilver.net) is wired up.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_SILVER_BULLETIN_HOST = "natesilver.net"
+_SUBSTACK_ARCHIVE_URL = "https://www.natesilver.net/api/v1/archive"
+_ARCHIVE_PAGE_LIMIT = 50
+_ARCHIVE_MAX_POSTS = 500
+_ARCHIVE_TIMEOUT = httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0)
+_USER_AGENT = "DraftGuru/1.0 (+https://draftguru)"
+
+_EXCLUDED_SECTION_SLUGS: frozenset[str] = frozenset({"models-and-forecasts"})
+_EXCLUDED_SLUG_SUBSTRINGS: tuple[str, ...] = ("methodology",)
+
+
+async def apply_publisher_filters(
+    feed_url: str,
+    entries: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], int]:
+    """Dispatch publisher-specific filters based on feed URL host.
+
+    Returns the entries unchanged for any publisher without explicit
+    restrictions.
+
+    Args:
+        feed_url: The configured ``NewsSource.feed_url``.
+        entries: Normalized RSS entries from ``fetch_rss_feed``.
+
+    Returns:
+        Tuple of ``(kept_entries, dropped_count)``.
+    """
+    if _SILVER_BULLETIN_HOST in feed_url.lower():
+        return await _filter_silver_bulletin(entries)
+    return entries, 0
+
+
+async def _filter_silver_bulletin(
+    entries: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], int]:
+    """Drop methodology posts and Models & Forecasts section posts.
+
+    Honors Silver Bulletin's editorial restriction (per Joseph George,
+    May 2026): methodology pages and the Models & Forecasts dashboards
+    should not be indexed on DraftGuru.
+
+    Two filters run as a union:
+    1. URL slug contains ``methodology`` — catches all known methodology
+       articles regardless of section. Cheap, no network dependency.
+    2. Substack ``section_slug == "models-and-forecasts"`` — catches the
+       live-model dashboard pages. Requires one ``/api/v1/archive`` call
+       per ingestion cycle to map URL → section_slug.
+
+    On archive API failure the section filter is skipped (logged as a
+    warning); the slug filter still applies.
+    """
+    if not entries:
+        return [], 0
+
+    url_to_section = await _fetch_silver_bulletin_archive()
+
+    kept: list[dict[str, Any]] = []
+    dropped = 0
+    for entry in entries:
+        url = entry.get("link") or ""
+        if not url:
+            kept.append(entry)
+            continue
+        drop, reason = _should_drop_silver_bulletin(url, url_to_section)
+        if drop:
+            dropped += 1
+            logger.info(f"  Silver Bulletin: dropping {url[:80]} ({reason})")
+            continue
+        kept.append(entry)
+    return kept, dropped
+
+
+def _should_drop_silver_bulletin(
+    url: str,
+    url_to_section: dict[str, str],
+) -> tuple[bool, str]:
+    """Return ``(drop, reason)`` for a Silver Bulletin entry URL.
+
+    Slug check runs first so it works even when the archive map is empty
+    (API failure fallback).
+    """
+    url_lower = url.lower()
+    for marker in _EXCLUDED_SLUG_SUBSTRINGS:
+        if marker in url_lower:
+            return True, f"slug contains '{marker}'"
+    section_slug = url_to_section.get(url)
+    if section_slug in _EXCLUDED_SECTION_SLUGS:
+        return True, f"section_slug={section_slug}"
+    return False, ""
+
+
+async def _fetch_silver_bulletin_archive() -> dict[str, str]:
+    """Build a ``canonical_url -> section_slug`` map from the Substack archive.
+
+    Paginated up to ``_ARCHIVE_MAX_POSTS`` (currently 500). On any failure
+    (network, non-2xx, JSON shape change) returns an empty map; callers
+    must treat that as "section info unavailable" rather than "no
+    exclusions apply".
+    """
+    url_to_section: dict[str, str] = {}
+    try:
+        async with httpx.AsyncClient(
+            headers={"User-Agent": _USER_AGENT},
+            timeout=_ARCHIVE_TIMEOUT,
+            follow_redirects=True,
+        ) as client:
+            for offset in range(0, _ARCHIVE_MAX_POSTS, _ARCHIVE_PAGE_LIMIT):
+                resp = await client.get(
+                    _SUBSTACK_ARCHIVE_URL,
+                    params={
+                        "sort": "new",
+                        "offset": offset,
+                        "limit": _ARCHIVE_PAGE_LIMIT,
+                    },
+                )
+                resp.raise_for_status()
+                batch = resp.json()
+                if not isinstance(batch, list) or not batch:
+                    break
+                for post in batch:
+                    if not isinstance(post, dict):
+                        continue
+                    canonical_url = post.get("canonical_url")
+                    section_slug = post.get("section_slug")
+                    if isinstance(canonical_url, str) and isinstance(section_slug, str):
+                        url_to_section[canonical_url] = section_slug
+                if len(batch) < _ARCHIVE_PAGE_LIMIT:
+                    break
+    except (httpx.HTTPError, ValueError) as exc:
+        logger.warning(
+            "Silver Bulletin archive fetch failed; falling back to slug-only "
+            f"filter: {exc}"
+        )
+        return {}
+    logger.debug(f"Silver Bulletin archive: mapped {len(url_to_section)} URLs")
+    return url_to_section

--- a/tests/integration/test_news_ingestion_relevance.py
+++ b/tests/integration/test_news_ingestion_relevance.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.schemas.news_items import NewsItem, NewsItemTag
 from app.schemas.news_sources import FeedType, NewsSource
-from app.services import news_ingestion_service
+from app.services import news_ingestion_service, publisher_filters
 from app.services.news_ingestion_service import (
     NewsSourceSnapshot,
     ingest_rss_source,
@@ -19,12 +19,17 @@ from app.services.news_ingestion_service import (
 from app.services.news_summarization_service import ArticleAnalysis
 
 
-def _entry(guid: str, title: str, description: str = "") -> dict[str, Any]:
+def _entry(
+    guid: str,
+    title: str,
+    description: str = "",
+    link: str | None = None,
+) -> dict[str, Any]:
     """Build a normalized RSS entry dict matching fetch_rss_feed output."""
     return {
         "title": title,
         "description": description,
-        "link": f"https://example.com/{guid}",
+        "link": link or f"https://example.com/{guid}",
         "guid": guid,
         "author": None,
         "image_url": None,
@@ -278,3 +283,336 @@ class TestIngestionRelevanceGate:
         )
         assert len(rows) == 1
         assert rows[0].external_id == "g-4-keep"
+
+
+@pytest.mark.asyncio
+class TestSilverBulletinPublisherFilter:
+    """Silver Bulletin honors a no-methodology / no-models-and-forecasts rule.
+
+    The filter activates by feed_url host (``natesilver.net``) and applies a
+    union of two checks: URL slug substring ``methodology`` and Substack
+    ``section_slug == "models-and-forecasts"``. Excluded entries are counted
+    against ``items_filtered`` and never reach the relevance gate or AI
+    analysis.
+    """
+
+    async def test_methodology_slug_is_filtered(
+        self,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Posts whose URL slug contains 'methodology' are dropped."""
+        source = await _make_source(
+            db_session,
+            name="silver-bulletin-meth",
+            feed_url="https://www.natesilver.net/feed",
+            is_draft_focused=False,
+        )
+
+        analyze_calls: list[str] = []
+        relevance_calls: list[str] = []
+
+        async def fake_fetch(_url: str) -> list[dict[str, Any]]:
+            return [
+                _entry(
+                    "g-meth",
+                    "How we calculate our PELE ratings",
+                    "Deep dive on the model",
+                    link="https://www.natesilver.net/p/pele-methodology",
+                ),
+            ]
+
+        async def fake_archive() -> dict[str, str]:
+            return {}  # archive empty -- slug filter alone must catch it
+
+        async def fake_relevance(title: str, _desc: str) -> bool:
+            relevance_calls.append(title)
+            return True
+
+        async def fake_analyze(title: str, description: str) -> ArticleAnalysis:
+            analyze_calls.append(title)
+            return _stub_analysis()
+
+        monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
+        monkeypatch.setattr(
+            publisher_filters, "_fetch_silver_bulletin_archive", fake_archive
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "check_draft_relevance",
+            fake_relevance,
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "analyze_article",
+            fake_analyze,
+        )
+
+        added, _skipped, filtered, _mentions = await ingest_rss_source(
+            db_session, _snapshot(source)
+        )
+
+        assert added == 0
+        assert filtered == 1
+        assert analyze_calls == []
+        assert relevance_calls == []
+
+    async def test_models_and_forecasts_section_is_filtered(
+        self,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Posts whose Substack section_slug is 'models-and-forecasts' are dropped."""
+        source = await _make_source(
+            db_session,
+            name="silver-bulletin-mf",
+            feed_url="https://www.natesilver.net/feed",
+            is_draft_focused=False,
+        )
+
+        dashboard_url = (
+            "https://www.natesilver.net/p/trump-approval-ratings-nate-silver-bulletin"
+        )
+        analyze_calls: list[str] = []
+
+        async def fake_fetch(_url: str) -> list[dict[str, Any]]:
+            return [
+                _entry(
+                    "g-mf",
+                    "How popular is Donald Trump?",
+                    "Live tracker",
+                    link=dashboard_url,
+                ),
+            ]
+
+        async def fake_archive() -> dict[str, str]:
+            return {dashboard_url: "models-and-forecasts"}
+
+        async def fake_relevance(_title: str, _desc: str) -> bool:
+            return True
+
+        async def fake_analyze(title: str, description: str) -> ArticleAnalysis:
+            analyze_calls.append(title)
+            return _stub_analysis()
+
+        monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
+        monkeypatch.setattr(
+            publisher_filters, "_fetch_silver_bulletin_archive", fake_archive
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "check_draft_relevance",
+            fake_relevance,
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "analyze_article",
+            fake_analyze,
+        )
+
+        added, _skipped, filtered, _mentions = await ingest_rss_source(
+            db_session, _snapshot(source)
+        )
+
+        assert added == 0
+        assert filtered == 1
+        assert analyze_calls == []
+
+    async def test_other_section_passes_through_to_relevance_gate(
+        self,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Posts outside excluded sections still hit the relevance gate.
+
+        A sports-section post with a draft keyword should be admitted.
+        """
+        source = await _make_source(
+            db_session,
+            name="silver-bulletin-pass",
+            feed_url="https://www.natesilver.net/feed",
+            is_draft_focused=False,
+        )
+
+        draft_url = (
+            "https://www.natesilver.net/p/"
+            "radical-plan-to-replace-the-nba-draft-lottery-arc-auction"
+        )
+        analyze_calls: list[str] = []
+
+        async def fake_fetch(_url: str) -> list[dict[str, Any]]:
+            return [
+                _entry(
+                    "g-draft",
+                    "Our radical plan to replace the NBA draft lottery",
+                    "Auction-based draft order",
+                    link=draft_url,
+                ),
+            ]
+
+        async def fake_archive() -> dict[str, str]:
+            return {draft_url: "sports"}
+
+        async def fake_relevance(_title: str, _desc: str) -> bool:
+            return True
+
+        async def fake_analyze(title: str, description: str) -> ArticleAnalysis:
+            analyze_calls.append(title)
+            return _stub_analysis()
+
+        monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
+        monkeypatch.setattr(
+            publisher_filters, "_fetch_silver_bulletin_archive", fake_archive
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "check_draft_relevance",
+            fake_relevance,
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "analyze_article",
+            fake_analyze,
+        )
+
+        added, _skipped, filtered, _mentions = await ingest_rss_source(
+            db_session, _snapshot(source)
+        )
+
+        assert added == 1
+        assert filtered == 0
+        assert len(analyze_calls) == 1
+
+    async def test_archive_failure_still_filters_methodology_slug(
+        self,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Archive API failure → section filter is bypassed but slug filter still runs.
+
+        Defense-in-depth: section info is the secondary layer. Failing the
+        archive lookup must not blackhole the entire feed.
+        """
+        source = await _make_source(
+            db_session,
+            name="silver-bulletin-fallback",
+            feed_url="https://www.natesilver.net/feed",
+            is_draft_focused=False,
+        )
+
+        meth_url = "https://www.natesilver.net/p/sbcb-methodology"
+        draft_url = (
+            "https://www.natesilver.net/p/"
+            "radical-plan-to-replace-the-nba-draft-lottery-arc-auction"
+        )
+        analyze_calls: list[str] = []
+
+        async def fake_fetch(_url: str) -> list[dict[str, Any]]:
+            return [
+                _entry(
+                    "g-meth-fb",
+                    "SBCB methodology",
+                    "How our model works",
+                    link=meth_url,
+                ),
+                _entry(
+                    "g-draft-fb",
+                    "NBA draft lottery proposal",
+                    "Auction-based fix",
+                    link=draft_url,
+                ),
+            ]
+
+        async def fake_archive() -> dict[str, str]:
+            return {}  # simulate API failure
+
+        async def fake_relevance(_title: str, _desc: str) -> bool:
+            return True
+
+        async def fake_analyze(title: str, description: str) -> ArticleAnalysis:
+            analyze_calls.append(title)
+            return _stub_analysis()
+
+        monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
+        monkeypatch.setattr(
+            publisher_filters, "_fetch_silver_bulletin_archive", fake_archive
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "check_draft_relevance",
+            fake_relevance,
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "analyze_article",
+            fake_analyze,
+        )
+
+        added, _skipped, filtered, _mentions = await ingest_rss_source(
+            db_session, _snapshot(source)
+        )
+
+        # Methodology dropped by slug filter; draft post admitted.
+        assert added == 1
+        assert filtered == 1
+        assert analyze_calls == ["NBA draft lottery proposal"]
+
+    async def test_non_silver_bulletin_source_is_untouched(
+        self,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Filter must not fire for sources whose feed URL is not natesilver.net.
+
+        A post whose URL coincidentally contains the substring 'methodology'
+        on a non-Silver-Bulletin feed should still be admitted (or be left to
+        the relevance gate).
+        """
+        source = await _make_source(
+            db_session,
+            name="other-source",
+            feed_url="https://other-publisher.com/feed",
+            is_draft_focused=False,
+        )
+
+        archive_calls: list[None] = []
+
+        async def fake_fetch(_url: str) -> list[dict[str, Any]]:
+            return [
+                _entry(
+                    "g-other-meth",
+                    "Our NBA Draft methodology",
+                    "Mock draft tier methodology",
+                    link="https://other-publisher.com/posts/draft-methodology",
+                ),
+            ]
+
+        async def fake_archive() -> dict[str, str]:
+            archive_calls.append(None)
+            return {}
+
+        async def fake_relevance(_title: str, _desc: str) -> bool:
+            return True
+
+        monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
+        monkeypatch.setattr(
+            publisher_filters, "_fetch_silver_bulletin_archive", fake_archive
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "check_draft_relevance",
+            fake_relevance,
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "analyze_article",
+            _stub_analysis,
+        )
+
+        added, _skipped, filtered, _mentions = await ingest_rss_source(
+            db_session, _snapshot(source)
+        )
+
+        assert added == 1
+        assert filtered == 0
+        assert archive_calls == []  # publisher filter never invoked


### PR DESCRIPTION
## Summary

- **Per-source relevance gate.** New `NewsSource.is_draft_focused` flag (defaults `true`). Sources with the flag off (mixed-topic feeds like Silver Bulletin) pass through a two-tier gate before AI analysis and DB insertion: shared draft-keyword pre-filter (lifted from podcast ingestion into `app/utils/draft_relevance.py` and reused by news/podcast/video), with a Gemini relevance fallback when no keyword hits. Strict-parsed: only `true` (Python bool or quoted string) admits an article, so the gate fails closed.
- **Silver Bulletin publisher filter.** New `app/services/publisher_filters.py`. For `natesilver.net` sources only, drops methodology slugs (substring match, catches all 5 current methodology articles) and the Models & Forecasts Substack section (via a single `/api/v1/archive` call per ingestion cycle that maps `canonical_url -> section_slug`). Honors Joseph George's May 2026 ask. Archive-API failure falls back to slug-only filtering rather than blackholing the feed.
- **Admin surface.** `is_draft_focused` is plumbed end-to-end: form, list view, GET/POST `/api/news/sources` payloads. Publisher filter is intentionally code-only — hardcoded for the single publisher with restrictions.
- **Alembic.** New migration adds the `is_draft_focused` column with `server_default=true`; rebased onto the new head (`35d4c25324b3`) to resolve the multi-head state.

## Test plan

- [x] `make precommit` (ruff + ruff-format + mypy)
- [x] `mypy app --ignore-missing-imports` — clean across 124 files
- [x] `pytest tests/unit -q` — 255 passed
- [x] `pytest tests/integration -q` — 294 passed (incl. 9 new SB filter cases + relevance-gate cases)
- [ ] `alembic upgrade head` against a disposable DB after merge
- [ ] Watch the next prod ingestion cycle for Silver Bulletin: confirm methodology + Models & Forecasts entries are filtered (logs: `Silver Bulletin: dropping ... (slug contains 'methodology' | section_slug=models-and-forecasts)`).