### PR TITLE
Add player career and draft status taxonomy

### DIFF
--- a/alembic/versions/e6f7g8h9i0j1_add_career_status_to_player_lifecycle.py
+++ b/alembic/versions/e6f7g8h9i0j1_add_career_status_to_player_lifecycle.py
@@ -1,0 +1,93 @@
+"""Add career_status to player_lifecycle.
+
+Revision ID: e6f7g8h9i0j1
+Revises: 35d4c25324b3
+Create Date: 2026-05-11
+"""
+
+from alembic import op  # type: ignore[attr-defined]
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "e6f7g8h9i0j1"
+down_revision = "35d4c25324b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add and backfill explicit career status taxonomy."""
+    bind = op.get_bind()
+    career_status_enum = postgresql.ENUM(
+        "ACTIVE",
+        "FREE_AGENT",
+        "PROSPECT",
+        "G_LEAGUE",
+        "OVERSEAS",
+        "RETIRED",
+        "UNDRAFTED",
+        "UNKNOWN",
+        name="career_status_enum",
+        create_type=False,
+    )
+    career_status_enum.create(bind, checkfirst=True)
+
+    op.add_column(
+        "player_lifecycle",
+        sa.Column(
+            "career_status",
+            career_status_enum,
+            nullable=False,
+            server_default="UNKNOWN",
+        ),
+    )
+    op.create_index(
+        op.f("ix_player_lifecycle_career_status"),
+        "player_lifecycle",
+        ["career_status"],
+        unique=False,
+    )
+
+    op.execute(
+        """
+        UPDATE player_lifecycle pl
+        SET career_status = (
+            CASE
+                WHEN ps.is_active_nba IS TRUE
+                    OR pl.lifecycle_stage = 'NBA_ACTIVE' THEN 'ACTIVE'
+                WHEN pl.competition_context = 'G_LEAGUE' THEN 'G_LEAGUE'
+                WHEN pl.competition_context = 'OVERSEAS_PRO'
+                    OR pl.lifecycle_stage = 'PRO_NON_NBA' THEN 'OVERSEAS'
+                WHEN pl.lifecycle_stage = 'INACTIVE_FORMER' THEN 'RETIRED'
+                WHEN pl.draft_status = 'UNDRAFTED' THEN 'UNDRAFTED'
+                WHEN pl.lifecycle_stage IN (
+                    'RECRUIT',
+                    'HIGH_SCHOOL',
+                    'COLLEGE',
+                    'INTERNATIONAL_AMATEUR',
+                    'DRAFT_DECLARED',
+                    'DRAFT_WITHDREW'
+                )
+                    OR pl.is_draft_prospect IS TRUE THEN 'PROSPECT'
+                WHEN pl.lifecycle_stage = 'DRAFTED_NOT_IN_NBA' THEN 'FREE_AGENT'
+                ELSE 'UNKNOWN'
+            END
+        )::career_status_enum
+        FROM players_master pm
+        LEFT JOIN player_status ps ON ps.player_id = pm.id
+        WHERE pl.player_id = pm.id
+        """
+    )
+
+
+def downgrade() -> None:
+    """Remove career status taxonomy."""
+    op.drop_index(
+        op.f("ix_player_lifecycle_career_status"),
+        table_name="player_lifecycle",
+    )
+    op.drop_column("player_lifecycle", "career_status")
+
+    bind = op.get_bind()
+    postgresql.ENUM(name="career_status_enum").drop(bind, checkfirst=True)

--- a/alembic/versions/n3o4p5q6r7s8_merge_player_taxonomy_and_news_relevance_heads.py
+++ b/alembic/versions/n3o4p5q6r7s8_merge_player_taxonomy_and_news_relevance_heads.py
@@ -1,0 +1,25 @@
+"""Merge player taxonomy and news relevance migration heads.
+
+Revision ID: n3o4p5q6r7s8
+Revises: e6f7g8h9i0j1, m2n3o4p5q6r7
+Create Date: 2026-05-12
+"""
+
+from typing import Sequence, Union
+
+
+revision: str = "n3o4p5q6r7s8"
+down_revision: Union[str, tuple[str, str], None] = (
+    "e6f7g8h9i0j1",
+    "m2n3o4p5q6r7",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Merge divergent migration heads without additional schema changes."""
+
+
+def downgrade() -> None:
+    """Unmerge divergent migration heads without additional schema changes."""

--- a/app/routes/admin/players.py
+++ b/app/routes/admin/players.py
@@ -144,6 +144,8 @@ async def _render_list_error(
             q=None,
             draft_year=None,
             position=None,
+            career_status=None,
+            draft_status=None,
             draft_years=list_result.draft_years,
             error=error,
             success=None,
@@ -274,7 +276,8 @@ async def list_players(
     q: str | None = Query(default=None),
     draft_year: str | None = Query(default=None),
     position: str | None = Query(default=None),
-    nba_status: str | None = Query(default=None),
+    career_status: str | None = Query(default=None),
+    draft_status: str | None = Query(default=None),
     db: AsyncSession = Depends(get_session),
 ) -> Response:
     """List all players with pagination and filters."""
@@ -294,7 +297,7 @@ async def list_players(
             draft_year_int = None
 
     result = await svc_list_players(
-        db, q, draft_year_int, position, nba_status, limit, offset
+        db, q, draft_year_int, position, career_status, draft_status, limit, offset
     )
 
     # Calculate pagination info
@@ -316,7 +319,8 @@ async def list_players(
             q=q,
             draft_year=draft_year_int,
             position=position,
-            nba_status=nba_status,
+            career_status=career_status,
+            draft_status=draft_status,
             draft_years=result.draft_years,
             success=SUCCESS_MESSAGES.get(success) if success else None,
             active_nav="players",
@@ -374,6 +378,13 @@ async def create_player(
     nba_debut_season: str | None = Form(default=None),
     reference_image_url: str | None = Form(default=None),
     reference_image_file: UploadFile | None = File(default=None),
+    career_status: str | None = Form(default="prospect"),
+    draft_status: str | None = Form(default=None),
+    lifecycle_stage: str | None = Form(default=None),
+    expected_draft_year: str | None = Form(default=None),
+    current_affiliation_name: str | None = Form(default=None),
+    current_affiliation_type: str | None = Form(default=None),
+    is_draft_prospect: str | None = Form(default=None),
     db: AsyncSession = Depends(get_session),
 ) -> Response:
     """Create a new player."""
@@ -426,6 +437,25 @@ async def create_player(
 
     async with db.begin():
         player = await svc_create_player(db, parsed)
+        assert player.id is not None
+        await svc_update_player_lifecycle(
+            db,
+            player.id,
+            PlayerLifecycleFormData(
+                career_status=career_status,
+                lifecycle_stage=lifecycle_stage,
+                draft_status=draft_status,
+                expected_draft_year=expected_draft_year,
+                current_affiliation_name=current_affiliation_name,
+                current_affiliation_type=current_affiliation_type,
+                is_draft_prospect=is_draft_prospect,
+            ),
+        )
+        await svc_update_player_status(
+            db,
+            player.id,
+            PlayerStatusFormData(career_status=career_status),
+        )
         # Upload reference image now that we have a player ID
         if upload_bytes and upload_ct:
             s3_key = _upload_reference_image(player, upload_bytes, upload_ct)
@@ -524,6 +554,7 @@ async def update_player(
     remove_reference_upload: str | None = Form(default=None),
     # Player status fields
     is_active_nba: str | None = Form(default=None),
+    career_status: str | None = Form(default=None),
     current_team: str | None = Form(default=None),
     nba_last_season: str | None = Form(default=None),
     raw_position: str | None = Form(default=None),
@@ -654,6 +685,7 @@ async def update_player(
         # Update player status
         status_data = PlayerStatusFormData(
             is_active_nba=is_active_nba,
+            career_status=career_status,
             current_team=current_team,
             nba_last_season=nba_last_season,
             raw_position=raw_position,
@@ -663,6 +695,7 @@ async def update_player(
         await svc_update_player_status(db, player_id, status_data)
 
         lifecycle_data = PlayerLifecycleFormData(
+            career_status=career_status,
             lifecycle_stage=lifecycle_stage,
             competition_context=competition_context,
             draft_status=draft_status,
@@ -701,7 +734,7 @@ async def delete_player(
         if not can_delete:
             # Re-fetch list data for rendering
             list_result = await svc_list_players(
-                db, None, None, None, None, DEFAULT_LIMIT, 0
+                db, None, None, None, None, None, DEFAULT_LIMIT, 0
             )
             return await _render_list_error(
                 request,

--- a/app/schemas/player_lifecycle.py
+++ b/app/schemas/player_lifecycle.py
@@ -49,6 +49,19 @@ class DraftStatus(str, Enum):
     UNKNOWN = "unknown"
 
 
+class CareerStatus(str, Enum):
+    """Current career status for a player."""
+
+    ACTIVE = "active"
+    FREE_AGENT = "free_agent"
+    PROSPECT = "prospect"
+    G_LEAGUE = "g_league"
+    OVERSEAS = "overseas"
+    RETIRED = "retired"
+    UNDRAFTED = "undrafted"
+    UNKNOWN = "unknown"
+
+
 class AffiliationType(str, Enum):
     """Type of current player affiliation."""
 
@@ -113,6 +126,17 @@ class PlayerLifecycle(SQLModel, table=True):  # type: ignore[call-arg]
             ),
             nullable=False,
             server_default=DraftStatus.UNKNOWN.name,
+        ),
+    )
+    career_status: CareerStatus = Field(
+        default=CareerStatus.UNKNOWN,
+        sa_column=Column(
+            SAEnum(
+                CareerStatus,
+                name="career_status_enum",
+            ),
+            nullable=False,
+            server_default=CareerStatus.UNKNOWN.name,
         ),
     )
 

--- a/app/services/admin_player_service.py
+++ b/app/services/admin_player_service.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from enum import Enum
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import func, or_, select
@@ -283,24 +283,32 @@ async def list_players(
         career_val = career_status.strip().lower()
         if career_val in {item.value for item in CareerStatus}:
             parsed_career = CareerStatus(career_val)
-            query = query.where(
-                PlayerLifecycle.career_status == parsed_career  # type: ignore[arg-type]
-            )
-            count_query = count_query.where(
-                PlayerLifecycle.career_status == parsed_career  # type: ignore[arg-type]
-            )
+            career_filter: Any
+            if parsed_career == CareerStatus.UNKNOWN:
+                career_filter = or_(
+                    PlayerLifecycle.id.is_(None),  # type: ignore[union-attr]
+                    PlayerLifecycle.career_status == parsed_career,  # type: ignore[arg-type]
+                )
+            else:
+                career_filter = PlayerLifecycle.career_status == parsed_career  # type: ignore[arg-type]
+            query = query.where(career_filter)
+            count_query = count_query.where(career_filter)
 
     # Apply draft status filter
     if draft_status and draft_status.strip():
         draft_val = draft_status.strip().lower()
         if draft_val in {item.value for item in DraftStatus}:
             parsed_draft = DraftStatus(draft_val)
-            query = query.where(
-                PlayerLifecycle.draft_status == parsed_draft  # type: ignore[arg-type]
-            )
-            count_query = count_query.where(
-                PlayerLifecycle.draft_status == parsed_draft  # type: ignore[arg-type]
-            )
+            draft_filter: Any
+            if parsed_draft == DraftStatus.UNKNOWN:
+                draft_filter = or_(
+                    PlayerLifecycle.id.is_(None),  # type: ignore[union-attr]
+                    PlayerLifecycle.draft_status == parsed_draft,  # type: ignore[arg-type]
+                )
+            else:
+                draft_filter = PlayerLifecycle.draft_status == parsed_draft  # type: ignore[arg-type]
+            query = query.where(draft_filter)
+            count_query = count_query.where(draft_filter)
 
     # Get total count
     total = await db.scalar(count_query)
@@ -817,11 +825,11 @@ async def update_player_status(
     # Parse and set fields. career_status is the source of truth; fall back to
     # the old form field only for older callers that have not been updated.
     derived_active = derive_is_active_nba(career_status)
-    status.is_active_nba = (
-        derived_active
-        if career_status != CareerStatus.UNKNOWN
-        else _parse_bool_field(data.is_active_nba)
-    )
+    parsed_active = _parse_bool_field(data.is_active_nba)
+    if career_status != CareerStatus.UNKNOWN:
+        status.is_active_nba = derived_active
+    elif parsed_active is not None:
+        status.is_active_nba = parsed_active
     status.current_team = _clean_str(data.current_team)
     status.nba_last_season = _clean_str(data.nba_last_season)
     status.raw_position = _clean_str(data.raw_position)

--- a/app/services/admin_player_service.py
+++ b/app/services/admin_player_service.py
@@ -28,6 +28,7 @@ from app.schemas.player_content_mentions import PlayerContentMention
 from app.schemas.player_external_ids import PlayerExternalId
 from app.schemas.player_lifecycle import (
     AffiliationType,
+    CareerStatus,
     CommitmentStatus,
     CompetitionContext,
     DraftStatus,
@@ -49,6 +50,18 @@ class PlayerWithStatus:
     player: PlayerMaster
     is_active_nba: bool | None = None
     current_team: str | None = None
+    career_status: CareerStatus | None = None
+    draft_status: DraftStatus | None = None
+
+    @property
+    def career_status_label(self) -> str:
+        """Human-readable career status for admin list display."""
+        return _career_status_label(self.career_status)
+
+    @property
+    def draft_status_label(self) -> str:
+        """Human-readable draft status for admin list display."""
+        return _draft_status_label(self.draft_status)
 
 
 @dataclass
@@ -121,12 +134,75 @@ def _clean_str(val: str | None) -> str | None:
     return None
 
 
+def _career_status_label(status: CareerStatus | None) -> str:
+    """Return display text for career status values."""
+    labels = {
+        CareerStatus.ACTIVE: "Active NBA",
+        CareerStatus.FREE_AGENT: "Free Agent",
+        CareerStatus.PROSPECT: "Draft Prospect",
+        CareerStatus.G_LEAGUE: "G League",
+        CareerStatus.OVERSEAS: "Overseas",
+        CareerStatus.RETIRED: "Retired",
+        CareerStatus.UNDRAFTED: "Undrafted",
+        CareerStatus.UNKNOWN: "Unknown",
+    }
+    return labels.get(status or CareerStatus.UNKNOWN, "Unknown")
+
+
+def _draft_status_label(status: DraftStatus | None) -> str:
+    """Return display text for draft status values."""
+    labels = {
+        DraftStatus.NOT_ELIGIBLE: "Future Eligible",
+        DraftStatus.ELIGIBLE: "Eligible",
+        DraftStatus.DECLARED: "Declared",
+        DraftStatus.WITHDREW: "Withdrew",
+        DraftStatus.DRAFTED: "Drafted",
+        DraftStatus.UNDRAFTED: "Undrafted",
+        DraftStatus.UNKNOWN: "Unknown",
+    }
+    return labels.get(status or DraftStatus.UNKNOWN, "Unknown")
+
+
+def derive_is_active_nba(career_status: CareerStatus | None) -> bool | None:
+    """Derive legacy NBA active flag from explicit career status."""
+    if career_status is None or career_status == CareerStatus.UNKNOWN:
+        return None
+    return career_status == CareerStatus.ACTIVE
+
+
+def derive_is_draft_prospect(
+    career_status: CareerStatus,
+    draft_status: DraftStatus,
+) -> bool | None:
+    """Infer prospect flag from career and draft status when not edited directly."""
+    if career_status == CareerStatus.PROSPECT:
+        return True
+    if draft_status in {
+        DraftStatus.NOT_ELIGIBLE,
+        DraftStatus.ELIGIBLE,
+        DraftStatus.DECLARED,
+        DraftStatus.WITHDREW,
+    }:
+        return True
+    if career_status in {
+        CareerStatus.ACTIVE,
+        CareerStatus.FREE_AGENT,
+        CareerStatus.G_LEAGUE,
+        CareerStatus.OVERSEAS,
+        CareerStatus.RETIRED,
+        CareerStatus.UNDRAFTED,
+    }:
+        return False
+    return None
+
+
 async def list_players(
     db: AsyncSession,
     q: str | None,
     draft_year: int | None,
     position: str | None,
-    nba_status: str | None,
+    career_status: str | None,
+    draft_status: str | None,
     limit: int,
     offset: int,
 ) -> PlayerListResult:
@@ -137,7 +213,8 @@ async def list_players(
         q: Search query (matches display_name, first_name, last_name, school)
         draft_year: Filter by draft year
         position: Filter by position (stored in shoots field)
-        nba_status: Filter by NBA status ("active", "inactive", "unknown")
+        career_status: Filter by explicit career status
+        draft_status: Filter by explicit draft status
         limit: Maximum results to return
         offset: Number of results to skip
 
@@ -150,8 +227,11 @@ async def list_players(
             PlayerMaster,
             PlayerStatus.is_active_nba,
             PlayerStatus.current_team,
+            PlayerLifecycle.career_status,
+            PlayerLifecycle.draft_status,
         )
         .outerjoin(PlayerStatus, PlayerStatus.player_id == PlayerMaster.id)
+        .outerjoin(PlayerLifecycle, PlayerLifecycle.player_id == PlayerMaster.id)
         .order_by(PlayerMaster.display_name)  # type: ignore[arg-type]
     )
     # Count query also needs the join for status filtering
@@ -161,6 +241,10 @@ async def list_players(
         .outerjoin(
             PlayerStatus,
             PlayerStatus.player_id == PlayerMaster.id,  # type: ignore[arg-type]
+        )
+        .outerjoin(
+            PlayerLifecycle,
+            PlayerLifecycle.player_id == PlayerMaster.id,  # type: ignore[arg-type]
         )
     )
 
@@ -194,36 +278,28 @@ async def list_players(
             PlayerMaster.shoots == position  # type: ignore[arg-type]
         )
 
-    # Apply NBA status filter
-    if nba_status and nba_status.strip():
-        status_val = nba_status.strip().lower()
-        if status_val == "active":
+    # Apply career status filter
+    if career_status and career_status.strip():
+        career_val = career_status.strip().lower()
+        if career_val in {item.value for item in CareerStatus}:
+            parsed_career = CareerStatus(career_val)
             query = query.where(
-                PlayerStatus.is_active_nba.is_(True)  # type: ignore[union-attr]
+                PlayerLifecycle.career_status == parsed_career  # type: ignore[arg-type]
             )
             count_query = count_query.where(
-                PlayerStatus.is_active_nba.is_(True)  # type: ignore[union-attr]
+                PlayerLifecycle.career_status == parsed_career  # type: ignore[arg-type]
             )
-        elif status_val == "inactive":
+
+    # Apply draft status filter
+    if draft_status and draft_status.strip():
+        draft_val = draft_status.strip().lower()
+        if draft_val in {item.value for item in DraftStatus}:
+            parsed_draft = DraftStatus(draft_val)
             query = query.where(
-                PlayerStatus.is_active_nba.is_(False)  # type: ignore[union-attr]
+                PlayerLifecycle.draft_status == parsed_draft  # type: ignore[arg-type]
             )
             count_query = count_query.where(
-                PlayerStatus.is_active_nba.is_(False)  # type: ignore[union-attr]
-            )
-        elif status_val == "unknown":
-            # Unknown = no status record OR is_active_nba is NULL
-            query = query.where(
-                or_(
-                    PlayerStatus.id.is_(None),  # type: ignore[union-attr]
-                    PlayerStatus.is_active_nba.is_(None),  # type: ignore[union-attr]
-                )
-            )
-            count_query = count_query.where(
-                or_(
-                    PlayerStatus.id.is_(None),  # type: ignore[union-attr]
-                    PlayerStatus.is_active_nba.is_(None),  # type: ignore[union-attr]
-                )
+                PlayerLifecycle.draft_status == parsed_draft  # type: ignore[arg-type]
             )
 
     # Get total count
@@ -242,6 +318,8 @@ async def list_players(
             player=row[0],
             is_active_nba=row[1],
             current_team=row[2],
+            career_status=row[3],
+            draft_status=row[4],
         )
         for row in rows
     ]
@@ -601,6 +679,7 @@ class PlayerStatusFormData:
     """Raw form data for player status fields."""
 
     is_active_nba: str | None = None  # "true", "false", "" (unknown)
+    career_status: str | None = None
     current_team: str | None = None
     nba_last_season: str | None = None
     raw_position: str | None = None
@@ -612,6 +691,7 @@ class PlayerStatusFormData:
 class PlayerLifecycleFormData:
     """Raw form data for player lifecycle fields."""
 
+    career_status: str | None = None
     lifecycle_stage: str | None = None
     competition_context: str | None = None
     draft_status: str | None = None
@@ -654,6 +734,32 @@ def _parse_enum_field(val: str | None, enum_cls: type[EnumT]) -> EnumT:
         return enum_cls(cleaned)
     except ValueError:
         return enum_cls("unknown")
+
+
+def _derive_lifecycle_stage(
+    career_status: CareerStatus,
+    draft_status: DraftStatus,
+    raw_lifecycle_stage: str | None,
+) -> PlayerLifecycleStage:
+    """Derive lifecycle detail when admin only chooses top-level taxonomies."""
+    lifecycle_stage = _parse_enum_field(raw_lifecycle_stage, PlayerLifecycleStage)
+    if lifecycle_stage != PlayerLifecycleStage.UNKNOWN:
+        return lifecycle_stage
+    if career_status == CareerStatus.ACTIVE:
+        return PlayerLifecycleStage.NBA_ACTIVE
+    if career_status in {CareerStatus.G_LEAGUE, CareerStatus.OVERSEAS}:
+        return PlayerLifecycleStage.PRO_NON_NBA
+    if career_status == CareerStatus.RETIRED:
+        return PlayerLifecycleStage.INACTIVE_FORMER
+    if draft_status == DraftStatus.DECLARED:
+        return PlayerLifecycleStage.DRAFT_DECLARED
+    if draft_status == DraftStatus.WITHDREW:
+        return PlayerLifecycleStage.DRAFT_WITHDREW
+    if draft_status == DraftStatus.DRAFTED:
+        return PlayerLifecycleStage.DRAFTED_NOT_IN_NBA
+    if career_status == CareerStatus.PROSPECT:
+        return PlayerLifecycleStage.COLLEGE
+    return PlayerLifecycleStage.UNKNOWN
 
 
 async def _resolve_position_id(db: AsyncSession, raw_position: str) -> int | None:
@@ -706,8 +812,16 @@ async def update_player_status(
         status = PlayerStatus(player_id=player_id)
         db.add(status)
 
-    # Parse and set fields
-    status.is_active_nba = _parse_bool_field(data.is_active_nba)
+    career_status = _parse_enum_field(data.career_status, CareerStatus)
+
+    # Parse and set fields. career_status is the source of truth; fall back to
+    # the old form field only for older callers that have not been updated.
+    derived_active = derive_is_active_nba(career_status)
+    status.is_active_nba = (
+        derived_active
+        if career_status != CareerStatus.UNKNOWN
+        else _parse_bool_field(data.is_active_nba)
+    )
     status.current_team = _clean_str(data.current_team)
     status.nba_last_season = _clean_str(data.nba_last_season)
     status.raw_position = _clean_str(data.raw_position)
@@ -738,13 +852,18 @@ async def update_player_lifecycle(
         lifecycle = PlayerLifecycle(player_id=player_id)
         db.add(lifecycle)
 
-    lifecycle.lifecycle_stage = _parse_enum_field(
-        data.lifecycle_stage, PlayerLifecycleStage
+    career_status = _parse_enum_field(data.career_status, CareerStatus)
+    draft_status = _parse_enum_field(data.draft_status, DraftStatus)
+    lifecycle.career_status = career_status
+    lifecycle.lifecycle_stage = _derive_lifecycle_stage(
+        career_status,
+        draft_status,
+        data.lifecycle_stage,
     )
     lifecycle.competition_context = _parse_enum_field(
         data.competition_context, CompetitionContext
     )
-    lifecycle.draft_status = _parse_enum_field(data.draft_status, DraftStatus)
+    lifecycle.draft_status = draft_status
     lifecycle.expected_draft_year = _parse_int_field(data.expected_draft_year)
     lifecycle.current_affiliation_name = _clean_str(data.current_affiliation_name)
     lifecycle.current_affiliation_type = _parse_enum_field(
@@ -754,7 +873,12 @@ async def update_player_lifecycle(
     lifecycle.commitment_status = _parse_enum_field(
         data.commitment_status, CommitmentStatus
     )
-    lifecycle.is_draft_prospect = _parse_bool_field(data.is_draft_prospect)
+    parsed_is_prospect = _parse_bool_field(data.is_draft_prospect)
+    lifecycle.is_draft_prospect = (
+        parsed_is_prospect
+        if parsed_is_prospect is not None
+        else derive_is_draft_prospect(career_status, draft_status)
+    )
     lifecycle.source = "manual"
     lifecycle.updated_at = datetime.now(UTC).replace(tzinfo=None)
     await db.flush()

--- a/app/services/player_mention_service.py
+++ b/app/services/player_mention_service.py
@@ -17,7 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.schemas.player_aliases import PlayerAlias
-from app.schemas.player_lifecycle import DraftStatus, PlayerLifecycle
+from app.schemas.player_lifecycle import CareerStatus, DraftStatus, PlayerLifecycle
 from app.schemas.players_master import PlayerMaster
 
 logger = logging.getLogger(__name__)
@@ -368,8 +368,9 @@ async def _upsert_stub_lifecycle(
         db.add(lifecycle)
 
     lifecycle.expected_draft_year = draft_year
+    lifecycle.career_status = CareerStatus.PROSPECT
     lifecycle.draft_status = DraftStatus.UNKNOWN
-    lifecycle.is_draft_prospect = True if draft_year is not None else None
+    lifecycle.is_draft_prospect = True
 
 
 async def _resolve_iter(

--- a/app/templates/admin/players/detail.html
+++ b/app/templates/admin/players/detail.html
@@ -284,11 +284,41 @@ document.addEventListener('DOMContentLoaded', function() {
       </div>
 
       <div class="admin-form__section">
-        <h3 class="admin-form__section-title">Lifecycle</h3>
+        <h3 class="admin-form__section-title">Career & Draft Status</h3>
 
         <div class="admin-form__row">
           <div class="admin-form__field">
-            <label class="admin-form__label" for="lifecycle_stage">Lifecycle Stage</label>
+            <label class="admin-form__label" for="career_status">Career Status</label>
+            <select class="admin-form__select" id="career_status" name="career_status">
+              {% set career_status_value = player_lifecycle.career_status.value if player_lifecycle else 'unknown' %}
+              <option value="unknown" {% if career_status_value == 'unknown' %}selected{% endif %}>Unknown</option>
+              <option value="active" {% if career_status_value == 'active' %}selected{% endif %}>Active NBA</option>
+              <option value="free_agent" {% if career_status_value == 'free_agent' %}selected{% endif %}>Free Agent</option>
+              <option value="prospect" {% if career_status_value == 'prospect' %}selected{% endif %}>Draft Prospect</option>
+              <option value="g_league" {% if career_status_value == 'g_league' %}selected{% endif %}>G League</option>
+              <option value="overseas" {% if career_status_value == 'overseas' %}selected{% endif %}>Overseas</option>
+              <option value="retired" {% if career_status_value == 'retired' %}selected{% endif %}>Retired</option>
+              <option value="undrafted" {% if career_status_value == 'undrafted' %}selected{% endif %}>Undrafted</option>
+            </select>
+            <span class="admin-form__help">Source of truth for the old active NBA flag.</span>
+          </div>
+
+          <div class="admin-form__field">
+            <label class="admin-form__label" for="draft_status">Draft Status</label>
+            <select class="admin-form__select" id="draft_status" name="draft_status">
+              {% set draft_status_value = player_lifecycle.draft_status.value if player_lifecycle else 'unknown' %}
+              <option value="unknown" {% if draft_status_value == 'unknown' %}selected{% endif %}>Unknown</option>
+              <option value="not_eligible" {% if draft_status_value == 'not_eligible' %}selected{% endif %}>Future Eligible</option>
+              <option value="eligible" {% if draft_status_value == 'eligible' %}selected{% endif %}>Eligible</option>
+              <option value="declared" {% if draft_status_value == 'declared' %}selected{% endif %}>Declared</option>
+              <option value="withdrew" {% if draft_status_value == 'withdrew' %}selected{% endif %}>Withdrew</option>
+              <option value="drafted" {% if draft_status_value == 'drafted' %}selected{% endif %}>Drafted</option>
+              <option value="undrafted" {% if draft_status_value == 'undrafted' %}selected{% endif %}>Undrafted</option>
+            </select>
+          </div>
+
+          <div class="admin-form__field">
+            <label class="admin-form__label" for="lifecycle_stage">Lifecycle Detail</label>
             <select class="admin-form__select" id="lifecycle_stage" name="lifecycle_stage">
               {% set lifecycle_stage_value = player_lifecycle.lifecycle_stage.value if player_lifecycle else 'unknown' %}
               <option value="unknown" {% if lifecycle_stage_value == 'unknown' %}selected{% endif %}>Unknown</option>
@@ -320,19 +350,6 @@ document.addEventListener('DOMContentLoaded', function() {
             </select>
           </div>
 
-          <div class="admin-form__field">
-            <label class="admin-form__label" for="draft_status">Draft Status</label>
-            <select class="admin-form__select" id="draft_status" name="draft_status">
-              {% set draft_status_value = player_lifecycle.draft_status.value if player_lifecycle else 'unknown' %}
-              <option value="unknown" {% if draft_status_value == 'unknown' %}selected{% endif %}>Unknown</option>
-              <option value="not_eligible" {% if draft_status_value == 'not_eligible' %}selected{% endif %}>Not Eligible</option>
-              <option value="eligible" {% if draft_status_value == 'eligible' %}selected{% endif %}>Eligible</option>
-              <option value="declared" {% if draft_status_value == 'declared' %}selected{% endif %}>Declared</option>
-              <option value="withdrew" {% if draft_status_value == 'withdrew' %}selected{% endif %}>Withdrew</option>
-              <option value="drafted" {% if draft_status_value == 'drafted' %}selected{% endif %}>Drafted</option>
-              <option value="undrafted" {% if draft_status_value == 'undrafted' %}selected{% endif %}>Undrafted</option>
-            </select>
-          </div>
         </div>
 
         <div class="admin-form__row">
@@ -490,15 +507,6 @@ document.addEventListener('DOMContentLoaded', function() {
         <h3 class="admin-form__section-title">Player Status</h3>
 
         <div class="admin-form__row">
-          <div class="admin-form__field">
-            <label class="admin-form__label" for="is_active_nba">NBA Status</label>
-            <select class="admin-form__select" id="is_active_nba" name="is_active_nba">
-              <option value="" {% if player_status is none or player_status.is_active_nba is none %}selected{% endif %}>Unknown</option>
-              <option value="true" {% if player_status and player_status.is_active_nba is true %}selected{% endif %}>NBA Active</option>
-              <option value="false" {% if player_status and player_status.is_active_nba is false %}selected{% endif %}>Not Active</option>
-            </select>
-          </div>
-
           <div class="admin-form__field">
             <label class="admin-form__label" for="current_team">Current Team</label>
             <input

--- a/app/templates/admin/players/form.html
+++ b/app/templates/admin/players/form.html
@@ -218,6 +218,96 @@
       </div>
     </div>
 
+    <div class="admin-form__section">
+      <h3 class="admin-form__section-title">Career & Draft Status</h3>
+
+      <div class="admin-form__row">
+        <div class="admin-form__field">
+          <label class="admin-form__label" for="career_status">Career Status</label>
+          <select class="admin-form__select" id="career_status" name="career_status">
+            <option value="unknown">Unknown</option>
+            <option value="active">Active NBA</option>
+            <option value="free_agent">Free Agent</option>
+            <option value="prospect" selected>Draft Prospect</option>
+            <option value="g_league">G League</option>
+            <option value="overseas">Overseas</option>
+            <option value="retired">Retired</option>
+            <option value="undrafted">Undrafted</option>
+          </select>
+          <span class="admin-form__help">This drives the legacy active NBA flag.</span>
+        </div>
+
+        <div class="admin-form__field">
+          <label class="admin-form__label" for="draft_status">Draft Status</label>
+          <select class="admin-form__select" id="draft_status" name="draft_status">
+            <option value="unknown">Unknown</option>
+            <option value="not_eligible">Future Eligible</option>
+            <option value="eligible">Eligible</option>
+            <option value="declared">Declared</option>
+            <option value="withdrew">Withdrew</option>
+            <option value="drafted">Drafted</option>
+            <option value="undrafted">Undrafted</option>
+          </select>
+        </div>
+
+        <div class="admin-form__field">
+          <label class="admin-form__label" for="lifecycle_stage">Lifecycle Detail</label>
+          <select class="admin-form__select" id="lifecycle_stage" name="lifecycle_stage">
+            <option value="unknown" selected>Auto</option>
+            <option value="recruit">Recruit</option>
+            <option value="high_school">High School</option>
+            <option value="college">College</option>
+            <option value="international_amateur">International Amateur</option>
+            <option value="draft_declared">Draft Declared</option>
+            <option value="draft_withdrew">Draft Withdrew</option>
+            <option value="drafted_not_in_nba">Drafted, Not in NBA</option>
+            <option value="nba_active">NBA Active</option>
+            <option value="pro_non_nba">Pro, Non-NBA</option>
+            <option value="inactive_former">Inactive Former</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="admin-form__row">
+        <div class="admin-form__field">
+          <label class="admin-form__label" for="expected_draft_year">Expected Draft Year</label>
+          <input
+            class="admin-form__input"
+            id="expected_draft_year"
+            name="expected_draft_year"
+            type="number"
+            min="1947"
+            max="2035"
+          />
+        </div>
+
+        <div class="admin-form__field">
+          <label class="admin-form__label" for="current_affiliation_name">Current Affiliation</label>
+          <input
+            class="admin-form__input"
+            id="current_affiliation_name"
+            name="current_affiliation_name"
+            type="text"
+            placeholder="e.g., Duke, Montverde Academy, Lakers"
+          />
+        </div>
+
+        <div class="admin-form__field">
+          <label class="admin-form__label" for="current_affiliation_type">Affiliation Type</label>
+          <select class="admin-form__select" id="current_affiliation_type" name="current_affiliation_type">
+            <option value="unknown" selected>Unknown</option>
+            <option value="high_school">High School</option>
+            <option value="college_team">College Team</option>
+            <option value="committed_school">Committed School</option>
+            <option value="nba_team">NBA Team</option>
+            <option value="g_league_team">G League Team</option>
+            <option value="overseas_club">Overseas Club</option>
+            <option value="independent">Independent</option>
+          </select>
+        </div>
+      </div>
+    </div>
+
     <!-- NBA Career Section -->
     <div class="admin-form__section">
       <h3 class="admin-form__section-title">NBA Career</h3>

--- a/app/templates/admin/players/index.html
+++ b/app/templates/admin/players/index.html
@@ -39,12 +39,31 @@
       </div>
 
       <div class="admin-filters__field">
-        <label class="admin-filters__label" for="nba_status">NBA Status</label>
-        <select class="admin-form__select" id="nba_status" name="nba_status">
+        <label class="admin-filters__label" for="career_status">Career Status</label>
+        <select class="admin-form__select" id="career_status" name="career_status">
           <option value="">All</option>
-          <option value="active" {% if nba_status == 'active' %}selected{% endif %}>NBA Active</option>
-          <option value="inactive" {% if nba_status == 'inactive' %}selected{% endif %}>Not Active</option>
-          <option value="unknown" {% if nba_status == 'unknown' %}selected{% endif %}>Unknown</option>
+          <option value="active" {% if career_status == 'active' %}selected{% endif %}>Active NBA</option>
+          <option value="free_agent" {% if career_status == 'free_agent' %}selected{% endif %}>Free Agent</option>
+          <option value="prospect" {% if career_status == 'prospect' %}selected{% endif %}>Draft Prospect</option>
+          <option value="g_league" {% if career_status == 'g_league' %}selected{% endif %}>G League</option>
+          <option value="overseas" {% if career_status == 'overseas' %}selected{% endif %}>Overseas</option>
+          <option value="retired" {% if career_status == 'retired' %}selected{% endif %}>Retired</option>
+          <option value="undrafted" {% if career_status == 'undrafted' %}selected{% endif %}>Undrafted</option>
+          <option value="unknown" {% if career_status == 'unknown' %}selected{% endif %}>Unknown</option>
+        </select>
+      </div>
+
+      <div class="admin-filters__field">
+        <label class="admin-filters__label" for="draft_status">Draft Status</label>
+        <select class="admin-form__select" id="draft_status" name="draft_status">
+          <option value="">All</option>
+          <option value="not_eligible" {% if draft_status == 'not_eligible' %}selected{% endif %}>Future Eligible</option>
+          <option value="eligible" {% if draft_status == 'eligible' %}selected{% endif %}>Eligible</option>
+          <option value="declared" {% if draft_status == 'declared' %}selected{% endif %}>Declared</option>
+          <option value="withdrew" {% if draft_status == 'withdrew' %}selected{% endif %}>Withdrew</option>
+          <option value="drafted" {% if draft_status == 'drafted' %}selected{% endif %}>Drafted</option>
+          <option value="undrafted" {% if draft_status == 'undrafted' %}selected{% endif %}>Undrafted</option>
+          <option value="unknown" {% if draft_status == 'unknown' %}selected{% endif %}>Unknown</option>
         </select>
       </div>
 
@@ -62,7 +81,8 @@
         <th>Name</th>
         <th>School</th>
         <th>Draft</th>
-        <th>Status</th>
+        <th>Career</th>
+        <th>Draft Status</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -92,10 +112,17 @@
           {% endif %}
         </td>
         <td>
-          {% if p.is_active_nba is true %}
-          <span class="admin-badge admin-badge--active">NBA</span>
-          {% elif p.is_active_nba is false %}
-          <span class="admin-badge admin-badge--inactive">Not Active</span>
+          {% if p.career_status and p.career_status.value == 'active' %}
+          <span class="admin-badge admin-badge--active">{{ p.career_status_label }}</span>
+          {% elif p.career_status and p.career_status.value != 'unknown' %}
+          <span class="admin-badge admin-badge--inactive">{{ p.career_status_label }}</span>
+          {% else %}
+          <span class="admin-badge admin-badge--unknown">Unknown</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if p.draft_status and p.draft_status.value != 'unknown' %}
+          <span class="admin-badge admin-badge--unknown">{{ p.draft_status_label }}</span>
           {% else %}
           <span class="admin-badge admin-badge--unknown">Unknown</span>
           {% endif %}
@@ -121,7 +148,7 @@
     </div>
     <div class="admin-pagination__controls">
       {% if current_page > 1 %}
-      <a href="/admin/players?limit={{ limit }}&offset={{ (current_page - 2) * limit }}{% if q %}&q={{ q }}{% endif %}{% if draft_year %}&draft_year={{ draft_year }}{% endif %}{% if position %}&position={{ position }}{% endif %}{% if nba_status %}&nba_status={{ nba_status }}{% endif %}"
+      <a href="/admin/players?limit={{ limit }}&offset={{ (current_page - 2) * limit }}{% if q %}&q={{ q }}{% endif %}{% if draft_year %}&draft_year={{ draft_year }}{% endif %}{% if position %}&position={{ position }}{% endif %}{% if career_status %}&career_status={{ career_status }}{% endif %}{% if draft_status %}&draft_status={{ draft_status }}{% endif %}"
          class="admin-btn admin-btn--secondary admin-btn--small">Previous</a>
       {% endif %}
 
@@ -130,7 +157,7 @@
       </span>
 
       {% if current_page < pages %}
-      <a href="/admin/players?limit={{ limit }}&offset={{ current_page * limit }}{% if q %}&q={{ q }}{% endif %}{% if draft_year %}&draft_year={{ draft_year }}{% endif %}{% if position %}&position={{ position }}{% endif %}{% if nba_status %}&nba_status={{ nba_status }}{% endif %}"
+      <a href="/admin/players?limit={{ limit }}&offset={{ current_page * limit }}{% if q %}&q={{ q }}{% endif %}{% if draft_year %}&draft_year={{ draft_year }}{% endif %}{% if position %}&position={{ position }}{% endif %}{% if career_status %}&career_status={{ career_status }}{% endif %}{% if draft_status %}&draft_status={{ draft_status }}{% endif %}"
          class="admin-btn admin-btn--secondary admin-btn--small">Next</a>
       {% endif %}
     </div>
@@ -142,13 +169,13 @@
     <div class="admin-empty__icon">&#127936;</div>
     <h3 class="admin-empty__title">No Players</h3>
     <p class="admin-empty__text">
-      {% if q or draft_year or position or nba_status %}
+      {% if q or draft_year or position or career_status or draft_status %}
       No players match your filters. Try adjusting the criteria.
       {% else %}
       No player records exist yet. Add a player to get started.
       {% endif %}
     </p>
-    {% if q or draft_year or position or nba_status %}
+    {% if q or draft_year or position or career_status or draft_status %}
     <a href="/admin/players" class="admin-btn admin-btn--secondary">Clear Filters</a>
     {% else %}
     <a href="/admin/players/new" class="admin-btn admin-btn--primary">Add Player</a>

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -113,6 +113,7 @@ async def async_engine(
     # Ensure SQLModel metadata is populated before creating tables.
     from app.schemas import positions  # noqa: F401
     from app.schemas import player_status  # noqa: F401
+    from app.schemas import player_lifecycle  # noqa: F401
     from app.schemas import combine_anthro  # noqa: F401
     from app.schemas import combine_agility  # noqa: F401
     from app.schemas import combine_shooting  # noqa: F401

--- a/tests/integration/test_admin_players.py
+++ b/tests/integration/test_admin_players.py
@@ -151,6 +151,46 @@ class TestPlayersList:
         assert response.status_code == 200
         assert "Test Player" in response.text
 
+    async def test_list_filters_by_career_and_draft_status(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_user_id: int,
+        sample_player_id: int,
+    ):
+        """Career and draft status filters narrow the admin player list."""
+        _ = admin_user_id
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO player_lifecycle (
+                    player_id, lifecycle_stage, competition_context,
+                    draft_status, career_status, current_affiliation_type,
+                    commitment_status, updated_at
+                )
+                VALUES (
+                    :id, 'COLLEGE', 'NCAA', 'DECLARED', 'PROSPECT',
+                    'COLLEGE_TEAM', 'UNKNOWN', CURRENT_TIMESTAMP
+                )
+                """
+            ),
+            {"id": sample_player_id},
+        )
+        await db_session.commit()
+        await login_staff(app_client, email=ADMIN_EMAIL, password=ADMIN_PASSWORD)
+
+        response = await app_client.get(
+            "/admin/players?career_status=prospect&draft_status=declared"
+        )
+        assert response.status_code == 200
+        assert "Test Player" in response.text
+        assert "Draft Prospect" in response.text
+        assert "Declared" in response.text
+
+        response = await app_client.get("/admin/players?career_status=retired")
+        assert response.status_code == 200
+        assert "Test Player" not in response.text
+
     async def test_list_shows_success_message(
         self,
         app_client: AsyncClient,
@@ -252,6 +292,21 @@ class TestPlayersCreate:
             )
         )
         assert result.scalar_one() == "New Player"
+
+        result = await db_session.execute(
+            text(
+                """
+                SELECT career_status, draft_status, is_draft_prospect
+                FROM player_lifecycle pl
+                JOIN players_master pm ON pm.id = pl.player_id
+                WHERE pm.display_name = 'New Player'
+                """
+            )
+        )
+        lifecycle = result.one()
+        assert lifecycle[0] == "PROSPECT"
+        assert lifecycle[1] == "UNKNOWN"
+        assert lifecycle[2] is True
 
     async def test_create_missing_display_name_error(
         self,
@@ -415,6 +470,7 @@ class TestPlayersEdit:
                 "last_name": "Player",
                 "school": "Test University",
                 "draft_year": "2024",
+                "career_status": "prospect",
                 "lifecycle_stage": "high_school",
                 "competition_context": "high_school",
                 "draft_status": "not_eligible",
@@ -432,7 +488,7 @@ class TestPlayersEdit:
         result = await db_session.execute(
             text(
                 """
-                SELECT lifecycle_stage, competition_context, draft_status,
+                SELECT career_status, lifecycle_stage, competition_context, draft_status,
                        expected_draft_year, current_affiliation_name,
                        current_affiliation_type, commitment_school,
                        commitment_status, is_draft_prospect
@@ -443,15 +499,59 @@ class TestPlayersEdit:
             {"id": sample_player_id},
         )
         row = result.one()
-        assert row[0] == "HIGH_SCHOOL"
+        assert row[0] == "PROSPECT"
         assert row[1] == "HIGH_SCHOOL"
-        assert row[2] == "NOT_ELIGIBLE"
-        assert row[3] == 2027
-        assert row[4] == "Montverde Academy"
-        assert row[5] == "HIGH_SCHOOL"
-        assert row[6] == "USC"
-        assert row[7] == "COMMITTED"
-        assert row[8] is True
+        assert row[2] == "HIGH_SCHOOL"
+        assert row[3] == "NOT_ELIGIBLE"
+        assert row[4] == 2027
+        assert row[5] == "Montverde Academy"
+        assert row[6] == "HIGH_SCHOOL"
+        assert row[7] == "USC"
+        assert row[8] == "COMMITTED"
+        assert row[9] is True
+
+    async def test_update_derives_legacy_active_flag_from_career_status(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_user_id: int,
+        sample_player_id: int,
+    ):
+        """Career status is the source for the old is_active_nba flag."""
+        _ = admin_user_id
+        await login_staff(app_client, email=ADMIN_EMAIL, password=ADMIN_PASSWORD)
+
+        response = await app_client.post(
+            f"/admin/players/{sample_player_id}",
+            data={
+                "display_name": "Test Player",
+                "first_name": "Test",
+                "last_name": "Player",
+                "school": "Test University",
+                "draft_year": "2024",
+                "career_status": "retired",
+                "draft_status": "drafted",
+                "current_team": "",
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code in {302, 303}
+
+        result = await db_session.execute(
+            text(
+                """
+                SELECT pl.career_status, pl.draft_status, ps.is_active_nba
+                FROM player_lifecycle pl
+                JOIN player_status ps ON ps.player_id = pl.player_id
+                WHERE pl.player_id = :id
+                """
+            ),
+            {"id": sample_player_id},
+        )
+        row = result.one()
+        assert row[0] == "RETIRED"
+        assert row[1] == "DRAFTED"
+        assert row[2] is False
 
     async def test_update_missing_required_field_error(
         self,

--- a/tests/integration/test_admin_players.py
+++ b/tests/integration/test_admin_players.py
@@ -191,6 +191,23 @@ class TestPlayersList:
         assert response.status_code == 200
         assert "Test Player" not in response.text
 
+    async def test_unknown_status_filters_include_missing_lifecycle_rows(
+        self,
+        app_client: AsyncClient,
+        admin_user_id: int,
+        sample_player_id: int,
+    ):
+        """Unknown taxonomy filters should include players with no lifecycle row."""
+        _ = admin_user_id
+        _ = sample_player_id
+        await login_staff(app_client, email=ADMIN_EMAIL, password=ADMIN_PASSWORD)
+
+        response = await app_client.get(
+            "/admin/players?career_status=unknown&draft_status=unknown"
+        )
+        assert response.status_code == 200
+        assert "Test Player" in response.text
+
     async def test_list_shows_success_message(
         self,
         app_client: AsyncClient,
@@ -552,6 +569,50 @@ class TestPlayersEdit:
         assert row[0] == "RETIRED"
         assert row[1] == "DRAFTED"
         assert row[2] is False
+
+    async def test_update_preserves_legacy_active_flag_when_career_unknown(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_user_id: int,
+        sample_player_id: int,
+    ):
+        """Saving unknown career status should not clear existing NBA active data."""
+        _ = admin_user_id
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO player_status (
+                    player_id, is_active_nba, source, updated_at
+                )
+                VALUES (:id, true, 'test', CURRENT_TIMESTAMP)
+                """
+            ),
+            {"id": sample_player_id},
+        )
+        await db_session.commit()
+        await login_staff(app_client, email=ADMIN_EMAIL, password=ADMIN_PASSWORD)
+
+        response = await app_client.post(
+            f"/admin/players/{sample_player_id}",
+            data={
+                "display_name": "Test Player",
+                "first_name": "Test",
+                "last_name": "Player",
+                "school": "Test University",
+                "draft_year": "2024",
+                "career_status": "unknown",
+                "draft_status": "unknown",
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code in {302, 303}
+
+        result = await db_session.execute(
+            text("SELECT is_active_nba FROM player_status WHERE player_id = :id"),
+            {"id": sample_player_id},
+        )
+        assert result.scalar_one() is True
 
     async def test_update_missing_required_field_error(
         self,

--- a/tests/integration/test_persist_player_mentions.py
+++ b/tests/integration/test_persist_player_mentions.py
@@ -1,13 +1,12 @@
 """Integration tests for _persist_player_mentions in news_ingestion_service."""
 
-from datetime import datetime, timezone
-
 import pytest
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.schemas.player_content_mentions import ContentType, MentionSource, PlayerContentMention
 from app.schemas.news_sources import NewsSource
+from app.schemas.player_content_mentions import ContentType, MentionSource, PlayerContentMention
+from app.schemas.player_lifecycle import CareerStatus, PlayerLifecycle
 from app.schemas.players_master import PlayerMaster
 from app.services.news_ingestion_service import _persist_player_mentions
 from tests.integration.conftest import make_article, make_player
@@ -83,6 +82,14 @@ class TestPersistPlayerMentions:
         )
         stub = (await db_session.execute(stmt)).scalar_one()
         assert stub.is_stub is True
+
+        lifecycle = (
+            await db_session.execute(
+                select(PlayerLifecycle).where(PlayerLifecycle.player_id == stub.id)
+            )
+        ).scalar_one()
+        assert lifecycle.career_status == CareerStatus.PROSPECT
+        assert lifecycle.is_draft_prospect is True
 
     async def test_skips_single_token_unknown_mentions(
         self,

--- a/tests/integration/test_player_mentions.py
+++ b/tests/integration/test_player_mentions.py
@@ -6,7 +6,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.schemas.player_aliases import PlayerAlias
-from app.schemas.player_lifecycle import DraftStatus, PlayerLifecycle
+from app.schemas.player_lifecycle import CareerStatus, DraftStatus, PlayerLifecycle
 from app.schemas.players_master import PlayerMaster
 from app.services.player_mention_service import resolve_player_names
 
@@ -114,8 +114,10 @@ async def test_create_stub_for_unknown_name(db_session: AsyncSession) -> None:
 
     lifecycle_stmt = select(PlayerLifecycle).where(PlayerLifecycle.player_id == row.id)
     lifecycle = (await db_session.execute(lifecycle_stmt)).scalar_one()
+    assert lifecycle.career_status == CareerStatus.PROSPECT
     assert lifecycle.draft_status == DraftStatus.UNKNOWN
     assert lifecycle.expected_draft_year is None
+    assert lifecycle.is_draft_prospect is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add explicit career_status taxonomy to player lifecycle with migration/backfill
- update admin create/edit/list flows to manage career and draft statuses directly
- derive legacy is_active_nba from career_status and mark mention-created stubs as draft prospects

## Verification
- conda run -n draftguru env DATABASE_URL='postgresql+asyncpg://user:pass@localhost:5432/test' SECRET_KEY='test-secret' ENV='dev' pytest tests/unit -q
- conda run -n draftguru mypy app --ignore-missing-imports
- conda run -n draftguru env DATABASE_URL='postgresql+asyncpg://user:pass@localhost:5432/test' SECRET_KEY='test-secret' ENV='dev' make precommit
- Browser UI verification against disposable local Postgres: create/edit/filter admin player taxonomy and mention-created stub taxonomy

## Notes
- Full integration suite skips locally without PYTEST_ALLOW_DB/TEST_DATABASE_URL.
- make visual still has unrelated homepage/film-room selector failures when run without a seeded app database.