### PR TITLE
Sticky news item + Silver Bulletin filter rework

### DIFF
--- a/alembic/versions/n3o4p5q6r7s8_add_news_items_is_sticky.py
+++ b/alembic/versions/n3o4p5q6r7s8_add_news_items_is_sticky.py
@@ -1,0 +1,46 @@
+"""Add is_sticky flag to news_items.
+
+Allows pinning a single news item to the top of the homepage and /news
+feeds. The single-sticky invariant is enforced at the service layer
+(setting is_sticky=True on one row unsets it on all others).
+
+Revision ID: n3o4p5q6r7s8
+Revises: m2n3o4p5q6r7
+Create Date: 2026-05-12
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op  # type: ignore[attr-defined]
+
+revision: str = "n3o4p5q6r7s8"
+down_revision: Union[str, None] = "m2n3o4p5q6r7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "news_items",
+        sa.Column(
+            "is_sticky",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    # Partial index makes the "fetch the sticky item" lookup O(1) without
+    # adding cost to inserts of non-sticky rows (which is ~all of them).
+    op.create_index(
+        "ix_news_items_is_sticky",
+        "news_items",
+        ["is_sticky"],
+        unique=False,
+        postgresql_where=sa.text("is_sticky = true"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_news_items_is_sticky", table_name="news_items")
+    op.drop_column("news_items", "is_sticky")

--- a/alembic/versions/o4p5q6r7s8t9_add_news_items_is_sticky.py
+++ b/alembic/versions/o4p5q6r7s8t9_add_news_items_is_sticky.py
@@ -30,13 +30,17 @@ def upgrade() -> None:
             server_default=sa.text("false"),
         ),
     )
-    # Partial index makes the "fetch the sticky item" lookup O(1) without
-    # adding cost to inserts of non-sticky rows (which is ~all of them).
+    # Unique partial index enforces the "at most one sticky row" invariant
+    # at the DB level, so a concurrent admin write that tries to pin a
+    # second article hits a constraint violation rather than silently
+    # leaving two rows with is_sticky=true. The partial WHERE also keeps
+    # the index O(1) for the "fetch the sticky item" lookup and adds no
+    # cost to inserts of non-sticky rows (which is ~all of them).
     op.create_index(
         "ix_news_items_is_sticky",
         "news_items",
         ["is_sticky"],
-        unique=False,
+        unique=True,
         postgresql_where=sa.text("is_sticky = true"),
     )
 

--- a/alembic/versions/o4p5q6r7s8t9_add_news_items_is_sticky.py
+++ b/alembic/versions/o4p5q6r7s8t9_add_news_items_is_sticky.py
@@ -4,8 +4,8 @@ Allows pinning a single news item to the top of the homepage and /news
 feeds. The single-sticky invariant is enforced at the service layer
 (setting is_sticky=True on one row unsets it on all others).
 
-Revision ID: n3o4p5q6r7s8
-Revises: m2n3o4p5q6r7
+Revision ID: o4p5q6r7s8t9
+Revises: n3o4p5q6r7s8
 Create Date: 2026-05-12
 """
 
@@ -14,8 +14,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op  # type: ignore[attr-defined]
 
-revision: str = "n3o4p5q6r7s8"
-down_revision: Union[str, None] = "m2n3o4p5q6r7"
+revision: str = "o4p5q6r7s8t9"
+down_revision: Union[str, None] = "n3o4p5q6r7s8"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/app/models/news.py
+++ b/app/models/news.py
@@ -22,6 +22,7 @@ class NewsItemRead(SQLModel):
     tag: str  # "Riser", "Faller", etc.
     read_more_text: str  # "Read at Floor and Ceiling"
     is_player_specific: bool = False  # True when article mentions this player
+    is_sticky: bool = False  # True when this item is pinned to the top of feeds
 
 
 class NewsFeedResponse(SQLModel):

--- a/app/routes/admin/news_items.py
+++ b/app/routes/admin/news_items.py
@@ -21,6 +21,7 @@ from app.routes.admin.helpers import (
 from app.schemas.news_items import NewsItem, NewsItemTag
 from app.schemas.news_sources import NewsSource
 from app.schemas.players_master import PlayerMaster
+from app.services.news_service import set_sticky_news_item
 from app.utils.db_async import get_session
 
 router = APIRouter(prefix="/news-items", tags=["admin-news-items"])
@@ -218,6 +219,7 @@ async def update_news_item(
     tag: str = Form(...),
     player_id: str | None = Form(default=None),
     summary: str | None = Form(default=None),
+    is_sticky: str | None = Form(default=None),
     db: AsyncSession = Depends(get_session),
 ) -> Response:
     """Update a news item."""
@@ -294,6 +296,18 @@ async def update_news_item(
         item.tag = tag_enum
         item.player_id = parsed_player_id
         item.summary = summary.strip() if summary and summary.strip() else None
+
+        # Sticky toggle: HTML form posts the field only when checked.
+        # set_sticky_news_item enforces the single-sticky invariant.
+        wants_sticky = is_sticky is not None and is_sticky.lower() in (
+            "on",
+            "true",
+            "1",
+        )
+        if wants_sticky:
+            await set_sticky_news_item(db, item_id)
+        elif item.is_sticky:
+            await set_sticky_news_item(db, None)
 
     return RedirectResponse(url="/admin/news-items?success=updated", status_code=303)
 

--- a/app/routes/ui.py
+++ b/app/routes/ui.py
@@ -511,34 +511,41 @@ async def news_page(
     db: AsyncSession = Depends(get_session),
 ):
     """Render the dedicated News page with filterable article feed."""
-    # Fetch filtered news feed
+    # Sticky pins to the top of the default /news view only: zero active
+    # filters. Once the user narrows the feed, the pin steps aside.
+    has_filters = any(
+        v is not None and v != "" for v in (tag, source, author, player, period)
+    )
+    sticky_item: NewsItemRead | None = None
+    if not has_filters:
+        sticky_item = await get_sticky_news_item(db)
+    sticky_id = sticky_item.id if sticky_item is not None else None
+
+    # When a sticky is in play, page 1 surrenders one slot to it (limit-1
+    # natural results + sticky card = NEWS_PAGE_LIMIT cards) and pages 2+
+    # shift their offset back by 1 to backfill the slot that page 1 did
+    # not consume. The query also drops the sticky id outright so it
+    # cannot reappear at its natural position on a later page.
+    sticky_consumed_a_slot = 1 if sticky_id is not None else 0
+    feed_limit = NEWS_PAGE_LIMIT - (sticky_consumed_a_slot if offset == 0 else 0)
+    feed_offset = offset - sticky_consumed_a_slot if offset > 0 else 0
+
     feed = await get_filtered_news_feed(
         db,
-        limit=NEWS_PAGE_LIMIT,
-        offset=offset,
+        limit=feed_limit,
+        offset=feed_offset,
         tag=tag,
         source_id=source,
         author=author,
         player_id=player,
         period=period,
+        exclude_id=sticky_id,
     )
-
-    # Sticky pins to the top of the default /news view only: first page and
-    # zero active filters. Once the user narrows the feed, the pin steps aside.
-    has_filters = any(
-        v is not None and v != "" for v in (tag, source, author, player, period)
-    )
-    sticky_item: NewsItemRead | None = None
-    if offset == 0 and not has_filters:
-        sticky_item = await get_sticky_news_item(db)
 
     feed_items: list[dict] = []
-    sticky_id = sticky_item.id if sticky_item is not None else None
-    if sticky_item is not None:
+    if sticky_item is not None and offset == 0:
         feed_items.append(_news_item_to_dict(sticky_item, is_sticky=True))
     for item in feed.items:
-        if item.id == sticky_id:
-            continue
         item_source = item.source_name.strip()
         item_author = (item.author or "").strip() or None
         feed_items.append(
@@ -556,6 +563,11 @@ async def news_page(
                 "is_sticky": False,
             }
         )
+
+    # Pagination math runs on the full feed including the sticky card, so
+    # the page links land on the right offsets and "X-Y of Z" matches the
+    # number of cards a user actually scrolls past.
+    total = feed.total + sticky_consumed_a_slot
 
     # Hero article: first page of any filter view
     hero_article_dict = None
@@ -628,7 +640,7 @@ async def news_page(
             "sources": sources_data,
             "authors": authors_list,
             "trending_players": trending_players,
-            "total": feed.total,
+            "total": total,
             "limit": NEWS_PAGE_LIMIT,
             "offset": offset,
             "active_tag": tag,

--- a/app/routes/ui.py
+++ b/app/routes/ui.py
@@ -9,6 +9,7 @@ from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.services.expanded_trending_service import get_expanded_trending_players
+from app.models.news import NewsItemRead
 from app.services.news_service import (
     format_relative_time,
     get_author_counts,
@@ -17,6 +18,7 @@ from app.services.news_service import (
     get_news_feed,
     get_player_news_feed,
     get_source_counts,
+    get_sticky_news_item,
     get_trending_players,
 )
 from app.schemas.player_content_mentions import ContentType
@@ -67,6 +69,23 @@ FOOTER_LINKS = [
 HOME_NEWS_FEED_LIMIT = 100
 HOME_NEWS_SIDEBAR_LIMIT = 8
 HOME_FILM_ROOM_LIMIT = 24
+
+
+def _news_item_to_dict(item: NewsItemRead, *, is_sticky: bool = False) -> dict:
+    """Render a NewsItemRead as the dict shape feed templates expect."""
+    return {
+        "id": item.id,
+        "source": item.source_name.strip(),
+        "title": item.title,
+        "summary": item.summary,
+        "url": item.url,
+        "image_url": item.image_url,
+        "author": (item.author or "").strip() or None,
+        "time": item.time,
+        "tag": item.tag,
+        "read_more_text": item.read_more_text,
+        "is_sticky": is_sticky,
+    }
 
 
 @router.get("/", response_class=HTMLResponse)
@@ -142,10 +161,17 @@ async def home(
     # Fetch news feed from database (falls back to empty if no items yet)
     # Fetch more items to enable pagination (6 per page in new grid layout)
     news_feed = await get_news_feed(db, limit=HOME_NEWS_FEED_LIMIT)
+    sticky_item = await get_sticky_news_item(db)
     source_counter: Counter[str] = Counter()
     author_counter: Counter[str] = Counter()
     feed_items: list[dict] = []
+    if sticky_item is not None:
+        feed_items.append(_news_item_to_dict(sticky_item, is_sticky=True))
+    sticky_id = sticky_item.id if sticky_item is not None else None
     for item in news_feed.items:
+        if item.id == sticky_id:
+            # Already prepended via the sticky lookup; skip the duplicate.
+            continue
         source = item.source_name.strip()
         author = (item.author or "").strip() or None
 
@@ -165,6 +191,7 @@ async def home(
                 "time": item.time,
                 "tag": item.tag,
                 "read_more_text": item.read_more_text,
+                "is_sticky": False,
             }
         )
 
@@ -496,8 +523,22 @@ async def news_page(
         period=period,
     )
 
+    # Sticky pins to the top of the default /news view only: first page and
+    # zero active filters. Once the user narrows the feed, the pin steps aside.
+    has_filters = any(
+        v is not None and v != "" for v in (tag, source, author, player, period)
+    )
+    sticky_item: NewsItemRead | None = None
+    if offset == 0 and not has_filters:
+        sticky_item = await get_sticky_news_item(db)
+
     feed_items: list[dict] = []
+    sticky_id = sticky_item.id if sticky_item is not None else None
+    if sticky_item is not None:
+        feed_items.append(_news_item_to_dict(sticky_item, is_sticky=True))
     for item in feed.items:
+        if item.id == sticky_id:
+            continue
         item_source = item.source_name.strip()
         item_author = (item.author or "").strip() or None
         feed_items.append(
@@ -512,6 +553,7 @@ async def news_page(
                 "time": item.time,
                 "tag": item.tag,
                 "read_more_text": item.read_more_text,
+                "is_sticky": False,
             }
         )
 

--- a/app/schemas/news_items.py
+++ b/app/schemas/news_items.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
+import sqlalchemy as sa
 from sqlalchemy import Column, Enum as SAEnum, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
@@ -86,3 +87,16 @@ class NewsItem(SQLModel, table=True):  # type: ignore[call-arg]
 
     # Future: player association
     player_id: Optional[int] = Field(default=None, foreign_key="players_master.id")
+
+    # Pinned/sticky: when true, this item is rendered at the top of the homepage
+    # and /news feeds. At most one row should have is_sticky=True at a time;
+    # the service layer enforces this invariant on writes.
+    is_sticky: bool = Field(
+        default=False,
+        sa_column=Column(
+            "is_sticky",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )

--- a/app/schemas/news_items.py
+++ b/app/schemas/news_items.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Optional
 
 import sqlalchemy as sa
-from sqlalchemy import Column, Enum as SAEnum, UniqueConstraint
+from sqlalchemy import Column, Enum as SAEnum, Index, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
 
@@ -54,6 +54,16 @@ class NewsItem(SQLModel, table=True):  # type: ignore[call-arg]
     __table_args__ = (
         UniqueConstraint(
             "source_id", "external_id", name="uq_news_items_source_external"
+        ),
+        # Unique partial index enforces the "at most one sticky row" invariant
+        # at the DB level. Mirrors the migration in
+        # alembic/versions/o4p5q6r7s8t9_add_news_items_is_sticky.py so test
+        # schemas built via SQLModel.metadata.create_all also pick it up.
+        Index(
+            "ix_news_items_is_sticky",
+            "is_sticky",
+            unique=True,
+            postgresql_where=sa.text("is_sticky = true"),
         ),
     )
 

--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -493,6 +493,7 @@ async def get_filtered_news_feed(
     author: str | None = None,
     player_id: int | None = None,
     period: str | None = None,
+    exclude_id: int | None = None,
 ) -> NewsFeedResponse:
     """Fetch paginated news feed with optional multi-dimensional filters.
 
@@ -507,6 +508,9 @@ async def get_filtered_news_feed(
         author: Filter by author name (case-insensitive)
         player_id: Filter to articles mentioning this player
         period: Time window filter ("today", "week", "month", or None for all)
+        exclude_id: Drop a specific news_item id from both items and total
+            (used to keep the sticky item from appearing twice when it is
+            rendered as a pinned card outside the normal pagination flow).
 
     Returns:
         NewsFeedResponse with filtered items and accurate total
@@ -518,6 +522,10 @@ async def get_filtered_news_feed(
     )
 
     count_base = select(func.count()).select_from(NewsItem)
+
+    if exclude_id is not None:
+        base_query = base_query.where(NewsItem.id != exclude_id)  # type: ignore[arg-type]
+        count_base = count_base.where(NewsItem.id != exclude_id)  # type: ignore[arg-type]
 
     # Apply filters to both queries
     if tag:

--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -28,6 +28,7 @@ _NEWS_FEED_COLUMNS = [
     NewsItem.author,
     NewsItem.tag,
     NewsItem.published_at,
+    NewsItem.is_sticky,
     NewsSource.display_name.label("source_name"),  # type: ignore[attr-defined]
 ]
 
@@ -745,4 +746,52 @@ def _row_to_news_item_read(row: dict, is_player_specific: bool = False) -> NewsI
         tag=_resolve_tag(row["tag"]),
         read_more_text=build_read_more_text(source_name),
         is_player_specific=is_player_specific,
+        is_sticky=bool(row.get("is_sticky", False)),
+    )
+
+
+async def get_sticky_news_item(db: AsyncSession) -> Optional[NewsItemRead]:
+    """Return the currently pinned news item, if any.
+
+    Uses the partial index on `is_sticky = true` for an O(1) lookup. The
+    service layer enforces a single sticky row, so `.limit(1)` is defensive.
+    """
+    stmt = (
+        select(*_NEWS_FEED_COLUMNS)  # type: ignore[call-overload]
+        .select_from(NewsItem)
+        .join(NewsSource, NewsSource.id == NewsItem.source_id)  # type: ignore[arg-type]
+        .where(NewsItem.is_sticky.is_(True))  # type: ignore[attr-defined]
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    row = result.mappings().first()
+    if not row:
+        return None
+    return _row_to_news_item_read(row)  # type: ignore[arg-type]
+
+
+async def set_sticky_news_item(db: AsyncSession, item_id: int | None) -> None:
+    """Pin `item_id` and unpin every other row, atomically.
+
+    Passing `item_id=None` clears the sticky entirely. Callers manage the
+    surrounding transaction (e.g., admin route wraps its updates in
+    `async with db.begin()`); we only emit the UPDATEs here.
+    """
+    from sqlalchemy import update
+
+    # Always unpin every currently-sticky row first. Cheap given the partial
+    # index, and keeps the invariant: at most one sticky row.
+    await db.execute(
+        update(NewsItem)
+        .where(NewsItem.is_sticky.is_(True))  # type: ignore[attr-defined]
+        .values(is_sticky=False)
+    )
+
+    if item_id is None:
+        return
+
+    await db.execute(
+        update(NewsItem)
+        .where(NewsItem.id == item_id)  # type: ignore[arg-type]
+        .values(is_sticky=True)
     )

--- a/app/services/publisher_filters.py
+++ b/app/services/publisher_filters.py
@@ -2,7 +2,7 @@
 
 Some publishers grant limited reuse rights. These filters honor those
 restrictions at the ingestion layer, before any AI relevance scoring
-runs — failing conservatively (when in doubt, exclude). Currently only
+runs -- failing conservatively (when in doubt, exclude). Currently only
 Silver Bulletin (natesilver.net) is wired up.
 """
 
@@ -11,19 +11,24 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import httpx
-
 logger = logging.getLogger(__name__)
 
 _SILVER_BULLETIN_HOST = "natesilver.net"
-_SUBSTACK_ARCHIVE_URL = "https://www.natesilver.net/api/v1/archive"
-_ARCHIVE_PAGE_LIMIT = 50
-_ARCHIVE_MAX_POSTS = 500
-_ARCHIVE_TIMEOUT = httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0)
-_USER_AGENT = "DraftGuru/1.0 (+https://draftguru)"
 
-_EXCLUDED_SECTION_SLUGS: frozenset[str] = frozenset({"models-and-forecasts"})
-_EXCLUDED_SLUG_SUBSTRINGS: tuple[str, ...] = ("methodology",)
+# Slug substrings that flag a post as a methodology / "how the model works"
+# explainer. Joseph George (May 2026) requested we surface the landing /
+# rankings pages but not the methodology write-ups he hides on the site.
+#
+# We deliberately match on slug rather than Substack section_slug because
+# section is a poor proxy: ``models-and-forecasts`` contains both the
+# rankings pages (admit) and some methodology pages (drop), while ``sports``
+# contains the PRISM "how our model works" methodology page itself. Slug
+# patterns map directly to article *type*.
+_EXCLUDED_SLUG_SUBSTRINGS: tuple[str, ...] = (
+    "methodology",
+    "model-works",
+    "how-we-calculate",
+)
 
 
 async def apply_publisher_filters(
@@ -43,33 +48,28 @@ async def apply_publisher_filters(
         Tuple of ``(kept_entries, dropped_count)``.
     """
     if _SILVER_BULLETIN_HOST in feed_url.lower():
-        return await _filter_silver_bulletin(entries)
+        return _filter_silver_bulletin(entries)
     return entries, 0
 
 
-async def _filter_silver_bulletin(
+def _filter_silver_bulletin(
     entries: list[dict[str, Any]],
 ) -> tuple[list[dict[str, Any]], int]:
-    """Drop methodology posts and Models & Forecasts section posts.
+    """Drop Silver Bulletin methodology / model-works explainers.
 
     Honors Silver Bulletin's editorial restriction (per Joseph George,
-    May 2026): methodology pages and the Models & Forecasts dashboards
-    should not be indexed on DraftGuru.
+    May 2026 clarification): the rankings/landing pages (e.g., PRISM
+    draft rankings) should be displayed; the methodology pages (e.g.,
+    "How our PRISM NBA draft model works") should not.
 
-    Two filters run as a union:
-    1. URL slug contains ``methodology`` — catches all known methodology
-       articles regardless of section. Cheap, no network dependency.
-    2. Substack ``section_slug == "models-and-forecasts"`` — catches the
-       live-model dashboard pages. Requires one ``/api/v1/archive`` call
-       per ingestion cycle to map URL → section_slug.
-
-    On archive API failure the section filter is skipped (logged as a
-    warning); the slug filter still applies.
+    Filtering is slug-substring only. The Substack ``section_slug`` was
+    tried as a secondary signal but proved unreliable (see the comment
+    on ``_EXCLUDED_SLUG_SUBSTRINGS``), so it was removed. Non-draft
+    dashboard pages (e.g., Trump approval, NCAA team ratings) are
+    handled by the downstream draft-relevance gate.
     """
     if not entries:
         return [], 0
-
-    url_to_section = await _fetch_silver_bulletin_archive()
 
     kept: list[dict[str, Any]] = []
     dropped = 0
@@ -78,7 +78,7 @@ async def _filter_silver_bulletin(
         if not url:
             kept.append(entry)
             continue
-        drop, reason = _should_drop_silver_bulletin(url, url_to_section)
+        drop, reason = _should_drop_silver_bulletin(url)
         if drop:
             dropped += 1
             logger.info(f"  Silver Bulletin: dropping {url[:80]} ({reason})")
@@ -87,67 +87,10 @@ async def _filter_silver_bulletin(
     return kept, dropped
 
 
-def _should_drop_silver_bulletin(
-    url: str,
-    url_to_section: dict[str, str],
-) -> tuple[bool, str]:
-    """Return ``(drop, reason)`` for a Silver Bulletin entry URL.
-
-    Slug check runs first so it works even when the archive map is empty
-    (API failure fallback).
-    """
+def _should_drop_silver_bulletin(url: str) -> tuple[bool, str]:
+    """Return ``(drop, reason)`` for a Silver Bulletin entry URL."""
     url_lower = url.lower()
     for marker in _EXCLUDED_SLUG_SUBSTRINGS:
         if marker in url_lower:
             return True, f"slug contains '{marker}'"
-    section_slug = url_to_section.get(url)
-    if section_slug in _EXCLUDED_SECTION_SLUGS:
-        return True, f"section_slug={section_slug}"
     return False, ""
-
-
-async def _fetch_silver_bulletin_archive() -> dict[str, str]:
-    """Build a ``canonical_url -> section_slug`` map from the Substack archive.
-
-    Paginated up to ``_ARCHIVE_MAX_POSTS`` (currently 500). On any failure
-    (network, non-2xx, JSON shape change) returns an empty map; callers
-    must treat that as "section info unavailable" rather than "no
-    exclusions apply".
-    """
-    url_to_section: dict[str, str] = {}
-    try:
-        async with httpx.AsyncClient(
-            headers={"User-Agent": _USER_AGENT},
-            timeout=_ARCHIVE_TIMEOUT,
-            follow_redirects=True,
-        ) as client:
-            for offset in range(0, _ARCHIVE_MAX_POSTS, _ARCHIVE_PAGE_LIMIT):
-                resp = await client.get(
-                    _SUBSTACK_ARCHIVE_URL,
-                    params={
-                        "sort": "new",
-                        "offset": offset,
-                        "limit": _ARCHIVE_PAGE_LIMIT,
-                    },
-                )
-                resp.raise_for_status()
-                batch = resp.json()
-                if not isinstance(batch, list) or not batch:
-                    break
-                for post in batch:
-                    if not isinstance(post, dict):
-                        continue
-                    canonical_url = post.get("canonical_url")
-                    section_slug = post.get("section_slug")
-                    if isinstance(canonical_url, str) and isinstance(section_slug, str):
-                        url_to_section[canonical_url] = section_slug
-                if len(batch) < _ARCHIVE_PAGE_LIMIT:
-                    break
-    except (httpx.HTTPError, ValueError) as exc:
-        logger.warning(
-            "Silver Bulletin archive fetch failed; falling back to slug-only "
-            f"filter: {exc}"
-        )
-        return {}
-    logger.debug(f"Silver Bulletin archive: mapped {len(url_to_section)} URLs")
-    return url_to_section

--- a/app/static/css/admin.css
+++ b/app/static/css/admin.css
@@ -412,6 +412,14 @@
   color: var(--color-slate-900);
 }
 
+.admin-badge--sticky {
+  background: var(--color-accent-amber, #f5b800);
+  color: var(--color-slate-900);
+  margin-right: 0.4rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 /* === Empty States === */
 .admin-empty {
   text-align: center;

--- a/app/static/css/news-grid.css
+++ b/app/static/css/news-grid.css
@@ -126,6 +126,34 @@
   font-family: var(--font-mono);
 }
 
+.article-card__meta-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Sticky / pinned indicator -- intentionally restrained. The card itself stays
+   unchanged in size and layout; only a small amber label + a hair-thin top
+   accent stripe distinguishes it from neighbors. */
+.article-card--sticky {
+  box-shadow:
+    inset 0 2px 0 0 var(--color-accent-amber),
+    0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.article-card__pinned {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-accent-amber);
+  padding: 0.125rem 0.375rem;
+  border: 1px solid var(--color-accent-amber);
+  border-radius: 0.25rem;
+  line-height: 1;
+}
+
 /* ============================================================================
    TAG COLOR CLASSES
    Solid backgrounds with white text for visibility on images

--- a/app/static/js/home.js
+++ b/app/static/js/home.js
@@ -540,9 +540,13 @@ const NewsGridModule = {
   renderArticleCard(item) {
     const tagClass = DraftGuru.getTagClass(item.tag);
     const hasImage = item.image_url && item.image_url.trim() !== '';
+    const stickyClass = item.is_sticky ? ' article-card--sticky' : '';
+    const stickyLabel = item.is_sticky
+      ? '<span class="article-card__pinned" aria-label="Pinned post">Pinned</span>'
+      : '';
 
     return `
-      <article class="article-card" onclick="window.open('${DraftGuru.escapeHtml(item.url)}', '_blank')">
+      <article class="article-card${stickyClass}" onclick="window.open('${DraftGuru.escapeHtml(item.url)}', '_blank')">
         <div class="article-card__image-wrapper">
           ${hasImage
             ? `<img src="${DraftGuru.escapeHtml(item.image_url)}" class="article-card__image" alt="" loading="lazy" />`
@@ -555,7 +559,10 @@ const NewsGridModule = {
           ${item.summary ? `<p class="article-card__summary">${DraftGuru.escapeHtml(item.summary)}</p>` : ''}
           <div class="article-card__meta">
             <span class="article-card__source">${DraftGuru.escapeHtml(item.source)}</span>
-            <span class="article-card__time">${DraftGuru.escapeHtml(item.time)}</span>
+            <span class="article-card__meta-right">
+              ${stickyLabel}
+              <span class="article-card__time">${DraftGuru.escapeHtml(item.time)}</span>
+            </span>
           </div>
         </div>
       </article>

--- a/app/static/js/news.js
+++ b/app/static/js/news.js
@@ -155,9 +155,13 @@ const NewsArticleGridModule = {
     const tagClass = DraftGuru.getTagClass(item.tag);
     const hasImage = item.image_url && item.image_url.trim() !== '';
     const esc = DraftGuru.escapeHtml.bind(DraftGuru);
+    const stickyClass = item.is_sticky ? ' article-card--sticky' : '';
+    const stickyLabel = item.is_sticky
+      ? '<span class="article-card__pinned" aria-label="Pinned post">Pinned</span>'
+      : '';
 
     return `
-      <article class="article-card" onclick="window.open('${esc(item.url)}', '_blank')">
+      <article class="article-card${stickyClass}" onclick="window.open('${esc(item.url)}', '_blank')">
         <div class="article-card__image-wrapper">
           ${hasImage
             ? `<img src="${esc(item.image_url)}" class="article-card__image" alt="" loading="lazy" />`
@@ -170,7 +174,10 @@ const NewsArticleGridModule = {
           ${item.summary ? `<p class="article-card__summary">${esc(item.summary)}</p>` : ''}
           <div class="article-card__meta">
             <span class="article-card__source">${esc(item.source)}</span>
-            <span class="article-card__time">${esc(item.time)}</span>
+            <span class="article-card__meta-right">
+              ${stickyLabel}
+              <span class="article-card__time">${esc(item.time)}</span>
+            </span>
           </div>
         </div>
       </article>

--- a/app/templates/admin/news-items/form.html
+++ b/app/templates/admin/news-items/form.html
@@ -101,6 +101,24 @@
       <span class="admin-form__help">A concise summary for display in feeds</span>
     </div>
 
+    <div class="admin-form__field">
+      <label class="admin-form__label" for="is_sticky">
+        <input
+          type="checkbox"
+          id="is_sticky"
+          name="is_sticky"
+          value="on"
+          {% if item.is_sticky %}checked{% endif %}
+        >
+        Pin to top of feeds
+      </label>
+      <span class="admin-form__help">
+        Renders this article at the top of the homepage and /news feeds.
+        Only one item can be pinned at a time — checking this auto-unpins
+        any other sticky article.
+      </span>
+    </div>
+
     <div class="admin-form__actions">
       <button type="submit" class="admin-btn admin-btn--primary">Save Changes</button>
       <a href="/admin/news-items" class="admin-btn admin-btn--secondary">Cancel</a>

--- a/app/templates/admin/news-items/index.html
+++ b/app/templates/admin/news-items/index.html
@@ -78,6 +78,7 @@
       {% for item in items %}
       <tr>
         <td>
+          {% if item.is_sticky %}<span class="admin-badge admin-badge--sticky" title="Pinned to top of feeds">Sticky</span>{% endif %}
           <a href="{{ item.url }}" target="_blank" rel="noopener noreferrer" class="admin-link">
             {{ item.title | truncate(60) }}
           </a>

--- a/tests/integration/test_news_ingestion_relevance.py
+++ b/tests/integration/test_news_ingestion_relevance.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.schemas.news_items import NewsItem, NewsItemTag
 from app.schemas.news_sources import FeedType, NewsSource
-from app.services import news_ingestion_service, publisher_filters
+from app.services import news_ingestion_service
 from app.services.news_ingestion_service import (
     NewsSourceSnapshot,
     ingest_rss_source,
@@ -287,13 +287,17 @@ class TestIngestionRelevanceGate:
 
 @pytest.mark.asyncio
 class TestSilverBulletinPublisherFilter:
-    """Silver Bulletin honors a no-methodology / no-models-and-forecasts rule.
+    """Silver Bulletin honors a no-methodology-pages rule.
 
-    The filter activates by feed_url host (``natesilver.net``) and applies a
-    union of two checks: URL slug substring ``methodology`` and Substack
-    ``section_slug == "models-and-forecasts"``. Excluded entries are counted
-    against ``items_filtered`` and never reach the relevance gate or AI
-    analysis.
+    The filter activates by feed_url host (``natesilver.net``) and drops any
+    post whose URL slug contains one of the methodology markers
+    (``methodology``, ``model-works``, ``how-we-calculate``). The Substack
+    ``section_slug`` was tried as a secondary signal during prototyping but
+    proved unreliable -- the ``models-and-forecasts`` section contains both
+    the PRISM draft rankings (admit) and some methodology pages (drop), and
+    the PRISM methodology page itself lives in ``sports``. Excluded entries
+    are counted against ``items_filtered`` and never reach the relevance
+    gate or AI analysis.
     """
 
     async def test_methodology_slug_is_filtered(
@@ -322,9 +326,6 @@ class TestSilverBulletinPublisherFilter:
                 ),
             ]
 
-        async def fake_archive() -> dict[str, str]:
-            return {}  # archive empty -- slug filter alone must catch it
-
         async def fake_relevance(title: str, _desc: str) -> bool:
             relevance_calls.append(title)
             return True
@@ -334,9 +335,6 @@ class TestSilverBulletinPublisherFilter:
             return _stub_analysis()
 
         monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
-        monkeypatch.setattr(
-            publisher_filters, "_fetch_silver_bulletin_archive", fake_archive
-        )
         monkeypatch.setattr(
             news_ingestion_service.news_summarization_service,
             "check_draft_relevance",
@@ -357,36 +355,39 @@ class TestSilverBulletinPublisherFilter:
         assert analyze_calls == []
         assert relevance_calls == []
 
-    async def test_models_and_forecasts_section_is_filtered(
+    async def test_prism_methodology_page_is_filtered(
         self,
         db_session: AsyncSession,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Posts whose Substack section_slug is 'models-and-forecasts' are dropped."""
+        """The PRISM 'how our model works' methodology page is dropped.
+
+        Joseph George (May 2026) specifically called this URL out as a
+        methodology page that should not be indexed. Its slug does not
+        contain 'methodology' literally -- the ``model-works`` substring
+        is what catches it.
+        """
         source = await _make_source(
             db_session,
-            name="silver-bulletin-mf",
+            name="silver-bulletin-prism-meth",
             feed_url="https://www.natesilver.net/feed",
             is_draft_focused=False,
         )
 
-        dashboard_url = (
-            "https://www.natesilver.net/p/trump-approval-ratings-nate-silver-bulletin"
-        )
         analyze_calls: list[str] = []
 
         async def fake_fetch(_url: str) -> list[dict[str, Any]]:
             return [
                 _entry(
-                    "g-mf",
-                    "How popular is Donald Trump?",
-                    "Live tracker",
-                    link=dashboard_url,
+                    "g-prism-meth",
+                    "How our PRISM NBA draft model works",
+                    "Methodology behind the rankings",
+                    link=(
+                        "https://www.natesilver.net/p/"
+                        "how-our-prism-nba-draft-model-works"
+                    ),
                 ),
             ]
-
-        async def fake_archive() -> dict[str, str]:
-            return {dashboard_url: "models-and-forecasts"}
 
         async def fake_relevance(_title: str, _desc: str) -> bool:
             return True
@@ -396,9 +397,6 @@ class TestSilverBulletinPublisherFilter:
             return _stub_analysis()
 
         monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
-        monkeypatch.setattr(
-            publisher_filters, "_fetch_silver_bulletin_archive", fake_archive
-        )
         monkeypatch.setattr(
             news_ingestion_service.news_summarization_service,
             "check_draft_relevance",
@@ -418,40 +416,39 @@ class TestSilverBulletinPublisherFilter:
         assert filtered == 1
         assert analyze_calls == []
 
-    async def test_other_section_passes_through_to_relevance_gate(
+    async def test_prism_rankings_landing_page_is_admitted(
         self,
         db_session: AsyncSession,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Posts outside excluded sections still hit the relevance gate.
+        """The PRISM draft rankings landing page must pass the publisher filter.
 
-        A sports-section post with a draft keyword should be admitted.
+        Joseph George (May 2026) explicitly wants the rankings page surfaced.
+        The earlier prototype filter dropped it (section_slug match); the
+        slug-only filter admits it as long as the relevance gate also lets
+        it through.
         """
         source = await _make_source(
             db_session,
-            name="silver-bulletin-pass",
+            name="silver-bulletin-prism-landing",
             feed_url="https://www.natesilver.net/feed",
             is_draft_focused=False,
         )
 
-        draft_url = (
-            "https://www.natesilver.net/p/"
-            "radical-plan-to-replace-the-nba-draft-lottery-arc-auction"
-        )
         analyze_calls: list[str] = []
 
         async def fake_fetch(_url: str) -> list[dict[str, Any]]:
             return [
                 _entry(
-                    "g-draft",
-                    "Our radical plan to replace the NBA draft lottery",
-                    "Auction-based draft order",
-                    link=draft_url,
+                    "g-prism-landing",
+                    "PRISM 2026 NBA draft rankings",
+                    "Our model's top prospects",
+                    link=(
+                        "https://www.natesilver.net/p/"
+                        "prism-2026-nba-draft-rankings"
+                    ),
                 ),
             ]
-
-        async def fake_archive() -> dict[str, str]:
-            return {draft_url: "sports"}
 
         async def fake_relevance(_title: str, _desc: str) -> bool:
             return True
@@ -462,8 +459,115 @@ class TestSilverBulletinPublisherFilter:
 
         monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
         monkeypatch.setattr(
-            publisher_filters, "_fetch_silver_bulletin_archive", fake_archive
+            news_ingestion_service.news_summarization_service,
+            "check_draft_relevance",
+            fake_relevance,
         )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "analyze_article",
+            fake_analyze,
+        )
+
+        added, _skipped, filtered, _mentions = await ingest_rss_source(
+            db_session, _snapshot(source)
+        )
+
+        assert added == 1
+        assert filtered == 0
+        assert analyze_calls == ["PRISM 2026 NBA draft rankings"]
+
+    async def test_how_we_calculate_slug_is_filtered(
+        self,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Future methodology pages using the 'how-we-calculate-*' pattern drop."""
+        source = await _make_source(
+            db_session,
+            name="silver-bulletin-howcalc",
+            feed_url="https://www.natesilver.net/feed",
+            is_draft_focused=False,
+        )
+
+        analyze_calls: list[str] = []
+
+        async def fake_fetch(_url: str) -> list[dict[str, Any]]:
+            return [
+                _entry(
+                    "g-howcalc",
+                    "How we calculate our draft model",
+                    "Inner workings",
+                    link=(
+                        "https://www.natesilver.net/p/"
+                        "how-we-calculate-our-draft-model"
+                    ),
+                ),
+            ]
+
+        async def fake_relevance(_title: str, _desc: str) -> bool:
+            return True
+
+        async def fake_analyze(title: str, description: str) -> ArticleAnalysis:
+            analyze_calls.append(title)
+            return _stub_analysis()
+
+        monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "check_draft_relevance",
+            fake_relevance,
+        )
+        monkeypatch.setattr(
+            news_ingestion_service.news_summarization_service,
+            "analyze_article",
+            fake_analyze,
+        )
+
+        added, _skipped, filtered, _mentions = await ingest_rss_source(
+            db_session, _snapshot(source)
+        )
+
+        assert added == 0
+        assert filtered == 1
+        assert analyze_calls == []
+
+    async def test_non_methodology_silver_bulletin_post_passes_through(
+        self,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A non-methodology Silver Bulletin post still hits the relevance gate."""
+        source = await _make_source(
+            db_session,
+            name="silver-bulletin-pass",
+            feed_url="https://www.natesilver.net/feed",
+            is_draft_focused=False,
+        )
+
+        analyze_calls: list[str] = []
+
+        async def fake_fetch(_url: str) -> list[dict[str, Any]]:
+            return [
+                _entry(
+                    "g-draft",
+                    "Our radical plan to replace the NBA draft lottery",
+                    "Auction-based draft order",
+                    link=(
+                        "https://www.natesilver.net/p/"
+                        "radical-plan-to-replace-the-nba-draft-lottery-arc-auction"
+                    ),
+                ),
+            ]
+
+        async def fake_relevance(_title: str, _desc: str) -> bool:
+            return True
+
+        async def fake_analyze(title: str, description: str) -> ArticleAnalysis:
+            analyze_calls.append(title)
+            return _stub_analysis()
+
+        monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
         monkeypatch.setattr(
             news_ingestion_service.news_summarization_service,
             "check_draft_relevance",
@@ -483,80 +587,6 @@ class TestSilverBulletinPublisherFilter:
         assert filtered == 0
         assert len(analyze_calls) == 1
 
-    async def test_archive_failure_still_filters_methodology_slug(
-        self,
-        db_session: AsyncSession,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Archive API failure → section filter is bypassed but slug filter still runs.
-
-        Defense-in-depth: section info is the secondary layer. Failing the
-        archive lookup must not blackhole the entire feed.
-        """
-        source = await _make_source(
-            db_session,
-            name="silver-bulletin-fallback",
-            feed_url="https://www.natesilver.net/feed",
-            is_draft_focused=False,
-        )
-
-        meth_url = "https://www.natesilver.net/p/sbcb-methodology"
-        draft_url = (
-            "https://www.natesilver.net/p/"
-            "radical-plan-to-replace-the-nba-draft-lottery-arc-auction"
-        )
-        analyze_calls: list[str] = []
-
-        async def fake_fetch(_url: str) -> list[dict[str, Any]]:
-            return [
-                _entry(
-                    "g-meth-fb",
-                    "SBCB methodology",
-                    "How our model works",
-                    link=meth_url,
-                ),
-                _entry(
-                    "g-draft-fb",
-                    "NBA draft lottery proposal",
-                    "Auction-based fix",
-                    link=draft_url,
-                ),
-            ]
-
-        async def fake_archive() -> dict[str, str]:
-            return {}  # simulate API failure
-
-        async def fake_relevance(_title: str, _desc: str) -> bool:
-            return True
-
-        async def fake_analyze(title: str, description: str) -> ArticleAnalysis:
-            analyze_calls.append(title)
-            return _stub_analysis()
-
-        monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
-        monkeypatch.setattr(
-            publisher_filters, "_fetch_silver_bulletin_archive", fake_archive
-        )
-        monkeypatch.setattr(
-            news_ingestion_service.news_summarization_service,
-            "check_draft_relevance",
-            fake_relevance,
-        )
-        monkeypatch.setattr(
-            news_ingestion_service.news_summarization_service,
-            "analyze_article",
-            fake_analyze,
-        )
-
-        added, _skipped, filtered, _mentions = await ingest_rss_source(
-            db_session, _snapshot(source)
-        )
-
-        # Methodology dropped by slug filter; draft post admitted.
-        assert added == 1
-        assert filtered == 1
-        assert analyze_calls == ["NBA draft lottery proposal"]
-
     async def test_non_silver_bulletin_source_is_untouched(
         self,
         db_session: AsyncSession,
@@ -575,8 +605,6 @@ class TestSilverBulletinPublisherFilter:
             is_draft_focused=False,
         )
 
-        archive_calls: list[None] = []
-
         async def fake_fetch(_url: str) -> list[dict[str, Any]]:
             return [
                 _entry(
@@ -587,17 +615,10 @@ class TestSilverBulletinPublisherFilter:
                 ),
             ]
 
-        async def fake_archive() -> dict[str, str]:
-            archive_calls.append(None)
-            return {}
-
         async def fake_relevance(_title: str, _desc: str) -> bool:
             return True
 
         monkeypatch.setattr(news_ingestion_service, "fetch_rss_feed", fake_fetch)
-        monkeypatch.setattr(
-            publisher_filters, "_fetch_silver_bulletin_archive", fake_archive
-        )
         monkeypatch.setattr(
             news_ingestion_service.news_summarization_service,
             "check_draft_relevance",
@@ -615,4 +636,3 @@ class TestSilverBulletinPublisherFilter:
 
         assert added == 1
         assert filtered == 0
-        assert archive_calls == []  # publisher filter never invoked

--- a/tests/integration/test_news_sticky.py
+++ b/tests/integration/test_news_sticky.py
@@ -219,6 +219,125 @@ class TestStickyOnPublicPages:
         assert response.status_code == 200
         assert '"is_sticky": true' not in response.text
 
+    async def test_news_page_pagination_no_duplicates_and_no_gaps(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        source: NewsSource,
+    ):
+        """An older sticky should not duplicate on the page it would naturally land on,
+        and the union of pages should cover every article exactly once.
+
+        Regression for the Codex P2 review: previously the route fetched
+        ``NEWS_PAGE_LIMIT`` items and unconditionally prepended the sticky,
+        yielding 13 cards on page 1 and a duplicate sticky at its natural
+        position on a later page.
+        """
+        # Build 15 natural articles + 1 older sticky so 2 pages are needed.
+        now = datetime.now(UTC).replace(tzinfo=None)
+        natural: list[NewsItem] = []
+        for i in range(15):
+            row = NewsItem(
+                source_id=source.id,  # type: ignore[arg-type]
+                external_id=f"pag-natural-{i}",
+                title=f"Natural Article {i:02d}",
+                url=f"https://example.com/natural-{i}",
+                tag=NewsItemTag.SCOUTING_REPORT,
+                published_at=now - timedelta(hours=i + 1),
+                created_at=now,
+            )
+            natural.append(row)
+            db_session.add(row)
+        sticky_row = NewsItem(
+            source_id=source.id,  # type: ignore[arg-type]
+            external_id="pag-sticky",
+            title="Sticky Article Old",
+            url="https://example.com/pag-sticky",
+            tag=NewsItemTag.SCOUTING_REPORT,
+            # Older than every natural item so its natural position is last.
+            published_at=now - timedelta(days=30),
+            created_at=now,
+        )
+        db_session.add(sticky_row)
+        await db_session.commit()
+        for row in [*natural, sticky_row]:
+            await db_session.refresh(row)
+
+        await set_sticky_news_item(db_session, sticky_row.id)
+        await db_session.commit()
+
+        # Page 1: sticky pinned + first 11 natural articles = 12 cards.
+        r1 = await app_client.get("/news")
+        assert r1.status_code == 200
+        body1 = r1.text
+        # The sticky title shows up on page 1, marked is_sticky=true.
+        assert "Sticky Article Old" in body1
+        assert '"is_sticky": true' in body1
+        # Page 1 should render Natural Article 00 through 10.
+        for i in range(11):
+            assert f"Natural Article {i:02d}" in body1, (
+                f"Natural Article {i:02d} missing from page 1"
+            )
+        # Page 1 should NOT yet show Natural Article 11..14.
+        for i in range(11, 15):
+            assert f"Natural Article {i:02d}" not in body1, (
+                f"Natural Article {i:02d} leaked onto page 1"
+            )
+
+        # Page 2: items 11..14 only. No sticky.
+        r2 = await app_client.get("/news?offset=12")
+        assert r2.status_code == 200
+        body2 = r2.text
+        assert "Sticky Article Old" not in body2, (
+            "Sticky appeared at its natural position on page 2 -- "
+            "exclude_id should have removed it from the feed query."
+        )
+        assert '"is_sticky": true' not in body2
+        for i in range(11, 15):
+            assert f"Natural Article {i:02d}" in body2, (
+                f"Natural Article {i:02d} missing from page 2"
+            )
+        # Verify page 1's articles did not bleed onto page 2.
+        for i in range(11):
+            assert f"Natural Article {i:02d}" not in body2, (
+                f"Natural Article {i:02d} duplicated onto page 2"
+            )
+
+
+@pytest.mark.asyncio
+class TestStickyDatabaseInvariant:
+    """The unique partial index must prevent a second sticky row at the DB layer."""
+
+    async def test_duplicate_sticky_insert_violates_constraint(
+        self,
+        db_session: AsyncSession,
+        items: list[NewsItem],
+    ):
+        """A raw UPDATE that ignores the service layer must still fail to
+        pin a second row -- this protects against concurrent admin writes
+        bypassing set_sticky_news_item's clear-then-set sequence.
+
+        Regression for the Codex P1 review.
+        """
+        from sqlalchemy.exc import IntegrityError
+        from sqlalchemy import text
+
+        # Pin the first item via the service helper, commit cleanly.
+        await set_sticky_news_item(db_session, items[0].id)
+        await db_session.commit()
+
+        # Now try to pin a second item with a raw UPDATE (mirrors what a
+        # second concurrent transaction would do once its row lock unblocks).
+        with pytest.raises(IntegrityError):
+            await db_session.execute(
+                text(
+                    "UPDATE news_items SET is_sticky = true WHERE id = :id"
+                ),
+                {"id": items[1].id},
+            )
+            await db_session.commit()
+        await db_session.rollback()
+
 
 @pytest.mark.asyncio
 class TestStickyAdminToggle:

--- a/tests/integration/test_news_sticky.py
+++ b/tests/integration/test_news_sticky.py
@@ -1,0 +1,327 @@
+"""Integration tests for the news sticky/pinned-post feature.
+
+Covers the service layer (`get_sticky_news_item`, `set_sticky_news_item`),
+the homepage and /news rendering paths, and the admin POST handler that
+toggles the sticky flag while enforcing the single-sticky invariant.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.news_items import NewsItem, NewsItemTag
+from app.schemas.news_sources import FeedType, NewsSource
+from app.services.news_service import (
+    get_sticky_news_item,
+    set_sticky_news_item,
+)
+from tests.integration.auth_helpers import create_auth_user, login_staff
+
+ADMIN_EMAIL = "sticky-admin@example.com"
+ADMIN_PASSWORD = "sticky-pass-123"
+
+
+@pytest_asyncio.fixture
+async def source(db_session: AsyncSession) -> NewsSource:
+    row = NewsSource(
+        name="sticky-source",
+        display_name="Sticky Source",
+        feed_type=FeedType.RSS,
+        feed_url="https://example.com/sticky-feed",
+        is_active=True,
+        fetch_interval_minutes=30,
+        created_at=datetime.now(UTC).replace(tzinfo=None),
+        updated_at=datetime.now(UTC).replace(tzinfo=None),
+    )
+    db_session.add(row)
+    await db_session.commit()
+    await db_session.refresh(row)
+    return row
+
+
+@pytest_asyncio.fixture
+async def items(db_session: AsyncSession, source: NewsSource) -> list[NewsItem]:
+    """Three plain news items, none sticky."""
+    now = datetime.now(UTC).replace(tzinfo=None)
+    rows = [
+        NewsItem(
+            source_id=source.id,  # type: ignore[arg-type]
+            external_id=f"sticky-item-{i}",
+            title=f"Sticky Test Article {i}",
+            url=f"https://example.com/sticky-{i}",
+            tag=NewsItemTag.SCOUTING_REPORT,
+            published_at=now - timedelta(hours=i),
+            created_at=now,
+        )
+        for i in range(1, 4)
+    ]
+    for r in rows:
+        db_session.add(r)
+    await db_session.commit()
+    for r in rows:
+        await db_session.refresh(r)
+    return rows
+
+
+@pytest.mark.asyncio
+class TestStickyService:
+    """Service-level: fetch + set sticky."""
+
+    async def test_returns_none_when_no_sticky(
+        self,
+        db_session: AsyncSession,
+        items: list[NewsItem],
+    ):
+        """get_sticky_news_item returns None when no row has is_sticky=True."""
+        _ = items
+        assert await get_sticky_news_item(db_session) is None
+
+    async def test_set_then_fetch_sticky(
+        self,
+        db_session: AsyncSession,
+        items: list[NewsItem],
+    ):
+        """Setting sticky on an item makes it returnable via the fetch helper."""
+        target = items[1]
+        await set_sticky_news_item(db_session, target.id)
+        await db_session.commit()
+
+        sticky = await get_sticky_news_item(db_session)
+        assert sticky is not None
+        assert sticky.id == target.id
+        assert sticky.is_sticky is True
+
+    async def test_set_sticky_unpins_prior(
+        self,
+        db_session: AsyncSession,
+        items: list[NewsItem],
+    ):
+        """Setting a new sticky must unset the prior sticky (single-row invariant)."""
+        first, second, _ = items
+        await set_sticky_news_item(db_session, first.id)
+        await db_session.commit()
+
+        await set_sticky_news_item(db_session, second.id)
+        await db_session.commit()
+
+        # Only `second` should be sticky now.
+        result = await db_session.execute(
+            select(NewsItem.id).where(NewsItem.is_sticky.is_(True))  # type: ignore[attr-defined,call-overload]
+        )
+        sticky_ids = [row[0] for row in result.all()]
+        assert sticky_ids == [second.id]
+
+    async def test_set_sticky_none_clears(
+        self,
+        db_session: AsyncSession,
+        items: list[NewsItem],
+    ):
+        """Passing item_id=None clears the sticky entirely."""
+        await set_sticky_news_item(db_session, items[0].id)
+        await db_session.commit()
+
+        await set_sticky_news_item(db_session, None)
+        await db_session.commit()
+
+        assert await get_sticky_news_item(db_session) is None
+
+
+@pytest.mark.asyncio
+class TestStickyOnPublicPages:
+    """Verify the public homepage and /news prepend + dedup the sticky."""
+
+    async def test_homepage_renders_pinned_label_for_sticky(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        items: list[NewsItem],
+    ):
+        """When a sticky is set, the homepage payload marks it is_sticky."""
+        target = items[2]  # Oldest one — proves it surfaces despite ordering.
+        await set_sticky_news_item(db_session, target.id)
+        await db_session.commit()
+
+        response = await app_client.get("/")
+        assert response.status_code == 200
+        # The feed_items list is serialized into a window.FEED_ITEMS literal;
+        # the sticky item should be there with is_sticky=true and appear first.
+        body = response.text
+        # Article 3 is the oldest, so without sticky it would be last. With
+        # sticky, it should still be present (and marked sticky in the JSON
+        # blob). We assert presence + a sticky marker rather than parse JS.
+        assert "Sticky Test Article 3" in body
+        assert '"is_sticky": true' in body
+
+    async def test_news_page_pins_when_no_filter(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        items: list[NewsItem],
+    ):
+        """/news with no filters prepends the sticky."""
+        target = items[2]
+        await set_sticky_news_item(db_session, target.id)
+        await db_session.commit()
+
+        response = await app_client.get("/news")
+        assert response.status_code == 200
+        body = response.text
+        assert "Sticky Test Article 3" in body
+        assert '"is_sticky": true' in body
+
+    async def test_news_page_hides_sticky_when_filtered(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        items: list[NewsItem],
+        source: NewsSource,
+    ):
+        """A filter on /news suppresses the sticky pin (cleaner mental model).
+
+        The sticky item could still appear if it organically matches the
+        filter, but it should NOT be flagged is_sticky=true. We pick a tag
+        the sticky item does not have.
+        """
+        # Sticky article has tag=SCOUTING_REPORT; filter to MOCK_DRAFT.
+        target = items[0]  # SCOUTING_REPORT
+        await set_sticky_news_item(db_session, target.id)
+        await db_session.commit()
+
+        response = await app_client.get(
+            f"/news?tag={NewsItemTag.MOCK_DRAFT.value}"
+        )
+        assert response.status_code == 200
+        body = response.text
+        # The sticky article shouldn't be there (wrong tag), and no
+        # is_sticky=true marker should be emitted.
+        assert "Sticky Test Article 1" not in body
+        assert '"is_sticky": true' not in body
+
+    async def test_news_page_pagination_skips_sticky(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        items: list[NewsItem],
+    ):
+        """Page 2 of /news must not re-render the sticky."""
+        target = items[0]
+        await set_sticky_news_item(db_session, target.id)
+        await db_session.commit()
+
+        # Offset > 0 means "not the first page" — sticky must be hidden.
+        response = await app_client.get("/news?offset=12")
+        assert response.status_code == 200
+        assert '"is_sticky": true' not in response.text
+
+
+@pytest.mark.asyncio
+class TestStickyAdminToggle:
+    """Admin form: checkbox toggles the sticky flag with invariant enforcement."""
+
+    async def _login_admin(
+        self, app_client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        await create_auth_user(
+            db_session,
+            email=ADMIN_EMAIL,
+            role="admin",
+            password=ADMIN_PASSWORD,
+        )
+        await login_staff(app_client, email=ADMIN_EMAIL, password=ADMIN_PASSWORD)
+
+    async def test_admin_pin_sets_is_sticky(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        items: list[NewsItem],
+    ):
+        """Submitting the edit form with is_sticky=on pins the item."""
+        await self._login_admin(app_client, db_session)
+        target = items[1]
+
+        response = await app_client.post(
+            f"/admin/news-items/{target.id}",
+            data={
+                "tag": NewsItemTag.SCOUTING_REPORT.value,
+                "player_id": "",
+                "summary": "",
+                "is_sticky": "on",
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code in {302, 303}
+
+        result = await db_session.execute(
+            text("SELECT is_sticky FROM news_items WHERE id = :id"),
+            {"id": target.id},
+        )
+        assert result.scalar_one() is True
+
+    async def test_admin_unchecked_clears_existing_sticky(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        items: list[NewsItem],
+    ):
+        """Submitting without the is_sticky field unpins a currently-sticky item."""
+        await self._login_admin(app_client, db_session)
+        target = items[0]
+        await set_sticky_news_item(db_session, target.id)
+        await db_session.commit()
+
+        response = await app_client.post(
+            f"/admin/news-items/{target.id}",
+            data={
+                "tag": NewsItemTag.SCOUTING_REPORT.value,
+                "player_id": "",
+                "summary": "",
+                # is_sticky intentionally omitted, like an unchecked checkbox
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code in {302, 303}
+
+        result = await db_session.execute(
+            text("SELECT is_sticky FROM news_items WHERE id = :id"),
+            {"id": target.id},
+        )
+        assert result.scalar_one() is False
+
+    async def test_admin_pin_enforces_single_sticky(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        items: list[NewsItem],
+    ):
+        """Pinning a second item via admin auto-unpins the first."""
+        await self._login_admin(app_client, db_session)
+        first, second, _ = items
+
+        # Pin the first item.
+        await set_sticky_news_item(db_session, first.id)
+        await db_session.commit()
+
+        # Pin the second via the admin POST.
+        response = await app_client.post(
+            f"/admin/news-items/{second.id}",
+            data={
+                "tag": NewsItemTag.SCOUTING_REPORT.value,
+                "player_id": "",
+                "summary": "",
+                "is_sticky": "on",
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code in {302, 303}
+
+        result = await db_session.execute(
+            text("SELECT id FROM news_items WHERE is_sticky = true ORDER BY id")
+        )
+        sticky_ids = [row[0] for row in result.all()]
+        assert sticky_ids == [second.id]


### PR DESCRIPTION
## Summary

- **Sticky news item.** Admins can pin a single article to the top of the homepage and `/news` feeds via a checkbox on `/admin/news-items/{id}`. Setting one auto-unpins any prior sticky. Visual treatment is intentionally minimal — a hair-thin amber inset on the card top and a small "Pinned" pill in the meta row — so the hero article and grid layout are unchanged. Filtered or paginated views suppress the pin. Initial use case: surface a Nate Silver article while we pitch outside writers.
- **Silver Bulletin filter rework.** Joseph George (May 2026) clarified he wants the PRISM rankings *landing* page surfaced and the methodology pages hidden. Our earlier prototype filter did the opposite: it dropped anything in `section_slug=models-and-forecasts` (which contains the PRISM rankings) and admitted methodology pages whose slug didn't literally contain "methodology" (e.g., the PRISM "how our model works" page in `section_slug=sports`). Replaced the brittle section filter (and its `/api/v1/archive` HTTP call) with an expanded slug-substring list: `methodology`, `model-works`, `how-we-calculate`. Non-draft Models & Forecasts dashboards are still filtered downstream by the draft-relevance gate.

## Behavior table (Silver Bulletin)

| URL slug | Section | Joseph wants | Filter outcome |
|---|---|---|---|
| `prism-2026-nba-draft-rankings` | `models-and-forecasts` | show | kept |
| `how-our-prism-nba-draft-model-works` | `sports` | hide | dropped (`model-works`) |
| `pele-methodology` | `sports` | hide | dropped (`methodology`) |
| `silver-bulletin-polling-average-methodology` | `models-and-forecasts` | hide | dropped (`methodology`) |
| Trump approval, NCAA team ratings | `models-and-forecasts` | n/a (not draft) | kept here, blocked by relevance gate |

## Test plan

- [ ] `conda run -n draftguru make precommit` — ruff/format/mypy/hooks
- [ ] `conda run -n draftguru mypy app --ignore-missing-imports`
- [ ] `conda run -n draftguru pytest tests/unit -q` (255 tests)
- [ ] Integration: `tests/integration/test_news_sticky.py` (11 new), `test_news_ingestion_relevance.py` (10 total, 4 new + 4 existing kept), `test_news.py`, `test_admin_crud_news_items.py`
- [ ] Visual: pin the Silver Bulletin "Rookie of the Year" article in dev, hit `/` and `/news`, confirm the amber "Pinned" pill renders on the first grid card and the hero is unchanged. Filter `/news?tag=Mock Draft` to confirm the pin is suppressed.
- [ ] Migration round-trip: `alembic upgrade head` → `alembic downgrade -1` → `alembic upgrade head` cleanly applies the new `is_sticky` column + partial index.