### PR TITLE
fix: inject S3 image base URL and style globals on homepage

### DIFF
--- a/app/routes/ui.py
+++ b/app/routes/ui.py
@@ -301,6 +301,8 @@ async def home(
             "film_room_video_counts": film_room_video_counts,
             "footer_links": FOOTER_LINKS,
             "current_year": datetime.now().year,
+            "image_style": settings.default_image_style,
+            "s3_image_base_url": get_s3_image_base_url(),
         },
     )
 

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -275,6 +275,9 @@
   // Podcast episodes for homepage section
   window.PODCAST_EPISODES = {{ podcast_episodes | tojson | safe }};
   window.FILM_ROOM_VIDEOS = {{ film_room_videos | tojson | safe }};
+  // Image style and S3 base URL for dynamic image URLs (used by VS Arena)
+  window.IMAGE_STYLE = {{ image_style | tojson | safe }};
+  window.S3_IMAGE_BASE_URL = {{ s3_image_base_url | tojson | safe }};
 </script>
 <script src="{{ url_for('static', path='js/home.js') }}"></script>
 <script src="{{ url_for('static', path='js/film-room.js') }}"></script>


### PR DESCRIPTION
## Summary
- VS Arena (homepage head-to-head) was rendering placeholders instead of player photos because `window.S3_IMAGE_BASE_URL` and `window.IMAGE_STYLE` were only injected on the player-detail template.
- Without `S3_IMAGE_BASE_URL`, `h2h-comparison.js` fell back to `/static/img/players/{id}_{slug}_{style}.png` paths that don't exist locally, so both photo `<img>` tags fired `onerror` and landed on placehold.co.
- Pass `image_style` (from `settings.default_image_style`) and `s3_image_base_url` (from `get_s3_image_base_url()`) through the home route context and inject them as `window.*` globals in `home.html`, matching the pattern already used on player-detail.

## Test plan
- [x] `make precommit` (ruff, ruff-format, mypy, commit/rollback guard) passes.
- [x] `mypy app --ignore-missing-imports` clean.
- [x] `curl /` confirms `window.IMAGE_STYLE = "default"` and `window.S3_IMAGE_BASE_URL = "https://draft-app-public-static.s3.us-east-1.amazonaws.com"` are present in the homepage HTML.
- [x] Manual verification of the constructed S3 URLs for Cooper Flagg and Ace Bailey returns HTTP 200.
- [ ] Visually confirm in dev that VS Arena now shows the actual player photos.