### PR TITLE
feature: big_boards schema + migration

### DIFF
--- a/alembic/versions/p5q6r7s8t9u0_add_big_boards.py
+++ b/alembic/versions/p5q6r7s8t9u0_add_big_boards.py
@@ -1,0 +1,116 @@
+"""Add big_boards and big_board_entries tables.
+
+Revision ID: p5q6r7s8t9u0
+Revises: o4p5q6r7s8t9
+Create Date: 2026-05-20
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op  # type: ignore[attr-defined]
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "p5q6r7s8t9u0"
+down_revision: Union[str, None] = "o4p5q6r7s8t9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+BOARD_STATUS_ENUM_NAME = "board_status_enum"
+BOARD_STATUS_VALUES = ("PENDING", "APPROVED", "REJECTED")
+
+
+def upgrade() -> None:
+    board_status_enum = postgresql.ENUM(
+        *BOARD_STATUS_VALUES, name=BOARD_STATUS_ENUM_NAME, create_type=False
+    )
+    board_status_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "big_boards",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("news_source_id", sa.Integer(), nullable=False),
+        sa.Column("news_item_id", sa.Integer(), nullable=True),
+        sa.Column("draft_year", sa.Integer(), nullable=False),
+        sa.Column("published_at", sa.DateTime(), nullable=False),
+        sa.Column("board_size", sa.Integer(), nullable=False),
+        sa.Column(
+            "status",
+            board_status_enum,
+            nullable=False,
+            server_default="PENDING",
+        ),
+        sa.Column("approved_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["news_source_id"],
+            ["news_sources.id"],
+            name="fk_big_boards_news_source",
+        ),
+        sa.ForeignKeyConstraint(
+            ["news_item_id"],
+            ["news_items.id"],
+            name="fk_big_boards_news_item",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_big_boards_news_source_id", "big_boards", ["news_source_id"])
+    op.create_index("ix_big_boards_draft_year", "big_boards", ["draft_year"])
+    op.create_index("ix_big_boards_published_at", "big_boards", ["published_at"])
+    op.create_index("ix_big_boards_status", "big_boards", ["status"])
+    op.create_index(
+        "ix_big_boards_status_draft_year", "big_boards", ["status", "draft_year"]
+    )
+    op.create_index(
+        "ix_big_boards_source_draft_year",
+        "big_boards",
+        ["news_source_id", "draft_year"],
+    )
+
+    op.create_table(
+        "big_board_entries",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("board_id", sa.Integer(), nullable=False),
+        sa.Column("player_id", sa.Integer(), nullable=False),
+        sa.Column("rank", sa.Integer(), nullable=False),
+        sa.Column("tier", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["board_id"],
+            ["big_boards.id"],
+            name="fk_big_board_entries_board",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["player_id"],
+            ["players_master.id"],
+            name="fk_big_board_entries_player",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("board_id", "rank", name="uq_big_board_entries_board_rank"),
+        sa.UniqueConstraint(
+            "board_id", "player_id", name="uq_big_board_entries_board_player"
+        ),
+    )
+    op.create_index("ix_big_board_entries_board_id", "big_board_entries", ["board_id"])
+    op.create_index("ix_big_board_entries_player", "big_board_entries", ["player_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_big_board_entries_player", table_name="big_board_entries")
+    op.drop_index("ix_big_board_entries_board_id", table_name="big_board_entries")
+    op.drop_table("big_board_entries")
+
+    op.drop_index("ix_big_boards_source_draft_year", table_name="big_boards")
+    op.drop_index("ix_big_boards_status_draft_year", table_name="big_boards")
+    op.drop_index("ix_big_boards_status", table_name="big_boards")
+    op.drop_index("ix_big_boards_published_at", table_name="big_boards")
+    op.drop_index("ix_big_boards_draft_year", table_name="big_boards")
+    op.drop_index("ix_big_boards_news_source_id", table_name="big_boards")
+    op.drop_table("big_boards")
+
+    bind = op.get_bind()
+    sa.Enum(name=BOARD_STATUS_ENUM_NAME).drop(bind, checkfirst=True)

--- a/app/schemas/big_boards.py
+++ b/app/schemas/big_boards.py
@@ -1,0 +1,81 @@
+"""Big Board tables: per-source talent rankings and their entries."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import Column, Enum as SAEnum, Index, UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+
+class BoardStatus(str, Enum):
+    """Lifecycle status for an ingested or manually entered big board."""
+
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+
+
+class BigBoard(SQLModel, table=True):  # type: ignore[call-arg]
+    """A single analyst's talent ranking of prospects for a given draft year.
+
+    One row per published board. Entries (the ranked players) live in
+    ``BigBoardEntry``. A board is in ``PENDING`` status until an admin
+    reviews it; after ``APPROVED`` it becomes immutable so it cannot be
+    edited to misrepresent the analyst's actual rankings.
+    """
+
+    __tablename__ = "big_boards"
+    __table_args__ = (
+        Index("ix_big_boards_status_draft_year", "status", "draft_year"),
+        Index("ix_big_boards_source_draft_year", "news_source_id", "draft_year"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    news_source_id: int = Field(foreign_key="news_sources.id", index=True)
+    news_item_id: Optional[int] = Field(
+        default=None,
+        foreign_key="news_items.id",
+        description="Link to the originating article when available.",
+    )
+    draft_year: int = Field(index=True)
+    published_at: datetime = Field(
+        index=True,
+        description="When the analyst published the board (not when we ingested it).",
+    )
+    board_size: int = Field(description="Number of ranked players on the board.")
+
+    status: BoardStatus = Field(
+        default=BoardStatus.PENDING,
+        sa_column=Column(
+            SAEnum(BoardStatus, name="board_status_enum"),
+            nullable=False,
+            server_default=BoardStatus.PENDING.value,
+            index=True,
+        ),
+    )
+    approved_at: Optional[datetime] = Field(default=None)
+
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class BigBoardEntry(SQLModel, table=True):  # type: ignore[call-arg]
+    """A single (player, rank) row on a ``BigBoard``."""
+
+    __tablename__ = "big_board_entries"
+    __table_args__ = (
+        UniqueConstraint("board_id", "rank", name="uq_big_board_entries_board_rank"),
+        UniqueConstraint(
+            "board_id", "player_id", name="uq_big_board_entries_board_player"
+        ),
+        Index("ix_big_board_entries_player", "player_id"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    board_id: int = Field(foreign_key="big_boards.id", index=True)
+    player_id: int = Field(foreign_key="players_master.id")
+    rank: int = Field(description="Analyst's talent-ranking position (1-based).")
+    tier: Optional[int] = Field(
+        default=None, description="Optional tier grouping assigned by the analyst."
+    )

--- a/app/services/admin_permission_service.py
+++ b/app/services/admin_permission_service.py
@@ -21,6 +21,7 @@ KNOWN_DATASETS = [
     "youtube_channels",
     "youtube_videos",
     "youtube_ingestion",
+    "big_boards",
 ]
 
 

--- a/docs/consensus_mock_plan.md
+++ b/docs/consensus_mock_plan.md
@@ -160,6 +160,40 @@ An analyst's prediction of what will actually happen on draft night.
 - Low volume (~5–10 new boards per week across all sources) makes this feasible
 - Approval UI can show extracted board side-by-side with original article for quick verification
 
+### Extraction Strategy — Single Extractor with Per-Source Hints
+
+Different substacks format big boards differently — numbered lists, tier
+headers, tables, prose with embedded rankings. The question is whether to
+have one generic extractor or a dedicated parser per source.
+
+**Decision: one shared LLM extractor that pulls per-source hints from
+`NewsSource` at call time.** Add an `extraction_hints` JSON column to
+`NewsSource` with format metadata, e.g.:
+
+```json
+{
+  "format": "tier_list",
+  "tier_labels": "Tier 1..Tier 5",
+  "rank_within_tier_is_implicit": true
+}
+```
+
+The shared prompt injects those hints so the model gets source-specific
+context without per-source code. New sources are added by writing hints,
+not code; the admin approval queue catches errors before any extracted
+board affects consensus, so the cost of an occasional bad parse is admin
+time, not bad data.
+
+**When this won't be enough** (defer until we hit the first failing case):
+
+- Image-only boards (e.g., a substack that posts a ranking screenshot)
+- Mock drafts — pick/team/trade triples are significantly harder than
+  ordered lists, and source-specific handling may be justified there
+- Sources that change format frequently mid-season
+
+The fallback for any extraction failure is the manual admin entry path
+(`app/routes/admin/big_boards.py`).
+
 ---
 
 ## Player Analytics (derived from consensus)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -133,6 +133,7 @@ async def async_engine(
     from app.schemas import youtube_channels  # noqa: F401
     from app.schemas import youtube_videos  # noqa: F401
     from app.schemas import auth  # noqa: F401
+    from app.schemas import big_boards  # noqa: F401
 
     connect_args = {
         # Disable prepared statement caching to avoid type OID/cache issues after DDL.


### PR DESCRIPTION
## Summary

- Adds `BigBoard` and `BigBoardEntry` tables for the consensus big-board feature (`docs/consensus_mock_plan.md`, Phase 1).
- Status enum (`PENDING` / `APPROVED` / `REJECTED`) with default `PENDING`; approval flow is implemented by the service layer in a follow-up PR.
- Unique constraints prevent duplicate ranks or duplicate players on a single board; `ON DELETE CASCADE` removes entries with their parent board.
- Adds `big_boards` to `KNOWN_DATASETS` so the staff-permissions UI can scope access.

Deliberately out of scope: service layer, admin routes, AI extraction, consensus computation, mock-draft side, homepage redesign. Those land in subsequent PRs.

## Test plan

- [x] `alembic upgrade head` applied cleanly against the test Neon branch; tables, indexes, FKs, unique constraints, and the `board_status_enum` all match the spec.
- [x] `alembic downgrade -1` cleanly drops both tables and the enum; alembic returns to `o4p5q6r7s8t9`.
- [x] `make precommit` clean (ruff, ruff-format, mypy, custom hooks).
- [x] `mypy app --ignore-missing-imports` clean across all 125 source files.
- [ ] Reviewer: run the migration locally if you want to double-check the round-trip.

## Heads-up

A separate in-progress branch (`feature/school-logos`) has an untracked `p5q6r7s8t9u0_add_x_post_history.py` migration that claims this same revision id. That branch will need to renumber its migration before merging — most natural choice is `q6r7s8t9u0v1` with `down_revision = "p5q6r7s8t9u0"`.