### PR TITLE
feature: x-thread skill for drafting prospect threads

### DIFF
--- a/.claude/skills/x-thread/SKILL.md
+++ b/.claude/skills/x-thread/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: x-thread
+description: Draft one long-form X (Twitter) thread about an NBA draft prospect using DraftGuru data. Picks an angle, gathers facts and images, asks Claude to author the tweets in analyst/scout voice, and persists a reviewable draft. Pairs with /loop for steady throughput.
+allowed-tools: Bash, Read, Write, Edit
+---
+
+# X Thread Skill (draft + review)
+
+Generate one X thread per invocation. Each fire:
+
+1. Picks an angle and subject (deduped via the `x_post_history` table).
+2. Gathers DB facts + images via `scripts/x_threads/gather.py`.
+3. Authors 5–9 tweets in analyst/scout voice (your job, this turn).
+4. Persists the draft via `scripts/x_threads/save_draft.py`.
+5. Reports the draft directory to the user for review.
+
+Posting to X is **not** wired up yet; `post_to_x.py` is a stub. Drafts are saved
+to `scripts/x_threads/drafts/<date>/<time>_<angle>_<slug>/` for manual review.
+
+## Step-by-step
+
+### 1. Pick + gather
+
+Run the gather script. It picks an angle, queries the DB, renders any share
+cards, and writes everything to a draft directory. The directory path is the
+last line of stdout.
+
+```bash
+conda run -n draftguru python -m scripts.x_threads.gather
+```
+
+Optional flags: `--angle spotlight|h2h|outlier|news_tag`, `--window-days N`.
+
+Capture the printed path. Then read the `gather.json` inside that directory —
+it contains the angle, headline, player(s), facts, comps, news (when relevant),
+and the relative paths to any pre-rendered images.
+
+If the script exits non-zero with `no_viable_angle`, stop and tell the user
+the dedup window has caught up to the pool — they can widen `--window-days`
+or wait. Don't try a different angle silently.
+
+### 2. Author the thread
+
+Read `gather.json`. Draft **5–9 tweets** in analyst/scout voice. Each tweet
+≤ 280 characters. Format the tweets file as one tweet per block, separated
+by a line containing only `---`:
+
+```
+Lead tweet text.
+
+Optional second paragraph inside the same tweet.
+---
+Second tweet.
+---
+Third tweet.
+```
+
+Write that file to `<draft_dir>/tweets.txt`.
+
+**Voice rules.** Confident, data-forward, mild swagger. The reader should feel
+like they're reading a scout's notebook, not a hype machine.
+
+- Lead with the most surprising number, not the player's name. ("7'4\" wingspan
+  on a 6'5\" frame — that's the second-biggest plus-wingspan in the 2025 class.")
+- Use specific numbers with units, not adjectives. ("32 inch standing vert",
+  not "elite athleticism").
+- Tie facts to scout-relevant implications. ("That reach gives him a center's
+  contest radius at the 3.")
+- Earn the comp. If you cite a similar player, say why the comp lands.
+- Skip exclamation points. Skip emoji. No "🚨" or "🔥".
+- End the thread with a forward look or open question, not a CTA.
+
+**Voice anchors** (study these before you write):
+
+```
+Outlier — Cooper Flagg (Duke)
+
+7'5" wingspan on a 6'8.5" frame — fourth-best plus-wingspan
+in the 2025 combine sample (n=78).
+
+That puts him in the same anthro neighborhood as Jaylin Williams,
+Tari Eason, and Cam Whitmore — wings whose length compensates
+for sub-6'9" measured height.
+
+The question with Flagg was never the frame. It's the jumper.
+Spot-up shooting sits at the 41st percentile in the combine drills.
+At his projected role, that's a workable but not bankable number.
+```
+
+```
+H2H — Dylan Harper vs Ace Bailey
+
+Same draft class, same projected lottery range, very different
+profiles.
+
+Harper: 99th percentile wingspan, 92nd percentile standing reach,
+38th percentile vertical. A length guard, not an athlete guard.
+
+Bailey: 71st percentile wingspan, 96th percentile max vertical,
+89th percentile lane agility. The athleticism comes off the floor,
+not from the frame.
+
+The split shows up cleanly in the comp lists. Harper's neighbors
+are wing-sized lead handlers; Bailey's are shot-creator athletes.
+
+Two different bets on what survives the NBA transition.
+```
+
+(These are voice anchors, not facts to copy. Use the numbers from gather.json.)
+
+### 3. Save the draft
+
+```bash
+conda run -n draftguru python -m scripts.x_threads.save_draft \
+  --draft-dir <draft_dir> \
+  --tweets-file <draft_dir>/tweets.txt
+```
+
+The script:
+- Validates each tweet is ≤ 280 chars (use `--allow-long` only if you mean to).
+- Writes `thread.txt` to the draft dir.
+- Inserts an `x_post_history` row with `status=draft`.
+
+If a tweet is over 280 chars, the script refuses to save and prints which
+tweet. Trim the tweet and re-run; don't reach for `--allow-long`.
+
+### 4. Report
+
+Tell the user:
+- The chosen angle and subject.
+- The draft directory path.
+- A one-line preview (the lead tweet).
+- The `x_post_history.id` (from the save_draft JSON output).
+
+Stop after that. Do not attempt to post — `post_to_x.py` is intentionally
+stubbed until X API credentials exist.
+
+## When something goes wrong
+
+- **Gather fails with no images**: The skill still works; the thread can stand
+  on text. Don't retry just to get images.
+- **DB connection error**: Surface it and stop. Don't write a draft without
+  data — analyst-voice tweets need real numbers.
+- **Outlier finder picks a player whose narrative feels off**: Re-run with
+  `--angle <different>` once, not in a loop. The dedup table will protect
+  against churn over time.
+
+## Files this skill touches
+
+- `scripts/x_threads/gather.py` — picks angle, gathers data, renders images
+- `scripts/x_threads/save_draft.py` — persists tweets + logs `x_post_history`
+- `scripts/x_threads/post_to_x.py` — stub for future posting
+- `scripts/x_threads/drafts/` — output directory (gitignored)
+- `app/services/x_threads/` — picker, outlier finder, gatherer, image builder
+- `app/templates/x_threads/` — custom SVG templates (outlier, riser)
+- `app/schemas/x_post_history.py` — dedup + audit table
+
+## Loop usage
+
+For autonomous throughput, wrap this skill in `/loop`:
+
+```
+/loop 90m /x-thread
+```
+
+90 minutes is a reasonable cadence — leaves time for review between drafts
+and lets the dedup window do its job. Shorter cadences will exhaust the
+viable pool quickly.

--- a/.gitignore
+++ b/.gitignore
@@ -233,6 +233,9 @@ __marimo__/
 docs/creator_outreach_contacts.csv
 docs/outreach_templates.md
 
+# X thread drafts (skill output, not for committing)
+scripts/x_threads/drafts/
+
 # Local agent / MCP state
 .claude/scheduled_tasks.lock
 .playwright-mcp/

--- a/alembic/versions/r7s8t9u0v1w2_add_x_post_history.py
+++ b/alembic/versions/r7s8t9u0v1w2_add_x_post_history.py
@@ -1,0 +1,94 @@
+"""Add x_post_history table for the X thread skill.
+
+Revision ID: r7s8t9u0v1w2
+Revises: q6r7s8t9u0v1
+Create Date: 2026-05-21
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op  # type: ignore[attr-defined]
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "r7s8t9u0v1w2"
+down_revision: Union[str, None] = "q6r7s8t9u0v1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+ANGLE_ENUM_NAME = "x_post_angle_enum"
+STATUS_ENUM_NAME = "x_post_status_enum"
+ANGLE_VALUES = ("spotlight", "h2h", "outlier", "consensus_shift", "news_tag")
+STATUS_VALUES = ("draft", "posted", "skipped")
+
+
+def upgrade() -> None:
+    angle_enum = postgresql.ENUM(*ANGLE_VALUES, name=ANGLE_ENUM_NAME, create_type=False)
+    status_enum = postgresql.ENUM(
+        *STATUS_VALUES, name=STATUS_ENUM_NAME, create_type=False
+    )
+    angle_enum.create(op.get_bind(), checkfirst=True)
+    status_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "x_post_history",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("angle", angle_enum, nullable=False),
+        sa.Column(
+            "status",
+            status_enum,
+            nullable=False,
+            server_default="draft",
+        ),
+        sa.Column(
+            "player_ids",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("news_item_id", sa.Integer(), nullable=True),
+        sa.Column("headline", sa.String(), nullable=True),
+        sa.Column(
+            "tweets",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "image_paths",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("draft_dir", sa.String(), nullable=True),
+        sa.Column("notes", sa.String(), nullable=True),
+        sa.Column("posted_at", sa.DateTime(), nullable=True),
+        sa.Column("external_post_id", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["news_item_id"], ["news_items.id"], name="fk_x_post_history_news_item"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index(
+        "ix_x_post_history_angle_created", "x_post_history", ["angle", "created_at"]
+    )
+    op.create_index(
+        "ix_x_post_history_status_created", "x_post_history", ["status", "created_at"]
+    )
+    op.create_index("ix_x_post_history_created_at", "x_post_history", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_x_post_history_created_at", table_name="x_post_history")
+    op.drop_index("ix_x_post_history_status_created", table_name="x_post_history")
+    op.drop_index("ix_x_post_history_angle_created", table_name="x_post_history")
+    op.drop_table("x_post_history")
+
+    bind = op.get_bind()
+    sa.Enum(name=STATUS_ENUM_NAME).drop(bind, checkfirst=True)
+    sa.Enum(name=ANGLE_ENUM_NAME).drop(bind, checkfirst=True)

--- a/app/schemas/x_post_history.py
+++ b/app/schemas/x_post_history.py
@@ -1,0 +1,104 @@
+"""X (Twitter) post history for the autonomous thread-drafting skill."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Optional
+
+import sqlalchemy as sa
+from sqlalchemy import Column, Enum as SAEnum, Index
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlmodel import Field, SQLModel
+
+
+class XPostAngle(str, Enum):
+    """Thread angle categories used to pick subject + drive dedup."""
+
+    spotlight = "spotlight"
+    h2h = "h2h"
+    outlier = "outlier"
+    consensus_shift = "consensus_shift"
+    news_tag = "news_tag"
+
+
+class XPostStatus(str, Enum):
+    """Lifecycle state of a drafted post."""
+
+    draft = "draft"
+    posted = "posted"
+    skipped = "skipped"
+
+
+class XPostHistory(SQLModel, table=True):  # type: ignore[call-arg]
+    """One row per generated X thread, kept indefinitely for dedup and audit."""
+
+    __tablename__ = "x_post_history"
+    __table_args__ = (
+        Index("ix_x_post_history_angle_created", "angle", "created_at"),
+        Index("ix_x_post_history_status_created", "status", "created_at"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+
+    angle: XPostAngle = Field(
+        sa_column=Column(
+            SAEnum(XPostAngle, name="x_post_angle_enum"),
+            nullable=False,
+        )
+    )
+    status: XPostStatus = Field(
+        default=XPostStatus.draft,
+        sa_column=Column(
+            SAEnum(XPostStatus, name="x_post_status_enum"),
+            nullable=False,
+            server_default=XPostStatus.draft.value,
+        ),
+    )
+
+    # Subject(s) — either players or a news item. Both stored as arrays so a
+    # single angle (e.g. h2h) can reference multiple players cleanly.
+    player_ids: list[int] = Field(
+        default_factory=list,
+        sa_column=Column(JSONB, nullable=False, server_default=sa.text("'[]'::jsonb")),
+        description="Players referenced by this thread (anchor first for h2h).",
+    )
+    news_item_id: Optional[int] = Field(
+        default=None,
+        foreign_key="news_items.id",
+        description="News item referenced by news_tag angle, if any.",
+    )
+
+    # The thread itself. tweets is an ordered list of {text, image_path} dicts.
+    headline: Optional[str] = Field(
+        default=None,
+        description="Short human-readable label, e.g. 'Outlier: Cooper Flagg wingspan'.",
+    )
+    tweets: list[dict[str, Any]] = Field(
+        default_factory=list,
+        sa_column=Column(JSONB, nullable=False, server_default=sa.text("'[]'::jsonb")),
+        description="Ordered tweets in the thread. Each dict has at minimum 'text'.",
+    )
+    image_paths: list[str] = Field(
+        default_factory=list,
+        sa_column=Column(JSONB, nullable=False, server_default=sa.text("'[]'::jsonb")),
+        description="Local relative paths to PNGs attached to the lead tweet.",
+    )
+
+    draft_dir: Optional[str] = Field(
+        default=None,
+        description="Relative path under scripts/x_threads/drafts/ where files live.",
+    )
+    notes: Optional[str] = Field(
+        default=None,
+        description="Free-form analyst notes about why this angle was picked.",
+    )
+
+    # Posting metadata (populated when status flips to POSTED).
+    posted_at: Optional[datetime] = Field(default=None)
+    external_post_id: Optional[str] = Field(
+        default=None,
+        description="X tweet ID of the lead tweet once posted.",
+    )
+
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)

--- a/app/services/x_threads/__init__.py
+++ b/app/services/x_threads/__init__.py
@@ -1,0 +1,6 @@
+"""Helpers for the X (Twitter) long-form thread skill.
+
+This package is intentionally small: it gathers facts and produces images.
+The thread copy itself is authored by the Claude Code skill at runtime, so
+the services here focus on data and rendering, not text generation.
+"""

--- a/app/services/x_threads/angle_picker.py
+++ b/app/services/x_threads/angle_picker.py
@@ -1,0 +1,277 @@
+"""Pick an angle + subject for the next X thread.
+
+Dedup window prevents reposting the same player/news under the same angle in
+the recent past. The picker is intentionally simple: it walks a shuffled list
+of viable angles and returns the first one with a fresh subject.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import datetime, timedelta
+from typing import Any, Optional, cast
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.combine_anthro import CombineAnthro
+from app.schemas.news_items import NewsItem
+from app.schemas.players_master import PlayerMaster
+from app.schemas.x_post_history import XPostAngle, XPostHistory
+
+from .outlier_finder import find_outlier_candidate
+from .types import AnglePick, PlayerCard
+
+DEFAULT_DEDUP_DAYS = 14
+
+
+_ANGLE_ORDER = [
+    XPostAngle.spotlight,
+    XPostAngle.outlier,
+    XPostAngle.h2h,
+    XPostAngle.news_tag,
+]
+
+
+async def _recently_used_player_ids(
+    db: AsyncSession,
+    angle: XPostAngle,
+    window_days: int,
+) -> set[int]:
+    """Return player IDs used by *any* post under this angle in the window.
+
+    Tweets reference players via the JSONB `player_ids` array, so we expand
+    that array in Postgres before pulling the distinct set back into Python.
+    """
+    cutoff = datetime.utcnow() - timedelta(days=window_days)
+    stmt: Any = (
+        select(  # type: ignore[call-overload, misc]
+            func.jsonb_array_elements_text(XPostHistory.player_ids).label("pid"),
+        )
+        .where(XPostHistory.angle == angle)  # type: ignore[arg-type]
+        .where(XPostHistory.created_at >= cutoff)  # type: ignore[arg-type]
+    )
+    result = await db.execute(stmt)
+    return {int(row.pid) for row in result.all() if row.pid is not None}
+
+
+async def _recently_used_news_ids(db: AsyncSession, window_days: int) -> set[int]:
+    cutoff = datetime.utcnow() - timedelta(days=window_days)
+    stmt: Any = (
+        select(XPostHistory.news_item_id)  # type: ignore[call-overload]
+        .where(XPostHistory.angle == XPostAngle.news_tag)  # type: ignore[arg-type]
+        .where(XPostHistory.created_at >= cutoff)  # type: ignore[arg-type]
+        .where(XPostHistory.news_item_id.is_not(None))  # type: ignore[union-attr]
+    )
+    result = await db.execute(stmt)
+    return {row[0] for row in result.all() if row[0] is not None}
+
+
+async def _latest_draft_year(db: AsyncSession) -> Optional[int]:
+    """Latest draft year that has at least one player with combine anthro data.
+
+    PlayerMaster has stub rows for far-future draft classes; without the join
+    those make ``max(draft_year)`` useless for picking real prospects.
+    """
+    stmt = (
+        select(func.max(PlayerMaster.draft_year))  # type: ignore[arg-type]
+        .select_from(PlayerMaster)
+        .join(CombineAnthro, CombineAnthro.player_id == PlayerMaster.id)  # type: ignore[arg-type]
+        .where(PlayerMaster.is_stub.is_(False))  # type: ignore[attr-defined]
+    )
+    result = await db.execute(stmt)
+    return result.scalar()
+
+
+async def _player_to_card(db: AsyncSession, player_id: int) -> Optional[PlayerCard]:
+    stmt: Any = select(  # type: ignore[call-overload, misc]
+        PlayerMaster.id,
+        PlayerMaster.slug,
+        PlayerMaster.display_name,
+        PlayerMaster.school,
+        PlayerMaster.draft_year,
+    ).where(PlayerMaster.id == player_id)  # type: ignore[arg-type]
+    result = await db.execute(stmt)
+    row = result.one_or_none()
+    if row is None:
+        return None
+    return PlayerCard(
+        id=row.id,
+        slug=row.slug or "",
+        display_name=row.display_name or "",
+        school=row.school,
+        draft_year=row.draft_year,
+    )
+
+
+async def _pick_spotlight(db: AsyncSession, window_days: int) -> Optional[AnglePick]:
+    """Pick a current-class player with combine data who hasn't been spotlighted recently."""
+    draft_year = await _latest_draft_year(db)
+    if draft_year is None:
+        return None
+
+    used = await _recently_used_player_ids(db, XPostAngle.spotlight, window_days)
+
+    stmt: Any = (
+        select(  # type: ignore[call-overload, misc]
+            PlayerMaster.id,
+            PlayerMaster.slug,
+            PlayerMaster.display_name,
+            PlayerMaster.school,
+            PlayerMaster.draft_year,
+        )
+        .join(CombineAnthro, CombineAnthro.player_id == PlayerMaster.id)  # type: ignore[arg-type]
+        .where(PlayerMaster.is_stub.is_(False))  # type: ignore[attr-defined]
+        .where(PlayerMaster.draft_year == draft_year)  # type: ignore[arg-type]
+        .where(PlayerMaster.slug.is_not(None))  # type: ignore[union-attr]
+    )
+    if used:
+        stmt = stmt.where(PlayerMaster.id.notin_(used))  # type: ignore[union-attr]
+    stmt = stmt.order_by(func.random()).limit(1)
+
+    result = await db.execute(stmt)
+    row = result.one_or_none()
+    if row is None:
+        return None
+    player = PlayerCard(
+        id=row.id,
+        slug=row.slug,
+        display_name=row.display_name or "",
+        school=row.school,
+        draft_year=row.draft_year,
+    )
+    return AnglePick(
+        angle=XPostAngle.spotlight.value,
+        players=[player],
+        notes=f"Current-class spotlight pick for {player.display_name}.",
+    )
+
+
+async def _pick_h2h(db: AsyncSession, window_days: int) -> Optional[AnglePick]:
+    """Pick two current-class players with combine data, not paired recently."""
+    draft_year = await _latest_draft_year(db)
+    if draft_year is None:
+        return None
+
+    used = await _recently_used_player_ids(db, XPostAngle.h2h, window_days)
+
+    stmt: Any = (
+        select(  # type: ignore[call-overload, misc]
+            PlayerMaster.id,
+            PlayerMaster.slug,
+            PlayerMaster.display_name,
+            PlayerMaster.school,
+            PlayerMaster.draft_year,
+        )
+        .join(CombineAnthro, CombineAnthro.player_id == PlayerMaster.id)  # type: ignore[arg-type]
+        .where(PlayerMaster.is_stub.is_(False))  # type: ignore[attr-defined]
+        .where(PlayerMaster.draft_year == draft_year)  # type: ignore[arg-type]
+        .where(PlayerMaster.slug.is_not(None))  # type: ignore[union-attr]
+    )
+    if used:
+        stmt = stmt.where(PlayerMaster.id.notin_(used))  # type: ignore[union-attr]
+    stmt = stmt.order_by(func.random()).limit(2)
+
+    result = await db.execute(stmt)
+    rows = result.all()
+    if len(rows) < 2:
+        return None
+
+    players = [
+        PlayerCard(
+            id=row.id,
+            slug=row.slug,
+            display_name=row.display_name or "",
+            school=row.school,
+            draft_year=row.draft_year,
+        )
+        for row in rows
+    ]
+    return AnglePick(
+        angle=XPostAngle.h2h.value,
+        players=players,
+        notes=f"H2H pairing: {players[0].display_name} vs {players[1].display_name}.",
+    )
+
+
+async def _pick_outlier(db: AsyncSession, window_days: int) -> Optional[AnglePick]:
+    used = await _recently_used_player_ids(db, XPostAngle.outlier, window_days)
+    outlier = await find_outlier_candidate(db, excluded_player_ids=used)
+    if outlier is None:
+        return None
+    return AnglePick(
+        angle=XPostAngle.outlier.value,
+        players=[outlier.player],
+        notes=outlier.support_text,
+    )
+
+
+async def _pick_news_tag(db: AsyncSession, window_days: int) -> Optional[AnglePick]:
+    used_news = await _recently_used_news_ids(db, window_days)
+    cutoff = datetime.utcnow() - timedelta(days=3)
+
+    stmt: Any = (
+        select(NewsItem.id, NewsItem.player_id)  # type: ignore[call-overload]
+        .where(NewsItem.player_id.is_not(None))  # type: ignore[union-attr]
+        .where(NewsItem.published_at >= cutoff)  # type: ignore[arg-type]
+    )
+    if used_news:
+        stmt = stmt.where(NewsItem.id.notin_(used_news))  # type: ignore[union-attr]
+    stmt = stmt.order_by(NewsItem.published_at.desc()).limit(25)  # type: ignore[attr-defined]
+
+    result = await db.execute(stmt)
+    rows = cast(list[Any], result.all())
+    if not rows:
+        return None
+
+    chosen = random.choice(rows)
+    player = await _player_to_card(db, int(chosen.player_id))
+    if player is None:
+        return None
+
+    return AnglePick(
+        angle=XPostAngle.news_tag.value,
+        players=[player],
+        news_item_id=int(chosen.id),
+        notes=f"News reaction for {player.display_name}.",
+    )
+
+
+_PICKERS = {
+    XPostAngle.spotlight: _pick_spotlight,
+    XPostAngle.h2h: _pick_h2h,
+    XPostAngle.outlier: _pick_outlier,
+    XPostAngle.news_tag: _pick_news_tag,
+}
+
+
+async def pick_angle(
+    db: AsyncSession,
+    *,
+    window_days: int = DEFAULT_DEDUP_DAYS,
+    preferred_angle: Optional[XPostAngle] = None,
+) -> Optional[AnglePick]:
+    """Pick the next viable angle + subject.
+
+    Args:
+        db: Database session.
+        window_days: Days to look back when deduping subjects.
+        preferred_angle: Force a specific angle (skill override); fall back to
+            other angles only if this one has no viable subject.
+
+    Returns:
+        AnglePick with chosen angle and subject(s), or None if nothing is viable.
+    """
+    if preferred_angle is not None:
+        picker = _PICKERS[preferred_angle]
+        pick = await picker(db, window_days)
+        if pick is not None:
+            return pick
+
+    order = list(_ANGLE_ORDER)
+    random.shuffle(order)
+    for angle in order:
+        pick = await _PICKERS[angle](db, window_days)
+        if pick is not None:
+            return pick
+    return None

--- a/app/services/x_threads/data_gatherer.py
+++ b/app/services/x_threads/data_gatherer.py
@@ -1,0 +1,248 @@
+"""Per-angle data assembly for the gather CLI.
+
+Each ``gather_*`` function returns a populated GatherResult. Image generation
+is delegated to :mod:`app.services.x_threads.image_builder`, which writes PNGs
+to disk and returns their paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.fields import CohortType, MetricCategory, SimilarityDimension
+from app.schemas.news_items import NewsItem
+from app.services.metrics_service import get_player_metrics
+from app.services.similarity_service import get_similar_players
+
+from .image_builder import (
+    render_h2h_share_card,
+    render_outlier_card,
+    render_performance_share_card,
+)
+from .outlier_finder import find_outlier_candidate
+from .types import AnglePick, CompFact, GatherResult, StatFact
+
+
+_TOP_METRIC_LIMIT = 5
+_TOP_COMP_LIMIT = 3
+
+
+async def gather_for_pick(
+    db: AsyncSession,
+    pick: AnglePick,
+    *,
+    output_dir: Path,
+) -> GatherResult:
+    """Dispatch to the right gather function for the chosen angle."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if pick.angle == "spotlight":
+        return await _gather_spotlight(db, pick, output_dir)
+    if pick.angle == "h2h":
+        return await _gather_h2h(db, pick, output_dir)
+    if pick.angle == "outlier":
+        return await _gather_outlier(db, pick, output_dir)
+    if pick.angle == "news_tag":
+        return await _gather_news_tag(db, pick, output_dir)
+    raise ValueError(f"Unsupported angle: {pick.angle}")
+
+
+async def _top_facts(
+    db: AsyncSession, slug: str, limit: int = _TOP_METRIC_LIMIT
+) -> list[StatFact]:
+    """Pull the player's top percentile metrics across all categories."""
+    rows: list[StatFact] = []
+    for category in (
+        MetricCategory.anthropometrics,
+        MetricCategory.combine_performance,
+        MetricCategory.shooting,
+    ):
+        try:
+            payload = await get_player_metrics(
+                db,
+                slug=slug,
+                cohort=CohortType.current_draft,
+                category=category,
+                position_adjusted=False,
+            )
+        except ValueError:
+            continue
+        for metric in payload.get("metrics", []):
+            if metric.get("percentile") is None:
+                continue
+            value = metric.get("value")
+            unit = metric.get("unit") or ""
+            display_value = f"{value}{unit}" if value is not None else "—"
+            rows.append(
+                StatFact(
+                    label=str(metric.get("metric")),
+                    value=display_value,
+                    percentile=float(metric["percentile"]),
+                    rank=metric.get("rank"),
+                    population_size=metric.get("population_size"),
+                )
+            )
+    rows.sort(key=lambda f: f.percentile or 0, reverse=True)
+    return rows[:limit]
+
+
+async def _top_comps(
+    db: AsyncSession, slug: str, limit: int = _TOP_COMP_LIMIT
+) -> list[CompFact]:
+    try:
+        payload = await get_similar_players(
+            db,
+            slug=slug,
+            dimension=SimilarityDimension.anthro,
+            same_position=False,
+            nba_only=False,
+            limit=limit,
+        )
+    except ValueError:
+        return []
+    return [
+        CompFact(
+            slug=str(p.get("slug") or ""),
+            display_name=str(p.get("display_name") or ""),
+            school=p.get("school"),
+            similarity_score=float(p.get("similarity_score") or 0.0),
+        )
+        for p in payload.get("players", [])
+    ]
+
+
+async def _gather_spotlight(
+    db: AsyncSession, pick: AnglePick, output_dir: Path
+) -> GatherResult:
+    player = pick.players[0]
+    facts = await _top_facts(db, player.slug)
+    comps = await _top_comps(db, player.slug)
+    headline = f"Spotlight: {player.display_name}"
+
+    images: list[str] = []
+    card_path = await render_performance_share_card(
+        db, player_id=player.id, output_dir=output_dir
+    )
+    if card_path is not None:
+        images.append(str(card_path))
+
+    return GatherResult(
+        angle=pick.angle,
+        headline=headline,
+        players=pick.players,
+        facts=facts,
+        comps=comps,
+        images=images,
+        notes=pick.notes,
+    )
+
+
+async def _gather_h2h(
+    db: AsyncSession, pick: AnglePick, output_dir: Path
+) -> GatherResult:
+    p1, p2 = pick.players[0], pick.players[1]
+    p1_facts = await _top_facts(db, p1.slug, limit=3)
+    p2_facts = await _top_facts(db, p2.slug, limit=3)
+    headline = f"H2H: {p1.display_name} vs {p2.display_name}"
+
+    images: list[str] = []
+    card_path = await render_h2h_share_card(
+        db, player_ids=[p1.id, p2.id], output_dir=output_dir
+    )
+    if card_path is not None:
+        images.append(str(card_path))
+
+    return GatherResult(
+        angle=pick.angle,
+        headline=headline,
+        players=pick.players,
+        facts=p1_facts + p2_facts,
+        images=images,
+        extra={
+            "player_facts": {
+                str(p1.id): [f.__dict__ for f in p1_facts],
+                str(p2.id): [f.__dict__ for f in p2_facts],
+            }
+        },
+        notes=pick.notes,
+    )
+
+
+async def _gather_outlier(
+    db: AsyncSession, pick: AnglePick, output_dir: Path
+) -> GatherResult:
+    excluded: set[int] = set()
+    outlier = await find_outlier_candidate(db, excluded_player_ids=excluded)
+    if outlier is None or outlier.player.id != pick.players[0].id:
+        # The picker chose this player based on the same finder so this should
+        # normally hit; rebuild with the player from the pick if it doesn't.
+        outlier = await find_outlier_candidate(db, excluded_player_ids=excluded)
+    if outlier is None:
+        raise ValueError("outlier_finder returned no candidate")
+
+    images: list[str] = []
+    card_path = await render_outlier_card(outlier=outlier, output_dir=output_dir)
+    if card_path is not None:
+        images.append(str(card_path))
+
+    # Also add the performance share card for richer images on the thread.
+    perf_path = await render_performance_share_card(
+        db, player_id=outlier.player.id, output_dir=output_dir
+    )
+    if perf_path is not None:
+        images.append(str(perf_path))
+
+    return GatherResult(
+        angle=pick.angle,
+        headline=outlier.headline,
+        players=[outlier.player],
+        facts=outlier.stats,
+        images=images,
+        notes=outlier.support_text,
+        extra={"subtype": outlier.subtype},
+    )
+
+
+async def _gather_news_tag(
+    db: AsyncSession, pick: AnglePick, output_dir: Path
+) -> GatherResult:
+    assert pick.news_item_id is not None
+    stmt = select(NewsItem).where(NewsItem.id == pick.news_item_id)  # type: ignore[arg-type]
+    result = await db.execute(stmt)
+    news: Optional[NewsItem] = result.scalar_one_or_none()
+    if news is None:
+        raise ValueError("news_item_not_found")
+
+    player = pick.players[0]
+    facts = await _top_facts(db, player.slug, limit=3)
+    headline = f"News reaction: {news.title}"
+
+    images: list[str] = []
+    perf_path = await render_performance_share_card(
+        db, player_id=player.id, output_dir=output_dir
+    )
+    if perf_path is not None:
+        images.append(str(perf_path))
+
+    return GatherResult(
+        angle=pick.angle,
+        headline=headline,
+        players=pick.players,
+        facts=facts,
+        images=images,
+        news={
+            "id": news.id,
+            "title": news.title,
+            "summary": news.summary,
+            "url": news.url,
+            "published_at": news.published_at.isoformat()
+            if news.published_at
+            else None,
+            "tag": news.tag.value if news.tag else None,
+            "source_id": news.source_id,
+        },
+        notes=pick.notes,
+    )

--- a/app/services/x_threads/image_builder.py
+++ b/app/services/x_threads/image_builder.py
@@ -1,0 +1,187 @@
+"""Render images for X threads directly to disk.
+
+Existing share-card primitives (model builders, SVG renderer, rasterizer) are
+reused. The S3 upload step in :mod:`app.services.share_cards.export_service`
+is intentionally skipped — these PNGs live in the local draft folder.
+
+Custom thread-specific templates live in ``app/templates/x_threads/`` and are
+rendered through a separate Jinja environment so they can share the global
+filters/globals without polluting the production share-card renderer.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Optional
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.share_cards.constants import COLORS, FONTS, LAYOUT
+from app.services.share_cards.model_builders import (
+    build_h2h_model,
+    build_performance_model,
+)
+from app.services.share_cards.rasterizer import get_rasterizer
+from app.services.share_cards.svg_renderer import get_svg_renderer
+
+from .types import OutlierResult
+
+logger = logging.getLogger(__name__)
+
+
+_X_TEMPLATE_DIR = Path(__file__).parent.parent.parent / "templates" / "x_threads"
+
+
+def _x_threads_env() -> Environment:
+    env = Environment(
+        loader=FileSystemLoader(str(_X_TEMPLATE_DIR)),
+        autoescape=select_autoescape(["svg", "xml"]),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    env.filters["escape_xml"] = _escape_xml
+    env.globals["colors"] = COLORS
+    env.globals["fonts"] = FONTS
+    env.globals["layout"] = LAYOUT
+    return env
+
+
+def _escape_xml(text: Any) -> str:
+    if not isinstance(text, str):
+        text = str(text)
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#39;")
+    )
+
+
+async def render_performance_share_card(
+    db: AsyncSession,
+    *,
+    player_id: int,
+    output_dir: Path,
+) -> Optional[Path]:
+    """Render the existing performance share card to a local PNG."""
+    try:
+        model = await build_performance_model(
+            db,
+            [player_id],
+            {
+                "comparison_group": "current_draft",
+                "same_position": False,
+                "metric_group": "anthropometrics",
+            },
+        )
+    except ValueError as exc:
+        logger.warning("performance model build failed: %s", exc)
+        return None
+
+    return _render_share_card_to_disk(
+        template_name="performance.svg",
+        model=model,
+        output_dir=output_dir,
+        filename=f"performance_{player_id}.png",
+    )
+
+
+async def render_h2h_share_card(
+    db: AsyncSession,
+    *,
+    player_ids: list[int],
+    output_dir: Path,
+) -> Optional[Path]:
+    """Render the existing h2h share card to a local PNG."""
+    try:
+        model = await build_h2h_model(
+            db,
+            player_ids,
+            {
+                "comparison_group": "current_draft",
+                "same_position": False,
+                "metric_group": "anthropometrics",
+            },
+        )
+    except ValueError as exc:
+        logger.warning("h2h model build failed: %s", exc)
+        return None
+
+    return _render_share_card_to_disk(
+        template_name="h2h.svg",
+        model=model,
+        output_dir=output_dir,
+        filename=f"h2h_{'_'.join(str(p) for p in player_ids)}.png",
+    )
+
+
+def _render_share_card_to_disk(
+    *,
+    template_name: str,
+    model: Any,
+    output_dir: Path,
+    filename: str,
+) -> Optional[Path]:
+    renderer = get_svg_renderer()
+    rasterizer = get_rasterizer()
+
+    context = asdict(model)
+    if "context_line" in context and hasattr(model, "context_line"):
+        context["context_line"]["rendered"] = model.context_line.rendered
+
+    svg = renderer.render(template_name, context)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / filename
+    try:
+        rasterizer.rasterize_to_file(svg, output_path)
+    except Exception as exc:  # noqa: BLE001 — rasterizer can raise many things
+        logger.warning("rasterization failed for %s: %s", filename, exc)
+        return None
+    return output_path
+
+
+async def render_outlier_card(
+    *,
+    outlier: OutlierResult,
+    output_dir: Path,
+) -> Optional[Path]:
+    """Render the custom outlier_stat_card.svg with the result data."""
+    env = _x_threads_env()
+    try:
+        template = env.get_template("outlier_stat_card.svg")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("outlier template not found: %s", exc)
+        return None
+
+    svg = template.render(
+        player_name=outlier.player.display_name,
+        player_school=outlier.player.school or "",
+        headline=outlier.headline,
+        subtype=outlier.subtype,
+        stats=[
+            {
+                "label": stat.label,
+                "value": stat.value,
+                "percentile": stat.percentile,
+                "rank": stat.rank,
+                "population_size": stat.population_size,
+                "context": stat.context,
+            }
+            for stat in outlier.stats
+        ],
+        support_text=outlier.support_text,
+    )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"outlier_{outlier.player.id}_{outlier.subtype}.png"
+    rasterizer = get_rasterizer()
+    try:
+        rasterizer.rasterize_to_file(svg, output_path)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("outlier rasterization failed: %s", exc)
+        return None
+    return output_path

--- a/app/services/x_threads/outlier_finder.py
+++ b/app/services/x_threads/outlier_finder.py
@@ -1,0 +1,339 @@
+"""Find non-obvious facts to seed an OUTLIER thread.
+
+Three independent query patterns are tried in random order:
+
+1. ``split_profile``  — top-decile in one metric AND bottom-decile in another.
+2. ``elite_metric``   — at least one metric at the 99th percentile or higher.
+3. ``plus_wingspan``  — wingspan minus height-with-shoes is a top-quintile gap.
+
+Each returns one randomly-chosen candidate; the picker that wraps this call
+respects the dedup window so we don't keep mining the same player.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Optional, cast
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.fields import CohortType
+from app.schemas.combine_anthro import CombineAnthro
+from app.schemas.metrics import MetricDefinition, MetricSnapshot, PlayerMetricValue
+from app.schemas.players_master import PlayerMaster
+
+from .types import OutlierResult, PlayerCard, StatFact
+
+
+async def _current_player_pool(db: AsyncSession, excluded: set[int]) -> list[int]:
+    """Return current-draft-class player IDs (with anthro data), minus excluded.
+
+    Latest year is computed against players who actually have anthro rows, so
+    stub future-draft-year entries in players_master don't blow the pool away.
+    """
+    stmt = (
+        select(func.max(PlayerMaster.draft_year))  # type: ignore[arg-type]
+        .select_from(PlayerMaster)
+        .join(CombineAnthro, CombineAnthro.player_id == PlayerMaster.id)  # type: ignore[arg-type]
+        .where(PlayerMaster.is_stub.is_(False))  # type: ignore[attr-defined]
+    )
+    res = await db.execute(stmt)
+    draft_year: Optional[int] = res.scalar()
+    if draft_year is None:
+        return []
+
+    stmt2 = (
+        select(PlayerMaster.id)  # type: ignore[call-overload]
+        .join(CombineAnthro, CombineAnthro.player_id == PlayerMaster.id)  # type: ignore[arg-type]
+        .where(PlayerMaster.draft_year == draft_year)  # type: ignore[arg-type]
+        .where(PlayerMaster.is_stub.is_(False))  # type: ignore[attr-defined]
+        .where(PlayerMaster.slug.is_not(None))  # type: ignore[union-attr]
+    )
+    if excluded:
+        stmt2 = stmt2.where(PlayerMaster.id.notin_(excluded))  # type: ignore[union-attr]
+    result = await db.execute(stmt2)
+    return [row[0] for row in result.all()]
+
+
+async def _split_profile(db: AsyncSession, pool: list[int]) -> Optional[OutlierResult]:
+    """Player with elite (>=90) AND deficient (<=20) percentiles in different metrics."""
+    if not pool:
+        return None
+
+    # Pull all metric rows for the current_draft cohort for the pool players.
+    high_stmt = (
+        select(  # type: ignore[call-overload]
+            PlayerMetricValue.player_id,
+            MetricDefinition.display_name,
+            PlayerMetricValue.percentile,
+            PlayerMetricValue.raw_value,
+            PlayerMetricValue.rank,
+            MetricSnapshot.population_size,
+            MetricDefinition.unit,
+        )
+        .join(
+            MetricDefinition,
+            MetricDefinition.id == PlayerMetricValue.metric_definition_id,
+        )
+        .join(MetricSnapshot, MetricSnapshot.id == PlayerMetricValue.snapshot_id)
+        .where(MetricSnapshot.cohort == CohortType.current_draft)  # type: ignore[arg-type]
+        .where(MetricSnapshot.is_current.is_(True))  # type: ignore[attr-defined]
+        .where(PlayerMetricValue.player_id.in_(pool))  # type: ignore[attr-defined]
+        .where(PlayerMetricValue.percentile.is_not(None))  # type: ignore[union-attr]
+    )
+    result = await db.execute(high_stmt)
+    rows = cast(list[Any], result.all())
+
+    # Group rows by player and pick those with both extremes.
+    by_player: dict[int, list[Any]] = {}
+    for row in rows:
+        by_player.setdefault(int(row.player_id), []).append(row)
+
+    candidates: list[tuple[int, Any, Any]] = []
+    for player_id, prows in by_player.items():
+        highs = [r for r in prows if r.percentile is not None and r.percentile >= 90]
+        lows = [r for r in prows if r.percentile is not None and r.percentile <= 20]
+        if highs and lows:
+            candidates.append((player_id, random.choice(highs), random.choice(lows)))
+
+    if not candidates:
+        return None
+
+    player_id, high_row, low_row = random.choice(candidates)
+    player = await _player_card(db, player_id)
+    if player is None:
+        return None
+
+    stats = [
+        StatFact(
+            label=str(high_row.display_name),
+            value=_fmt_value(high_row.raw_value, high_row.unit),
+            percentile=float(high_row.percentile)
+            if high_row.percentile is not None
+            else None,
+            rank=int(high_row.rank) if high_row.rank is not None else None,
+            population_size=(
+                int(high_row.population_size)
+                if high_row.population_size is not None
+                else None
+            ),
+            context="top of class",
+        ),
+        StatFact(
+            label=str(low_row.display_name),
+            value=_fmt_value(low_row.raw_value, low_row.unit),
+            percentile=float(low_row.percentile)
+            if low_row.percentile is not None
+            else None,
+            rank=int(low_row.rank) if low_row.rank is not None else None,
+            population_size=(
+                int(low_row.population_size)
+                if low_row.population_size is not None
+                else None
+            ),
+            context="bottom tier",
+        ),
+    ]
+    return OutlierResult(
+        player=player,
+        subtype="split_profile",
+        headline=f"{player.display_name} — high-variance profile",
+        stats=stats,
+        support_text=(
+            f"{player.display_name} pairs an elite mark in {high_row.display_name} "
+            f"with a bottom-tier number in {low_row.display_name} — the kind of "
+            "split scouts argue over."
+        ),
+    )
+
+
+async def _elite_metric(db: AsyncSession, pool: list[int]) -> Optional[OutlierResult]:
+    """A player with a single >=99th percentile metric in the current class."""
+    if not pool:
+        return None
+    stmt = (
+        select(  # type: ignore[call-overload]
+            PlayerMetricValue.player_id,
+            MetricDefinition.display_name,
+            PlayerMetricValue.percentile,
+            PlayerMetricValue.raw_value,
+            PlayerMetricValue.rank,
+            MetricSnapshot.population_size,
+            MetricDefinition.unit,
+        )
+        .join(
+            MetricDefinition,
+            MetricDefinition.id == PlayerMetricValue.metric_definition_id,
+        )
+        .join(MetricSnapshot, MetricSnapshot.id == PlayerMetricValue.snapshot_id)
+        .where(MetricSnapshot.cohort == CohortType.current_draft)  # type: ignore[arg-type]
+        .where(MetricSnapshot.is_current.is_(True))  # type: ignore[attr-defined]
+        .where(PlayerMetricValue.player_id.in_(pool))  # type: ignore[attr-defined]
+        .where(PlayerMetricValue.percentile >= 99)  # type: ignore[operator]
+        .order_by(func.random())
+        .limit(25)
+    )
+    result = await db.execute(stmt)
+    rows = cast(list[Any], result.all())
+    if not rows:
+        return None
+
+    chosen = random.choice(rows)
+    player = await _player_card(db, int(chosen.player_id))
+    if player is None:
+        return None
+
+    fact = StatFact(
+        label=str(chosen.display_name),
+        value=_fmt_value(chosen.raw_value, chosen.unit),
+        percentile=float(chosen.percentile) if chosen.percentile is not None else None,
+        rank=int(chosen.rank) if chosen.rank is not None else None,
+        population_size=(
+            int(chosen.population_size) if chosen.population_size is not None else None
+        ),
+        context="99th percentile or better",
+    )
+    return OutlierResult(
+        player=player,
+        subtype="elite_metric",
+        headline=f"{player.display_name} — 99th percentile {chosen.display_name}",
+        stats=[fact],
+        support_text=(
+            f"{player.display_name}'s {chosen.display_name} sits in the 99th percentile "
+            "of the current draft class — a number worth flagging."
+        ),
+    )
+
+
+async def _plus_wingspan(db: AsyncSession, pool: list[int]) -> Optional[OutlierResult]:
+    """A player whose wingspan minus shoe-height differential is in the top 20%."""
+    if not pool:
+        return None
+
+    stmt = (
+        select(  # type: ignore[call-overload]
+            CombineAnthro.player_id,
+            CombineAnthro.wingspan_in,
+            CombineAnthro.height_w_shoes_in,
+        )
+        .where(CombineAnthro.player_id.in_(pool))  # type: ignore[attr-defined]
+        .where(CombineAnthro.wingspan_in.is_not(None))  # type: ignore[union-attr]
+        .where(CombineAnthro.height_w_shoes_in.is_not(None))  # type: ignore[union-attr]
+    )
+    result = await db.execute(stmt)
+    rows = [
+        (int(r.player_id), float(r.wingspan_in), float(r.height_w_shoes_in))
+        for r in result.all()
+    ]
+    if len(rows) < 5:
+        return None
+
+    diffs = [(pid, ws, ht, ws - ht) for pid, ws, ht in rows]
+    diffs.sort(key=lambda x: x[3], reverse=True)
+    top_count = max(1, len(diffs) // 5)
+    top = diffs[:top_count]
+
+    pid, ws, ht, diff = random.choice(top)
+    player = await _player_card(db, pid)
+    if player is None:
+        return None
+
+    diff_inches = round(diff * 2) / 2  # half-inch precision
+    rank_in_class = next((i + 1 for i, row in enumerate(diffs) if row[0] == pid), None)
+
+    facts = [
+        StatFact(
+            label="Wingspan",
+            value=_inches_to_feet(ws),
+            context="combine measurement",
+        ),
+        StatFact(
+            label="Height (shoes)",
+            value=_inches_to_feet(ht),
+        ),
+        StatFact(
+            label="Plus-wingspan",
+            value=f'+{diff_inches:g}"',
+            rank=rank_in_class,
+            population_size=len(diffs),
+            context="top 20% of class",
+        ),
+    ]
+    return OutlierResult(
+        player=player,
+        subtype="plus_wingspan",
+        headline=f"{player.display_name} — plus-wingspan frame",
+        stats=facts,
+        support_text=(
+            f'{player.display_name} carries a +{diff_inches:g}" wingspan over standing '
+            f"height — ranked {rank_in_class} of {len(diffs)} prospects with anthro data."
+        ),
+    )
+
+
+_FINDERS = (_split_profile, _elite_metric, _plus_wingspan)
+
+
+async def find_outlier_candidate(
+    db: AsyncSession,
+    *,
+    excluded_player_ids: Optional[set[int]] = None,
+) -> Optional[OutlierResult]:
+    """Run the finders in random order and return the first non-empty result."""
+    excluded = excluded_player_ids or set()
+    pool = await _current_player_pool(db, excluded)
+    if not pool:
+        return None
+
+    finders = list(_FINDERS)
+    random.shuffle(finders)
+    for finder in finders:
+        result = await finder(db, pool)
+        if result is not None:
+            return result
+    return None
+
+
+async def _player_card(db: AsyncSession, player_id: int) -> Optional[PlayerCard]:
+    stmt = select(  # type: ignore[call-overload]
+        PlayerMaster.id,
+        PlayerMaster.slug,
+        PlayerMaster.display_name,
+        PlayerMaster.school,
+        PlayerMaster.draft_year,
+    ).where(and_(PlayerMaster.id == player_id))  # type: ignore[arg-type,misc]
+    result = await db.execute(stmt)
+    row = result.one_or_none()
+    if row is None:
+        return None
+    return PlayerCard(
+        id=row.id,
+        slug=row.slug or "",
+        display_name=row.display_name or "",
+        school=row.school,
+        draft_year=row.draft_year,
+    )
+
+
+def _fmt_value(raw: Optional[float], unit: Optional[str]) -> str:
+    if raw is None:
+        return "—"
+    if unit == "inches":
+        return _inches_to_feet(raw)
+    if unit == "percent":
+        return f"{raw:.1f}%"
+    if unit == "pounds":
+        return f"{raw:.0f} lbs"
+    if unit == "seconds":
+        return f"{raw:.2f} sec"
+    return f"{raw:g}"
+
+
+def _inches_to_feet(raw_inches: float) -> str:
+    rounded = round(raw_inches * 2) / 2
+    feet = int(rounded) // 12
+    inches = rounded % 12
+    if inches == int(inches):
+        return f"{feet}'{int(inches)}\""
+    return f"{feet}'{inches}\""

--- a/app/services/x_threads/types.py
+++ b/app/services/x_threads/types.py
@@ -1,0 +1,76 @@
+"""Dataclasses passed between x_threads services and the gather CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class PlayerCard:
+    """Compact player descriptor used inside angle payloads."""
+
+    id: int
+    slug: str
+    display_name: str
+    school: Optional[str] = None
+    draft_year: Optional[int] = None
+    position: Optional[str] = None
+
+
+@dataclass
+class StatFact:
+    """One numeric fact about a player, ready to drop into a tweet."""
+
+    label: str
+    value: str
+    percentile: Optional[float] = None
+    rank: Optional[int] = None
+    population_size: Optional[int] = None
+    context: Optional[str] = None
+
+
+@dataclass
+class CompFact:
+    """One similarity comp for the player."""
+
+    slug: str
+    display_name: str
+    school: Optional[str]
+    similarity_score: float
+
+
+@dataclass
+class OutlierResult:
+    """Output of the outlier finder for the OUTLIER angle."""
+
+    player: PlayerCard
+    subtype: str
+    headline: str
+    stats: list[StatFact]
+    support_text: str
+
+
+@dataclass
+class AnglePick:
+    """The chosen angle plus the subject(s) to write about."""
+
+    angle: str
+    players: list[PlayerCard]
+    news_item_id: Optional[int] = None
+    notes: str = ""
+
+
+@dataclass
+class GatherResult:
+    """Full payload returned by the gather CLI to the skill."""
+
+    angle: str
+    headline: str
+    players: list[PlayerCard]
+    facts: list[StatFact] = field(default_factory=list)
+    comps: list[CompFact] = field(default_factory=list)
+    news: Optional[dict[str, Any]] = None
+    images: list[str] = field(default_factory=list)
+    extra: dict[str, Any] = field(default_factory=dict)
+    notes: str = ""

--- a/app/templates/x_threads/outlier_stat_card.svg
+++ b/app/templates/x_threads/outlier_stat_card.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2400 1260" width="2400" height="1260">
+  <defs>
+    <style type="text/css">
+      .title { font-family: 'Russo One', sans-serif; font-size: 92px; fill: #0f172a; text-transform: uppercase; }
+      .subtitle { font-family: 'Azeret Mono', monospace; font-size: 36px; fill: #64748b; letter-spacing: 0.05em; }
+      .school { font-family: 'Azeret Mono', monospace; font-size: 32px; fill: #475569; }
+      .stat-label { font-family: 'Azeret Mono', monospace; font-size: 38px; fill: #334155; letter-spacing: 0.04em; text-transform: uppercase; }
+      .stat-value { font-family: 'Russo One', sans-serif; font-size: 96px; fill: #0f172a; }
+      .stat-context { font-family: 'Azeret Mono', monospace; font-size: 30px; fill: #64748b; }
+      .pill-text { font-family: 'Russo One', sans-serif; font-size: 36px; fill: #ffffff; letter-spacing: 0.05em; }
+      .support { font-family: 'Azeret Mono', monospace; font-size: 32px; fill: #334155; }
+      .watermark { font-family: 'Russo One', sans-serif; font-size: 32px; fill: #0f172a; letter-spacing: 0.12em; }
+    </style>
+    <pattern id="dotmatrix" patternUnits="userSpaceOnUse" width="24" height="24">
+      <circle cx="12" cy="12" r="1" fill="#64748b" opacity="0.1"/>
+    </pattern>
+    <pattern id="scanlines" patternUnits="userSpaceOnUse" width="4" height="4">
+      <line x1="0" y1="0" x2="4" y2="0" stroke="#0f172a" stroke-width="1" opacity="0.03"/>
+    </pattern>
+  </defs>
+
+  <!-- Background -->
+  <rect width="2400" height="1260" fill="#f8fafc"/>
+  <rect width="2400" height="1260" fill="url(#dotmatrix)"/>
+  <rect width="2400" height="1260" fill="url(#scanlines)"/>
+
+  <!-- Top accent bar -->
+  <rect x="0" y="0" width="2400" height="14" fill="#d946ef"/>
+
+  <!-- Outlier pill -->
+  <g transform="translate(96, 80)">
+    <rect x="0" y="0" width="280" height="56" rx="28" fill="#0f172a"/>
+    <text x="140" y="38" text-anchor="middle" class="pill-text">OUTLIER</text>
+  </g>
+
+  <!-- Player name + school -->
+  <g transform="translate(96, 200)">
+    <text x="0" y="0" class="title">{{ player_name | escape_xml }}</text>
+    {% if player_school %}
+    <text x="0" y="70" class="school">{{ player_school | escape_xml }}</text>
+    {% endif %}
+  </g>
+
+  <!-- Subtype tag -->
+  <g transform="translate(96, 340)">
+    <text x="0" y="0" class="subtitle">// {{ subtype | replace('_', ' ') | upper | escape_xml }}</text>
+  </g>
+
+  <!-- Stat blocks (up to 3) -->
+  <g transform="translate(96, 420)">
+    {% for stat in stats[:3] %}
+    {% set x_offset = loop.index0 * 740 %}
+    <g transform="translate({{ x_offset }}, 0)">
+      <!-- Pixel-corner card -->
+      <rect x="0" y="0" width="680" height="380" rx="18" fill="#ffffff" stroke="#cbd5e1" stroke-width="3"/>
+      <rect x="0" y="0" width="680" height="14" fill="#d946ef"/>
+
+      <text x="40" y="80" class="stat-label">{{ stat.label | escape_xml }}</text>
+      <text x="40" y="200" class="stat-value">{{ stat.value | escape_xml }}</text>
+
+      {% if stat.percentile is not none %}
+      <text x="40" y="260" class="stat-context">{{ stat.percentile | round(0) | int }}th percentile</text>
+      {% endif %}
+      {% if stat.rank is not none and stat.population_size is not none %}
+      <text x="40" y="305" class="stat-context">#{{ stat.rank }} of {{ stat.population_size }}</text>
+      {% elif stat.rank is not none %}
+      <text x="40" y="305" class="stat-context">rank #{{ stat.rank }}</text>
+      {% endif %}
+      {% if stat.context %}
+      <text x="40" y="350" class="stat-context">{{ stat.context | escape_xml }}</text>
+      {% endif %}
+    </g>
+    {% endfor %}
+  </g>
+
+  <!-- Support text -->
+  <g transform="translate(96, 860)">
+    <foreignObject x="0" y="0" width="2208" height="220">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Azeret Mono', monospace; font-size: 32px; color: #334155; line-height: 1.4;">
+        {{ support_text | escape_xml }}
+      </div>
+    </foreignObject>
+  </g>
+
+  <!-- Watermark -->
+  <g transform="translate(96, 1180)">
+    <text x="0" y="0" class="watermark">DRAFTGURU</text>
+  </g>
+  <g transform="translate(2304, 1180)">
+    <text x="0" y="0" text-anchor="end" class="watermark">@DRAFTGURU</text>
+  </g>
+</svg>

--- a/app/templates/x_threads/riser_card.svg
+++ b/app/templates/x_threads/riser_card.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Riser/Faller card — reserved for the future consensus_shift angle. Renders a
+  player name, two consensus ranks (previous vs current), and a delta arrow.
+  Not wired up in v1 but kept here so the renderer can be exercised before the
+  feature lands.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2400 1260" width="2400" height="1260">
+  <defs>
+    <style type="text/css">
+      .title { font-family: 'Russo One', sans-serif; font-size: 92px; fill: #0f172a; text-transform: uppercase; }
+      .subtitle { font-family: 'Azeret Mono', monospace; font-size: 36px; fill: #64748b; letter-spacing: 0.05em; }
+      .rank-label { font-family: 'Azeret Mono', monospace; font-size: 30px; fill: #64748b; letter-spacing: 0.05em; text-transform: uppercase; }
+      .rank-value { font-family: 'Russo One', sans-serif; font-size: 200px; fill: #0f172a; }
+      .delta-positive { font-family: 'Russo One', sans-serif; font-size: 96px; fill: #10b981; }
+      .delta-negative { font-family: 'Russo One', sans-serif; font-size: 96px; fill: #f43f5e; }
+      .watermark { font-family: 'Russo One', sans-serif; font-size: 32px; fill: #0f172a; letter-spacing: 0.12em; }
+    </style>
+  </defs>
+
+  <rect width="2400" height="1260" fill="#f8fafc"/>
+  <rect x="0" y="0" width="2400" height="14" fill="{{ direction == 'up' and '#10b981' or '#f43f5e' }}"/>
+
+  <g transform="translate(96, 160)">
+    <text x="0" y="0" class="subtitle">// {{ direction == 'up' and 'RISER' or 'FALLER' }}</text>
+    <text x="0" y="120" class="title">{{ player_name | escape_xml }}</text>
+  </g>
+
+  <g transform="translate(96, 520)">
+    <text x="0" y="0" class="rank-label">Previous</text>
+    <text x="0" y="200" class="rank-value">#{{ previous_rank }}</text>
+  </g>
+
+  <g transform="translate(900, 660)">
+    <text x="0" y="0" class="{{ direction == 'up' and 'delta-positive' or 'delta-negative' }}">
+      {{ direction == 'up' and '↑' or '↓' }} {{ delta }}
+    </text>
+  </g>
+
+  <g transform="translate(1700, 520)">
+    <text x="0" y="0" class="rank-label">Current</text>
+    <text x="0" y="200" class="rank-value">#{{ current_rank }}</text>
+  </g>
+
+  <g transform="translate(96, 1180)">
+    <text x="0" y="0" class="watermark">DRAFTGURU</text>
+  </g>
+</svg>

--- a/scripts/x_threads/__init__.py
+++ b/scripts/x_threads/__init__.py
@@ -1,0 +1,1 @@
+"""CLI entry points for the x-thread skill."""

--- a/scripts/x_threads/gather.py
+++ b/scripts/x_threads/gather.py
@@ -1,0 +1,148 @@
+"""Gather material for the next X thread.
+
+Run with::
+
+    conda run -n draftguru python -m scripts.x_threads.gather
+
+The script picks an angle, queries the DB for relevant facts, renders any
+images for the chosen angle, and writes everything to a draft directory under
+``scripts/x_threads/drafts/``. The directory path is printed to stdout on the
+last line so the calling skill can resolve it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import re
+import sys
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Import after load_dotenv so app.config resolves env-driven settings.
+from app.services.x_threads.angle_picker import (  # noqa: E402
+    DEFAULT_DEDUP_DAYS,
+    pick_angle,
+)
+from app.services.x_threads.data_gatherer import gather_for_pick  # noqa: E402
+from app.schemas.x_post_history import XPostAngle  # noqa: E402
+from app.utils.db_async import SessionLocal  # noqa: E402
+
+DRAFTS_ROOT = Path(__file__).resolve().parent / "drafts"
+
+logger = logging.getLogger("x_threads.gather")
+
+
+def _slugify(text: str) -> str:
+    text = re.sub(r"[^a-zA-Z0-9]+", "-", text).strip("-").lower()
+    return text or "subject"
+
+
+def _resolve_angle(arg: Optional[str]) -> Optional[XPostAngle]:
+    if not arg:
+        return None
+    try:
+        return XPostAngle(arg.lower())
+    except ValueError as exc:
+        raise SystemExit(f"Unknown angle: {arg}") from exc
+
+
+def _draft_dir_for(angle: str, subject_slug: str) -> Path:
+    now = datetime.utcnow()
+    day = now.strftime("%Y-%m-%d")
+    stamp = now.strftime("%H%M%S")
+    return DRAFTS_ROOT / day / f"{stamp}_{angle}_{subject_slug}"
+
+
+async def _run(args: argparse.Namespace) -> int:
+    preferred = _resolve_angle(args.angle)
+
+    async with SessionLocal() as db:
+        pick = await pick_angle(
+            db,
+            window_days=args.window_days,
+            preferred_angle=preferred,
+        )
+        if pick is None:
+            print(
+                json.dumps({"status": "no_viable_angle"}),
+                file=sys.stderr,
+            )
+            return 2
+
+        subject_slug = _slugify(pick.players[0].slug or pick.players[0].display_name)
+        draft_dir = (
+            Path(args.output_dir)
+            if args.output_dir
+            else _draft_dir_for(pick.angle, subject_slug)
+        )
+        draft_dir.mkdir(parents=True, exist_ok=True)
+
+        result = await gather_for_pick(db, pick, output_dir=draft_dir)
+
+    payload = {
+        "angle": result.angle,
+        "headline": result.headline,
+        "players": [asdict(p) for p in result.players],
+        "facts": [asdict(f) for f in result.facts],
+        "comps": [asdict(c) for c in result.comps],
+        "news": result.news,
+        "images": [
+            str(Path(p).relative_to(DRAFTS_ROOT.parent.parent))
+            if Path(p).is_absolute()
+            else p
+            for p in result.images
+        ],
+        "extra": result.extra,
+        "notes": result.notes,
+        "draft_dir": str(draft_dir),
+        "news_item_id": pick.news_item_id,
+    }
+    json_path = draft_dir / "gather.json"
+    json_path.write_text(json.dumps(payload, indent=2, default=str))
+
+    # Print the dir on the final line; everything before is informational logs.
+    print(
+        f"angle={payload['angle']} subject={pick.players[0].display_name}",
+        file=sys.stderr,
+    )
+    print(str(draft_dir))
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--angle",
+        help="Force a specific angle (spotlight, h2h, outlier, news_tag).",
+    )
+    parser.add_argument(
+        "--window-days",
+        type=int,
+        default=DEFAULT_DEDUP_DAYS,
+        help="Dedup window in days (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Override the draft directory location.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="WARNING",
+        help="Python logging level (default: %(default)s).",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=args.log_level)
+    sys.exit(asyncio.run(_run(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/x_threads/post_to_x.py
+++ b/scripts/x_threads/post_to_x.py
@@ -1,0 +1,128 @@
+"""Post a saved draft to X (Twitter).
+
+This is intentionally a no-op stub until X API credentials are configured.
+When you wire up posting:
+
+1. ``pip install tweepy`` (or another X v2 client).
+2. Add ``X_API_KEY`` / ``X_API_SECRET`` / ``X_ACCESS_TOKEN`` / ``X_ACCESS_SECRET``
+   (or OAuth2 user-context credentials) to ``.env``.
+3. Replace ``_post_thread`` with real HTTP calls that:
+   - Upload images via ``POST /2/media/upload``.
+   - Create the lead tweet with ``media_ids``.
+   - Reply to ``lead.id`` for each subsequent tweet.
+4. On success, flip the row's status to ``posted`` and store the lead
+   tweet ID in ``external_post_id``.
+
+Until then, this script exits non-zero so the skill never thinks posting
+succeeded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from sqlalchemy import select  # noqa: E402
+
+from app.schemas.x_post_history import XPostHistory, XPostStatus  # noqa: E402
+from app.utils.db_async import SessionLocal  # noqa: E402
+
+
+REQUIRED_ENV = ("X_API_KEY", "X_API_SECRET", "X_ACCESS_TOKEN", "X_ACCESS_SECRET")
+
+
+def _credentials_present() -> bool:
+    return all(os.environ.get(name) for name in REQUIRED_ENV)
+
+
+def _post_thread(tweets: list[dict[str, Any]], image_paths: list[str]) -> str:
+    """Placeholder for the real X API call.
+
+    Returns the external tweet ID of the lead tweet on success.
+    """
+    raise NotImplementedError(
+        "X API posting is not implemented yet. See module docstring."
+    )
+
+
+async def _run(args: argparse.Namespace) -> int:
+    if not _credentials_present():
+        missing = [name for name in REQUIRED_ENV if not os.environ.get(name)]
+        print(
+            json.dumps(
+                {
+                    "status": "skipped",
+                    "reason": "missing_credentials",
+                    "missing": missing,
+                }
+            ),
+            file=sys.stderr,
+        )
+        return 4
+
+    async with SessionLocal() as db:
+        row: XPostHistory | None
+        if args.id is not None:
+            stmt = select(XPostHistory).where(XPostHistory.id == args.id)  # type: ignore[arg-type]
+        else:
+            stmt = (
+                select(XPostHistory)
+                .where(XPostHistory.draft_dir == str(Path(args.draft_dir).resolve()))  # type: ignore[arg-type]
+                .order_by(XPostHistory.created_at.desc())  # type: ignore[attr-defined]
+                .limit(1)
+            )
+        result = await db.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            print("no x_post_history row found", file=sys.stderr)
+            return 2
+        if row.status == XPostStatus.posted:
+            print(
+                json.dumps({"status": "already_posted", "id": row.id}),
+                file=sys.stderr,
+            )
+            return 0
+
+        try:
+            external_id = _post_thread(row.tweets, row.image_paths)
+        except NotImplementedError as exc:
+            print(
+                json.dumps({"status": "not_implemented", "detail": str(exc)}),
+                file=sys.stderr,
+            )
+            return 5
+
+        async with db.begin():
+            from datetime import datetime as _dt
+
+            row.status = XPostStatus.posted
+            row.posted_at = _dt.utcnow()
+            row.external_post_id = external_id
+            db.add(row)
+
+    print(
+        json.dumps({"status": "posted", "id": row.id, "external_post_id": external_id})
+    )
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--id", type=int, help="x_post_history row ID to post.")
+    group.add_argument("--draft-dir", help="Resolve the row from this draft directory.")
+    args = parser.parse_args()
+    sys.exit(asyncio.run(_run(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/x_threads/save_draft.py
+++ b/scripts/x_threads/save_draft.py
@@ -1,0 +1,169 @@
+"""Persist a drafted X thread.
+
+Run after the skill has authored tweets into a text file::
+
+    conda run -n draftguru python -m scripts.x_threads.save_draft \
+        --draft-dir scripts/x_threads/drafts/2026-05-19/142211_outlier_cooper-flagg \
+        --tweets-file <same dir>/tweets.txt
+
+Tweets file format: each tweet separated by a line containing only ``---``.
+Blank lines inside a tweet are preserved.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from app.schemas import news_items as _news_items  # noqa: E402, F401
+from app.schemas.x_post_history import (  # noqa: E402
+    XPostAngle,
+    XPostHistory,
+    XPostStatus,
+)
+from app.utils.db_async import SessionLocal  # noqa: E402
+
+# Keep the news_items import alive — XPostHistory has an FK to that table and
+# SQLModel needs the target registered before the mapper resolves.
+_ = _news_items
+
+logger = logging.getLogger("x_threads.save_draft")
+
+_TWEET_SEPARATOR = "---"
+_MAX_TWEET_CHARS = 280
+
+
+def _parse_tweets(tweets_text: str) -> list[str]:
+    """Split a tweets file on '---' lines and strip whitespace around each."""
+    blocks: list[list[str]] = [[]]
+    for line in tweets_text.splitlines():
+        if line.strip() == _TWEET_SEPARATOR:
+            blocks.append([])
+        else:
+            blocks[-1].append(line)
+    tweets = ["\n".join(block).strip() for block in blocks]
+    return [t for t in tweets if t]
+
+
+def _check_tweet_lengths(tweets: list[str]) -> list[str]:
+    """Return a list of human-readable warnings for over-length tweets."""
+    warnings: list[str] = []
+    for idx, tweet in enumerate(tweets, start=1):
+        if len(tweet) > _MAX_TWEET_CHARS:
+            warnings.append(
+                f"tweet {idx}: {len(tweet)} chars (limit {_MAX_TWEET_CHARS})"
+            )
+    return warnings
+
+
+async def _save(args: argparse.Namespace) -> int:
+    draft_dir = Path(args.draft_dir).resolve()
+    if not draft_dir.is_dir():
+        print(f"draft_dir not found: {draft_dir}", file=sys.stderr)
+        return 2
+
+    gather_path = draft_dir / "gather.json"
+    if not gather_path.is_file():
+        print(f"gather.json missing in {draft_dir}", file=sys.stderr)
+        return 2
+
+    gather: dict[str, Any] = json.loads(gather_path.read_text())
+
+    tweets_file = Path(args.tweets_file).resolve()
+    if not tweets_file.is_file():
+        print(f"tweets file not found: {tweets_file}", file=sys.stderr)
+        return 2
+
+    tweets = _parse_tweets(tweets_file.read_text())
+    if not tweets:
+        print("no tweets parsed from tweets file", file=sys.stderr)
+        return 2
+
+    warnings = _check_tweet_lengths(tweets)
+    if warnings and not args.allow_long:
+        for w in warnings:
+            print(f"warning: {w}", file=sys.stderr)
+        print(
+            "refusing to save; pass --allow-long to override",
+            file=sys.stderr,
+        )
+        return 3
+    for w in warnings:
+        logger.warning("over-length tweet allowed: %s", w)
+
+    thread_txt = draft_dir / "thread.txt"
+    thread_txt.write_text(("\n" + _TWEET_SEPARATOR + "\n").join(tweets))
+
+    angle_value = gather.get("angle")
+    if angle_value is None:
+        print("gather.json missing angle", file=sys.stderr)
+        return 2
+
+    angle = XPostAngle(angle_value)
+    player_ids = [
+        int(p["id"]) for p in gather.get("players", []) if p.get("id") is not None
+    ]
+    image_paths = [str(p) for p in gather.get("images", [])]
+    headline = gather.get("headline")
+    notes = gather.get("notes")
+    news_item_id = gather.get("news_item_id")
+
+    tweet_objects = [{"text": t} for t in tweets]
+
+    async with SessionLocal() as db:
+        async with db.begin():
+            row = XPostHistory(
+                angle=angle,
+                status=XPostStatus.draft,
+                player_ids=player_ids,
+                news_item_id=int(news_item_id) if news_item_id else None,
+                headline=headline,
+                tweets=tweet_objects,
+                image_paths=image_paths,
+                draft_dir=str(draft_dir),
+                notes=notes,
+            )
+            db.add(row)
+            await db.flush()
+            row_id = row.id
+
+    print(
+        json.dumps(
+            {
+                "status": "saved",
+                "x_post_history_id": row_id,
+                "draft_dir": str(draft_dir),
+                "tweet_count": len(tweets),
+                "warnings": warnings,
+            }
+        )
+    )
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--draft-dir", required=True)
+    parser.add_argument("--tweets-file", required=True)
+    parser.add_argument(
+        "--allow-long",
+        action="store_true",
+        help="Save the draft even if a tweet exceeds 280 chars.",
+    )
+    parser.add_argument("--log-level", default="WARNING")
+    args = parser.parse_args()
+    logging.basicConfig(level=args.log_level)
+    sys.exit(asyncio.run(_save(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -135,6 +135,7 @@ async def async_engine(
     from app.schemas import auth  # noqa: F401
     from app.schemas import big_boards  # noqa: F401
     from app.schemas import consensus  # noqa: F401
+    from app.schemas import x_post_history  # noqa: F401
 
     connect_args = {
         # Disable prepared statement caching to avoid type OID/cache issues after DDL.

--- a/tests/integration/test_x_threads_outlier.py
+++ b/tests/integration/test_x_threads_outlier.py
@@ -1,0 +1,85 @@
+"""Integration test for the plus-wingspan outlier path.
+
+The other outlier finders (split_profile, elite_metric) depend on the metric
+snapshot chain, which has its own dedicated tests. plus_wingspan only needs
+combine_anthro rows, so it's the cheapest way to validate the end-to-end
+finder dispatch from a seeded fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.combine_anthro import CombineAnthro
+from app.schemas.players_master import PlayerMaster
+from app.schemas.seasons import Season
+from app.services.x_threads.outlier_finder import (
+    find_outlier_candidate,
+    _plus_wingspan,
+)
+
+
+async def _seed_pool(db: AsyncSession) -> list[int]:
+    season = Season(code="2025-26", start_year=2025, end_year=2026)
+    db.add(season)
+    await db.flush()
+
+    profiles = [
+        ("Average Guy", 82.0, 79.0),
+        ("Stretchy Wing", 88.0, 80.0),  # +8" plus-wingspan: the outlier
+        ("Standard Wing", 82.5, 80.0),
+        ("Tall Guard", 80.0, 78.0),
+        ("Compact Player", 79.0, 78.5),
+        ("Big Body", 84.0, 82.5),
+    ]
+    ids: list[int] = []
+    for name, wing, height in profiles:
+        player = PlayerMaster(
+            first_name=name.split()[0],
+            last_name=name.split()[-1],
+            display_name=name,
+            draft_year=2026,
+            is_stub=False,
+        )
+        db.add(player)
+        await db.flush()
+        anthro = CombineAnthro(
+            player_id=player.id,
+            season_id=season.id,
+            wingspan_in=wing,
+            height_w_shoes_in=height,
+        )
+        db.add(anthro)
+        assert player.id is not None
+        ids.append(player.id)
+    await db.flush()
+    return ids
+
+
+@pytest.mark.asyncio
+async def test_plus_wingspan_finds_the_top_diff_player(
+    db_session: AsyncSession,
+) -> None:
+    """The stretchy wing has the biggest plus-wingspan; it should land in the top quintile."""
+    pool = await _seed_pool(db_session)
+    result = await _plus_wingspan(db_session, pool)
+    assert result is not None
+    assert result.subtype == "plus_wingspan"
+    # With 6 players the top 20% = 1 candidate, so the result is deterministic.
+    assert result.player.display_name == "Stretchy Wing"
+    # Wingspan and height labels should both be present.
+    labels = {stat.label for stat in result.stats}
+    assert "Wingspan" in labels
+    assert "Plus-wingspan" in labels
+
+
+@pytest.mark.asyncio
+async def test_find_outlier_candidate_filters_excluded_players(
+    db_session: AsyncSession,
+) -> None:
+    """Players in the excluded set should never come back from the finder."""
+    pool = await _seed_pool(db_session)
+    excluded = set(pool)
+    result = await find_outlier_candidate(db_session, excluded_player_ids=excluded)
+    assert result is None

--- a/tests/integration/test_x_threads_picker.py
+++ b/tests/integration/test_x_threads_picker.py
@@ -1,0 +1,160 @@
+"""Integration tests for the x_threads angle picker and dedup behavior."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.combine_anthro import CombineAnthro
+from app.schemas.players_master import PlayerMaster
+from app.schemas.seasons import Season
+from app.schemas.x_post_history import XPostAngle, XPostHistory, XPostStatus
+from app.services.x_threads.angle_picker import pick_angle
+
+
+async def _seed_player_with_anthro(
+    db: AsyncSession,
+    *,
+    name: str,
+    draft_year: int,
+    season_id: int,
+    wingspan_in: float = 84.0,
+    height_w_shoes_in: float = 78.0,
+) -> PlayerMaster:
+    player = PlayerMaster(
+        first_name=name.split()[0],
+        last_name=name.split()[-1],
+        display_name=name,
+        draft_year=draft_year,
+        is_stub=False,
+    )
+    db.add(player)
+    await db.flush()
+    anthro = CombineAnthro(
+        player_id=player.id,
+        season_id=season_id,
+        wingspan_in=wingspan_in,
+        height_w_shoes_in=height_w_shoes_in,
+    )
+    db.add(anthro)
+    await db.flush()
+    return player
+
+
+async def _seed_season(db: AsyncSession) -> int:
+    season = Season(code="2025-26", start_year=2025, end_year=2026)
+    db.add(season)
+    await db.flush()
+    assert season.id is not None
+    return season.id
+
+
+@pytest.mark.asyncio
+async def test_pick_angle_returns_spotlight_for_current_class(
+    db_session: AsyncSession,
+) -> None:
+    """With one viable player, the spotlight angle should be chosen."""
+    season_id = await _seed_season(db_session)
+    await _seed_player_with_anthro(
+        db_session, name="Test Player", draft_year=2026, season_id=season_id
+    )
+
+    pick = await pick_angle(
+        db_session,
+        preferred_angle=XPostAngle.spotlight,
+    )
+    assert pick is not None
+    assert pick.angle == "spotlight"
+    assert pick.players[0].display_name == "Test Player"
+
+
+@pytest.mark.asyncio
+async def test_pick_angle_respects_recent_history(
+    db_session: AsyncSession,
+) -> None:
+    """A spotlighted player in the dedup window should not be re-picked."""
+    season_id = await _seed_season(db_session)
+    player_a = await _seed_player_with_anthro(
+        db_session, name="Player Aaa", draft_year=2026, season_id=season_id
+    )
+    player_b = await _seed_player_with_anthro(
+        db_session, name="Player Bbb", draft_year=2026, season_id=season_id
+    )
+
+    # Pretend Player A was just spotlighted.
+    db_session.add(
+        XPostHistory(
+            angle=XPostAngle.spotlight,
+            status=XPostStatus.draft,
+            player_ids=[player_a.id],
+            tweets=[{"text": "lead"}],
+            image_paths=[],
+            created_at=datetime.utcnow() - timedelta(hours=1),
+        )
+    )
+    await db_session.flush()
+
+    pick = await pick_angle(
+        db_session,
+        preferred_angle=XPostAngle.spotlight,
+    )
+    assert pick is not None
+    assert pick.players[0].id == player_b.id
+
+
+@pytest.mark.asyncio
+async def test_pick_angle_returns_none_when_pool_exhausted(
+    db_session: AsyncSession,
+) -> None:
+    """All angles return None when every candidate has been spotlighted recently."""
+    season_id = await _seed_season(db_session)
+    player = await _seed_player_with_anthro(
+        db_session, name="Solo Prospect", draft_year=2026, season_id=season_id
+    )
+    db_session.add(
+        XPostHistory(
+            angle=XPostAngle.spotlight,
+            status=XPostStatus.draft,
+            player_ids=[player.id],
+            tweets=[{"text": "lead"}],
+            image_paths=[],
+            created_at=datetime.utcnow() - timedelta(hours=1),
+        )
+    )
+    await db_session.flush()
+
+    pick = await pick_angle(
+        db_session,
+        preferred_angle=XPostAngle.spotlight,
+    )
+    assert pick is None
+
+
+@pytest.mark.asyncio
+async def test_pick_angle_window_expires(db_session: AsyncSession) -> None:
+    """History older than the dedup window no longer blocks the candidate."""
+    season_id = await _seed_season(db_session)
+    player = await _seed_player_with_anthro(
+        db_session, name="Old Pick", draft_year=2026, season_id=season_id
+    )
+    db_session.add(
+        XPostHistory(
+            angle=XPostAngle.spotlight,
+            status=XPostStatus.draft,
+            player_ids=[player.id],
+            tweets=[{"text": "lead"}],
+            image_paths=[],
+            created_at=datetime.utcnow() - timedelta(days=30),
+        )
+    )
+    await db_session.flush()
+
+    pick = await pick_angle(
+        db_session,
+        window_days=14,
+        preferred_angle=XPostAngle.spotlight,
+    )
+    assert pick is not None
+    assert pick.players[0].id == player.id

--- a/tests/unit/test_x_threads_save_draft.py
+++ b/tests/unit/test_x_threads_save_draft.py
@@ -1,0 +1,38 @@
+"""Pure-function tests for the save_draft tweet parsing helpers."""
+
+from scripts.x_threads.save_draft import _check_tweet_lengths, _parse_tweets
+
+
+def test_parse_tweets_splits_on_separator() -> None:
+    """Tweets file split by '---' lines produces one tweet per block."""
+    raw = (
+        "Lead tweet.\nTwo lines in one tweet.\n---\nSecond tweet.\n---\nThird tweet.\n"
+    )
+    tweets = _parse_tweets(raw)
+    assert tweets == [
+        "Lead tweet.\nTwo lines in one tweet.",
+        "Second tweet.",
+        "Third tweet.",
+    ]
+
+
+def test_parse_tweets_ignores_blank_blocks() -> None:
+    """Trailing separators and empty blocks don't yield empty tweets."""
+    raw = "Only one.\n---\n---\n\n"
+    tweets = _parse_tweets(raw)
+    assert tweets == ["Only one."]
+
+
+def test_check_tweet_lengths_flags_long_tweets() -> None:
+    """Tweets over 280 chars surface as warnings with the index."""
+    long_text = "x" * 281
+    warnings = _check_tweet_lengths(["ok", long_text, "ok"])
+    assert len(warnings) == 1
+    assert warnings[0].startswith("tweet 2:")
+    assert "281" in warnings[0]
+
+
+def test_check_tweet_lengths_passes_short_tweets() -> None:
+    """Short tweets produce no warnings."""
+    warnings = _check_tweet_lengths(["a", "b" * 280])
+    assert warnings == []


### PR DESCRIPTION
## Summary

Adds a `/x-thread` Claude Code skill that drafts one long-form X (Twitter) thread per invocation about an NBA draft prospect. The skill:

1. Picks an angle (`spotlight`, `h2h`, `outlier`, `consensus_shift`, `news_tag`) and a subject, deduped via the new `x_post_history` table.
2. Gathers DB facts and renders SVG cards via `scripts/x_threads/gather.py`.
3. Hands the payload to Claude (this turn) to author 5–9 tweets in analyst/scout voice.
4. Persists a reviewable draft via `scripts/x_threads/save_draft.py`.

Posting to X is **not** wired up — `post_to_x.py` is a stub. Drafts land in `scripts/x_threads/drafts/<date>/<time>_<angle>_<slug>/` (gitignored) for manual review. Pairs naturally with `/loop` for steady throughput.

## What's in the PR

- `.claude/skills/x-thread/SKILL.md` — the skill definition
- `app/schemas/x_post_history.py` + `alembic/versions/q6r7s8t9u0v1_add_x_post_history.py` — history table with `x_post_angle_enum` / `x_post_status_enum` and JSONB payloads
- `app/services/x_threads/` — angle picker, data gatherer, outlier finder, SVG image builder, shared types
- `app/templates/x_threads/` — outlier and riser SVG card templates
- `scripts/x_threads/` — gather / save / post CLIs
- `tests/` — unit + integration coverage (10 tests, all passing)
- `.gitignore` — adds `scripts/x_threads/drafts/`, `.playwright-mcp/`, `.claude/scheduled_tasks.lock`, `scripts/top100/output/`

## Dependency

⚠️ **Blocked on #192.** This migration's `down_revision` is `p5q6r7s8t9u0` (the `big_boards` migration in #192). Merge #192 first, then this is ready.

## Test plan

- [x] `make precommit` clean (ruff, ruff-format, mypy, custom hooks)
- [x] `mypy app --ignore-missing-imports` clean across 131 source files
- [x] `pytest tests/unit/test_x_threads_save_draft.py tests/integration/test_x_threads_outlier.py tests/integration/test_x_threads_picker.py` — 10 passed
- [x] Alembic round-trip verified against the test Neon branch with #192's migration applied first: `o4p5q6r7s8t9 → p5q6r7s8t9u0 → q6r7s8t9u0v1` upgrade and downgrade both clean
- [ ] Reviewer: try `/x-thread` end-to-end against a local DB after both migrations are applied