### PR TITLE
feature: manual big board entry and admin approval flow

### DIFF
--- a/app/routes/admin/__init__.py
+++ b/app/routes/admin/__init__.py
@@ -14,6 +14,7 @@ from starlette.responses import Response
 
 from app.routes.admin.account import router as account_router
 from app.routes.admin.auth import router as auth_router
+from app.routes.admin.big_boards import router as big_boards_router
 from app.routes.admin.helpers import base_context, get_current_user
 from app.routes.admin.images import router as images_router
 from app.routes.admin.news_items import router as news_items_router
@@ -56,4 +57,5 @@ router.include_router(podcast_shows_router)
 router.include_router(podcast_episodes_router)
 router.include_router(youtube_channels_router)
 router.include_router(youtube_videos_router)
+router.include_router(big_boards_router)
 router.include_router(users_router)

--- a/app/routes/admin/big_boards.py
+++ b/app/routes/admin/big_boards.py
@@ -1,0 +1,465 @@
+"""Admin routes for manual big-board entry, review, and approval.
+
+Workflow:
+    1. Admin creates an empty PENDING board (source + draft year + published_at).
+    2. Admin adds entries one at a time on the detail page (autocomplete to
+       the existing /players/search endpoint).
+    3. Admin approves or rejects. APPROVED and REJECTED boards are
+       immutable; only PENDING boards may be edited or deleted.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Form, Query, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response
+
+from app.routes.admin.helpers import (
+    base_context_with_permissions,
+    require_dataset_access,
+)
+from app.schemas.big_boards import BoardStatus
+from app.schemas.news_sources import NewsSource
+from app.schemas.players_master import PlayerMaster
+from app.services import big_board_service as svc
+from app.utils.db_async import get_session
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/big-boards", tags=["admin-big-boards"])
+
+_SUCCESS_MESSAGES: dict[str, str] = {
+    "created": "Big board created. Add entries below.",
+    "entry_added": "Entry added.",
+    "entry_updated": "Entry updated.",
+    "entry_deleted": "Entry removed.",
+    "approved": "Board approved.",
+    "rejected": "Board rejected.",
+    "deleted": "Board deleted.",
+}
+
+
+@router.get("", response_class=HTMLResponse)
+async def list_big_boards(
+    request: Request,
+    status: str | None = Query(default=None),
+    success: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """List big boards, optionally filtered by status."""
+    redirect, user = await require_dataset_access(
+        request, db, "big_boards", need_edit=False, next_path="/admin/big-boards"
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    status_filter: BoardStatus | None = None
+    if status:
+        try:
+            status_filter = BoardStatus(status.upper())
+        except ValueError:
+            status_filter = None
+
+    boards = await svc.list_boards(db, status=status_filter)
+
+    source_ids = {b.news_source_id for b in boards}
+    sources_by_id: dict[int, NewsSource] = {}
+    if source_ids:
+        rows = await db.execute(
+            select(NewsSource).where(NewsSource.id.in_(source_ids))  # type: ignore[union-attr]
+        )
+        sources_by_id = {s.id: s for s in rows.scalars().all() if s.id is not None}
+
+    return request.app.state.templates.TemplateResponse(
+        "admin/big-boards/index.html",
+        await base_context_with_permissions(
+            request,
+            db,
+            user,
+            boards=boards,
+            sources_by_id=sources_by_id,
+            status_filter=status_filter.value if status_filter else None,
+            statuses=[s.value for s in BoardStatus],
+            success=_SUCCESS_MESSAGES.get(success) if success else None,
+        ),
+    )
+
+
+@router.get("/new", response_class=HTMLResponse)
+async def new_big_board(
+    request: Request,
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Display the create-board form."""
+    redirect, user = await require_dataset_access(
+        request,
+        db,
+        "big_boards",
+        need_edit=True,
+        next_path="/admin/big-boards/new",
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    sources = (
+        (
+            await db.execute(
+                select(NewsSource)
+                .where(NewsSource.is_active)  # type: ignore[arg-type]
+                .order_by(NewsSource.display_name)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    return request.app.state.templates.TemplateResponse(
+        "admin/big-boards/new.html",
+        await base_context_with_permissions(
+            request,
+            db,
+            user,
+            sources=sources,
+            default_draft_year=datetime.utcnow().year + 1,
+            error=None,
+        ),
+    )
+
+
+@router.post("", response_class=HTMLResponse)
+async def create_big_board(
+    request: Request,
+    news_source_id: int = Form(...),
+    draft_year: int = Form(...),
+    published_at: str = Form(...),
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Create an empty PENDING board and redirect to its detail page."""
+    redirect, user = await require_dataset_access(
+        request, db, "big_boards", need_edit=True, next_path="/admin/big-boards"
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    try:
+        published_dt = datetime.fromisoformat(published_at)
+    except ValueError:
+        return await _render_new_with_error(
+            request,
+            db,
+            user,
+            "Published-at must be an ISO date/time (e.g., 2026-05-20).",
+        )
+    if published_dt.tzinfo is not None:
+        published_dt = published_dt.replace(tzinfo=None)
+
+    async with db.begin():
+        board = await svc.create_board(
+            db,
+            news_source_id=news_source_id,
+            draft_year=draft_year,
+            published_at=published_dt,
+            entries=[],
+        )
+
+    return RedirectResponse(
+        url=f"/admin/big-boards/{board.id}?success=created", status_code=303
+    )
+
+
+@router.get("/{board_id}", response_class=HTMLResponse)
+async def big_board_detail(
+    request: Request,
+    board_id: int,
+    success: str | None = Query(default=None),
+    error: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Show a single board, its entries, and the add/approve/reject controls."""
+    redirect, user = await require_dataset_access(
+        request,
+        db,
+        "big_boards",
+        need_edit=False,
+        next_path=f"/admin/big-boards/{board_id}",
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    try:
+        board, entries = await svc.get_board_with_entries(db, board_id)
+    except svc.BoardNotFoundError:
+        return RedirectResponse(url="/admin/big-boards", status_code=303)
+
+    source = await db.get(NewsSource, board.news_source_id)
+
+    player_ids = [e.player_id for e in entries]
+    players_by_id: dict[int, PlayerMaster] = {}
+    if player_ids:
+        rows = await db.execute(
+            select(PlayerMaster).where(PlayerMaster.id.in_(player_ids))  # type: ignore[union-attr]
+        )
+        players_by_id = {p.id: p for p in rows.scalars().all() if p.id is not None}
+
+    return request.app.state.templates.TemplateResponse(
+        "admin/big-boards/detail.html",
+        await base_context_with_permissions(
+            request,
+            db,
+            user,
+            board=board,
+            entries=entries,
+            source=source,
+            players_by_id=players_by_id,
+            is_pending=board.status is BoardStatus.PENDING,
+            success=_SUCCESS_MESSAGES.get(success) if success else None,
+            error=error,
+        ),
+    )
+
+
+@router.post("/{board_id}/entries", response_class=HTMLResponse)
+async def add_board_entry(
+    request: Request,
+    board_id: int,
+    player_id: int = Form(...),
+    rank: int = Form(...),
+    tier: str | None = Form(default=None),
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Append an entry to a PENDING board."""
+    redirect, user = await require_dataset_access(
+        request,
+        db,
+        "big_boards",
+        need_edit=True,
+        next_path=f"/admin/big-boards/{board_id}",
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    tier_int = _parse_optional_int(tier)
+    try:
+        async with db.begin():
+            await svc.add_entry(
+                db,
+                board_id=board_id,
+                player_id=player_id,
+                rank=rank,
+                tier=tier_int,
+            )
+    except svc.BigBoardError as exc:
+        return _redirect_with_error(board_id, str(exc))
+
+    return RedirectResponse(
+        url=f"/admin/big-boards/{board_id}?success=entry_added", status_code=303
+    )
+
+
+@router.post("/{board_id}/entries/{entry_id}/update", response_class=HTMLResponse)
+async def update_board_entry(
+    request: Request,
+    board_id: int,
+    entry_id: int,
+    rank: int = Form(...),
+    tier: str | None = Form(default=None),
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Edit rank/tier on a PENDING board's entry."""
+    redirect, user = await require_dataset_access(
+        request,
+        db,
+        "big_boards",
+        need_edit=True,
+        next_path=f"/admin/big-boards/{board_id}",
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    tier_int = _parse_optional_int(tier)
+    try:
+        async with db.begin():
+            await svc.update_entry(db, entry_id=entry_id, rank=rank, tier=tier_int)
+    except svc.BigBoardError as exc:
+        return _redirect_with_error(board_id, str(exc))
+
+    return RedirectResponse(
+        url=f"/admin/big-boards/{board_id}?success=entry_updated", status_code=303
+    )
+
+
+@router.post("/{board_id}/entries/{entry_id}/delete", response_class=HTMLResponse)
+async def delete_board_entry(
+    request: Request,
+    board_id: int,
+    entry_id: int,
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Remove an entry from a PENDING board."""
+    redirect, user = await require_dataset_access(
+        request,
+        db,
+        "big_boards",
+        need_edit=True,
+        next_path=f"/admin/big-boards/{board_id}",
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    try:
+        async with db.begin():
+            await svc.delete_entry(db, entry_id=entry_id)
+    except svc.BigBoardError as exc:
+        return _redirect_with_error(board_id, str(exc))
+
+    return RedirectResponse(
+        url=f"/admin/big-boards/{board_id}?success=entry_deleted", status_code=303
+    )
+
+
+@router.post("/{board_id}/approve", response_class=HTMLResponse)
+async def approve_big_board(
+    request: Request,
+    board_id: int,
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Approve a PENDING board, locking it for downstream consensus."""
+    redirect, user = await require_dataset_access(
+        request,
+        db,
+        "big_boards",
+        need_edit=True,
+        next_path=f"/admin/big-boards/{board_id}",
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    try:
+        async with db.begin():
+            await svc.approve_board(db, board_id=board_id)
+    except svc.BigBoardError as exc:
+        return _redirect_with_error(board_id, str(exc))
+
+    return RedirectResponse(
+        url=f"/admin/big-boards/{board_id}?success=approved", status_code=303
+    )
+
+
+@router.post("/{board_id}/reject", response_class=HTMLResponse)
+async def reject_big_board(
+    request: Request,
+    board_id: int,
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Reject a PENDING board (kept for audit, not used for consensus)."""
+    redirect, user = await require_dataset_access(
+        request,
+        db,
+        "big_boards",
+        need_edit=True,
+        next_path=f"/admin/big-boards/{board_id}",
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    try:
+        async with db.begin():
+            await svc.reject_board(db, board_id=board_id)
+    except svc.BigBoardError as exc:
+        return _redirect_with_error(board_id, str(exc))
+
+    return RedirectResponse(
+        url=f"/admin/big-boards/{board_id}?success=rejected", status_code=303
+    )
+
+
+@router.post("/{board_id}/delete", response_class=HTMLResponse)
+async def delete_big_board(
+    request: Request,
+    board_id: int,
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Hard-delete a PENDING board (for typos; use reject for audit trail)."""
+    redirect, user = await require_dataset_access(
+        request,
+        db,
+        "big_boards",
+        need_edit=True,
+        next_path=f"/admin/big-boards/{board_id}",
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    try:
+        async with db.begin():
+            await svc.delete_board(db, board_id=board_id)
+    except svc.BigBoardError as exc:
+        return _redirect_with_error(board_id, str(exc))
+
+    return RedirectResponse(url="/admin/big-boards?success=deleted", status_code=303)
+
+
+def _parse_optional_int(raw: str | None) -> int | None:
+    if raw is None:
+        return None
+    cleaned = raw.strip()
+    if not cleaned:
+        return None
+    try:
+        return int(cleaned)
+    except ValueError:
+        return None
+
+
+def _redirect_with_error(board_id: int, message: str) -> Response:
+    from urllib.parse import quote
+
+    return RedirectResponse(
+        url=f"/admin/big-boards/{board_id}?error={quote(message)}",
+        status_code=303,
+    )
+
+
+async def _render_new_with_error(
+    request: Request,
+    db: AsyncSession,
+    user: object,
+    message: str,
+) -> Response:
+    sources = (
+        (
+            await db.execute(
+                select(NewsSource)
+                .where(NewsSource.is_active)  # type: ignore[arg-type]
+                .order_by(NewsSource.display_name)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return request.app.state.templates.TemplateResponse(
+        "admin/big-boards/new.html",
+        await base_context_with_permissions(
+            request,
+            db,
+            user,  # type: ignore[arg-type]
+            sources=sources,
+            default_draft_year=datetime.utcnow().year + 1,
+            error=message,
+        ),
+    )

--- a/app/schemas/big_boards.py
+++ b/app/schemas/big_boards.py
@@ -4,7 +4,14 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import Column, Enum as SAEnum, Index, UniqueConstraint
+from sqlalchemy import (
+    Column,
+    Enum as SAEnum,
+    ForeignKey,
+    Index,
+    Integer,
+    UniqueConstraint,
+)
 from sqlmodel import Field, SQLModel
 
 
@@ -73,7 +80,14 @@ class BigBoardEntry(SQLModel, table=True):  # type: ignore[call-arg]
     )
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    board_id: int = Field(foreign_key="big_boards.id", index=True)
+    board_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("big_boards.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        )
+    )
     player_id: int = Field(foreign_key="players_master.id")
     rank: int = Field(description="Analyst's talent-ranking position (1-based).")
     tier: Optional[int] = Field(

--- a/app/services/big_board_service.py
+++ b/app/services/big_board_service.py
@@ -1,0 +1,284 @@
+"""Service layer for big board CRUD and approval lifecycle.
+
+Boards move through PENDING -> APPROVED or PENDING -> REJECTED. Only PENDING
+boards may be edited or deleted; APPROVED and REJECTED rows are immutable
+so they preserve a faithful record of the analyst's rankings (and the
+admin's review decision) for downstream consensus computation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.big_boards import BigBoard, BigBoardEntry, BoardStatus
+
+
+class BigBoardError(Exception):
+    """Business-rule violation raised by the big board service."""
+
+
+class BoardNotFoundError(BigBoardError):
+    """Raised when a board id does not resolve to a row."""
+
+
+class EntryNotFoundError(BigBoardError):
+    """Raised when an entry id does not resolve to a row on the given board."""
+
+
+class BoardNotEditableError(BigBoardError):
+    """Raised when a mutation targets a board that is no longer PENDING."""
+
+
+class DuplicateRankError(BigBoardError):
+    """Raised when a board already contains the requested rank."""
+
+
+class DuplicatePlayerError(BigBoardError):
+    """Raised when a board already contains the requested player."""
+
+
+@dataclass(frozen=True)
+class EntryInput:
+    """One ranked player passed in during board creation or row addition."""
+
+    player_id: int
+    rank: int
+    tier: Optional[int] = None
+
+
+async def create_board(
+    db: AsyncSession,
+    *,
+    news_source_id: int,
+    draft_year: int,
+    published_at: datetime,
+    entries: Sequence[EntryInput],
+    news_item_id: Optional[int] = None,
+) -> BigBoard:
+    """Create a PENDING big board with its initial entries.
+
+    Args:
+        db: Async session; caller owns commit.
+        news_source_id: FK to the analyst/outlet that published this board.
+        draft_year: Draft year the board ranks prospects for.
+        published_at: When the analyst published the board.
+        entries: Initial set of ranked players. May be empty if the admin
+            wants to create the shell first and add rows afterward.
+        news_item_id: Optional FK linking to the source article.
+
+    Returns:
+        The persisted BigBoard (with ``id``, ``status`` defaulted to PENDING).
+
+    Raises:
+        DuplicateRankError / DuplicatePlayerError: If ``entries`` violates
+            the per-board uniqueness constraints.
+    """
+    board = BigBoard(
+        news_source_id=news_source_id,
+        news_item_id=news_item_id,
+        draft_year=draft_year,
+        published_at=published_at,
+        board_size=len(entries),
+        status=BoardStatus.PENDING,
+    )
+    db.add(board)
+    await db.flush()
+    assert board.id is not None  # populated by flush
+
+    for entry in entries:
+        db.add(
+            BigBoardEntry(
+                board_id=board.id,
+                player_id=entry.player_id,
+                rank=entry.rank,
+                tier=entry.tier,
+            )
+        )
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        _translate_entry_integrity_error(exc)
+
+    return board
+
+
+async def get_board(db: AsyncSession, board_id: int) -> BigBoard:
+    """Return the board or raise ``BoardNotFoundError``."""
+    board = await db.get(BigBoard, board_id)
+    if board is None:
+        raise BoardNotFoundError(f"No big board with id={board_id}")
+    return board
+
+
+async def get_board_with_entries(
+    db: AsyncSession, board_id: int
+) -> tuple[BigBoard, list[BigBoardEntry]]:
+    """Return ``(board, entries)`` ordered by rank ascending."""
+    board = await get_board(db, board_id)
+    result = await db.execute(
+        select(BigBoardEntry)  # type: ignore[call-overload]
+        .where(BigBoardEntry.board_id == board_id)  # type: ignore[arg-type]
+        .order_by(BigBoardEntry.rank)  # type: ignore[arg-type]
+    )
+    return board, list(result.scalars().all())
+
+
+async def list_boards(
+    db: AsyncSession,
+    *,
+    status: Optional[BoardStatus] = None,
+    news_source_id: Optional[int] = None,
+    draft_year: Optional[int] = None,
+) -> list[BigBoard]:
+    """List boards filtered by any combination of status, source, year.
+
+    Results ordered by ``published_at`` desc so the most recent boards
+    appear first.
+    """
+    stmt = select(BigBoard)  # type: ignore[call-overload]
+    if status is not None:
+        stmt = stmt.where(BigBoard.status == status)  # type: ignore[arg-type]
+    if news_source_id is not None:
+        stmt = stmt.where(BigBoard.news_source_id == news_source_id)  # type: ignore[arg-type]
+    if draft_year is not None:
+        stmt = stmt.where(BigBoard.draft_year == draft_year)  # type: ignore[arg-type]
+    stmt = stmt.order_by(BigBoard.published_at.desc())  # type: ignore[attr-defined]
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def add_entry(
+    db: AsyncSession,
+    *,
+    board_id: int,
+    player_id: int,
+    rank: int,
+    tier: Optional[int] = None,
+) -> BigBoardEntry:
+    """Append an entry to a PENDING board and bump ``board_size``."""
+    board = await get_board(db, board_id)
+    _require_pending(board)
+
+    entry = BigBoardEntry(board_id=board_id, player_id=player_id, rank=rank, tier=tier)
+    db.add(entry)
+    board.board_size = board.board_size + 1
+    board.updated_at = datetime.utcnow()
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        _translate_entry_integrity_error(exc)
+    return entry
+
+
+async def update_entry(
+    db: AsyncSession,
+    *,
+    entry_id: int,
+    player_id: Optional[int] = None,
+    rank: Optional[int] = None,
+    tier: Optional[int] = None,
+) -> BigBoardEntry:
+    """Patch a single entry on a PENDING board.
+
+    Pass ``None`` to leave a field unchanged. ``tier`` is set verbatim,
+    including to ``None`` if explicitly cleared via ``update_entry(...,
+    tier=None)`` — callers that mean "don't touch tier" should omit it.
+    """
+    entry = await db.get(BigBoardEntry, entry_id)
+    if entry is None:
+        raise EntryNotFoundError(f"No big board entry with id={entry_id}")
+
+    board = await get_board(db, entry.board_id)
+    _require_pending(board)
+
+    if player_id is not None:
+        entry.player_id = player_id
+    if rank is not None:
+        entry.rank = rank
+    if tier is not None:
+        entry.tier = tier
+    board.updated_at = datetime.utcnow()
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        _translate_entry_integrity_error(exc)
+    return entry
+
+
+async def delete_entry(db: AsyncSession, *, entry_id: int) -> None:
+    """Remove an entry from a PENDING board and decrement ``board_size``."""
+    entry = await db.get(BigBoardEntry, entry_id)
+    if entry is None:
+        raise EntryNotFoundError(f"No big board entry with id={entry_id}")
+
+    board = await get_board(db, entry.board_id)
+    _require_pending(board)
+
+    await db.delete(entry)
+    board.board_size = max(0, board.board_size - 1)
+    board.updated_at = datetime.utcnow()
+    await db.flush()
+
+
+async def delete_board(db: AsyncSession, *, board_id: int) -> None:
+    """Hard-delete a PENDING board (entries cascade).
+
+    Reserved for typos / accidental boards. Use ``reject_board`` instead
+    when the audit trail should record that a real submission was
+    refused.
+    """
+    board = await get_board(db, board_id)
+    _require_pending(board)
+    await db.delete(board)
+    await db.flush()
+
+
+async def approve_board(db: AsyncSession, *, board_id: int) -> BigBoard:
+    """Transition a PENDING board to APPROVED and stamp ``approved_at``."""
+    board = await get_board(db, board_id)
+    _require_pending(board)
+    now = datetime.utcnow()
+    board.status = BoardStatus.APPROVED
+    board.approved_at = now
+    board.updated_at = now
+    await db.flush()
+    return board
+
+
+async def reject_board(db: AsyncSession, *, board_id: int) -> BigBoard:
+    """Transition a PENDING board to REJECTED.
+
+    The row is preserved so the audit trail records that the analyst's
+    submission was reviewed and refused. ``approved_at`` stays ``None``.
+    """
+    board = await get_board(db, board_id)
+    _require_pending(board)
+    board.status = BoardStatus.REJECTED
+    board.updated_at = datetime.utcnow()
+    await db.flush()
+    return board
+
+
+def _require_pending(board: BigBoard) -> None:
+    if board.status is not BoardStatus.PENDING:
+        raise BoardNotEditableError(
+            f"Board {board.id} is {board.status.value}; only PENDING boards may be modified."
+        )
+
+
+def _translate_entry_integrity_error(exc: IntegrityError) -> None:
+    """Map DB unique-constraint violations to typed service errors."""
+    message = str(exc.orig) if exc.orig else str(exc)
+    if "uq_big_board_entries_board_rank" in message:
+        raise DuplicateRankError(
+            "This board already has an entry at that rank."
+        ) from exc
+    if "uq_big_board_entries_board_player" in message:
+        raise DuplicatePlayerError("This board already includes that player.") from exc
+    raise BigBoardError(message) from exc

--- a/app/static/big-boards-detail.js
+++ b/app/static/big-boards-detail.js
@@ -1,0 +1,92 @@
+// Player autocomplete for the big-board add-entry form.
+// Calls the existing /players/search endpoint and writes the selected
+// player's id into the hidden #player_id input that the form posts.
+
+(function () {
+  function init() {
+    const input = document.getElementById("player-search");
+    const list = document.getElementById("player-autocomplete");
+    const hidden = document.getElementById("player_id");
+    if (!input || !list || !hidden) return;
+
+    let abortCtrl = null;
+    let debounceTimer = null;
+
+    function hide() {
+      list.hidden = true;
+      list.replaceChildren();
+    }
+
+    function show(results) {
+      list.replaceChildren();
+      if (!results.length) {
+        hide();
+        return;
+      }
+      for (const r of results) {
+        const li = document.createElement("li");
+        li.className = "admin-autocomplete__item";
+        const name = document.createElement("strong");
+        name.textContent = r.display_name;
+        li.appendChild(name);
+        if (r.school) {
+          const school = document.createElement("span");
+          school.className = "admin-text--small";
+          school.style.marginLeft = "0.5rem";
+          school.textContent = r.school;
+          li.appendChild(school);
+        }
+        li.addEventListener("mousedown", function (ev) {
+          ev.preventDefault();
+          input.value = r.display_name;
+          hidden.value = r.id;
+          hide();
+        });
+        list.appendChild(li);
+      }
+      list.hidden = false;
+    }
+
+    async function query(q) {
+      if (abortCtrl) abortCtrl.abort();
+      abortCtrl = new AbortController();
+      try {
+        const resp = await fetch(
+          "/players/search?q=" + encodeURIComponent(q),
+          { signal: abortCtrl.signal }
+        );
+        if (!resp.ok) return;
+        const results = await resp.json();
+        show(results);
+      } catch (err) {
+        if (err && err.name !== "AbortError") {
+          // Network or parse error — silently hide rather than block the form.
+          hide();
+        }
+      }
+    }
+
+    input.addEventListener("input", function () {
+      // Any keystroke invalidates a previously-selected id.
+      hidden.value = "";
+      const q = input.value.trim();
+      clearTimeout(debounceTimer);
+      if (q.length < 2) {
+        hide();
+        return;
+      }
+      debounceTimer = setTimeout(() => query(q), 150);
+    });
+
+    input.addEventListener("blur", function () {
+      // Hide after the click handler has had a chance to fire.
+      setTimeout(hide, 120);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/app/static/css/admin.css
+++ b/app/static/css/admin.css
@@ -1212,6 +1212,34 @@
   margin: 0 0 1rem;
 }
 
+/* Autocomplete dropdown used by the big-board entry form. */
+.admin-autocomplete {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 30;
+  max-height: 14rem;
+  overflow-y: auto;
+  margin: 0.125rem 0 0;
+  padding: 0.25rem 0;
+  list-style: none;
+  background: var(--color-white, #fff);
+  border: 1px solid var(--color-slate-300, #cbd5e1);
+  border-radius: 0.375rem;
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.08);
+}
+
+.admin-autocomplete__item {
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.admin-autocomplete__item:hover {
+  background: var(--color-slate-100, #f1f5f9);
+}
+
 @media (max-width: 768px) {
   .admin-combine-header {
     flex-direction: column;

--- a/app/templates/admin/base.html
+++ b/app/templates/admin/base.html
@@ -37,7 +37,8 @@
         {% set can_view_youtube_channels = is_admin or (permissions and permissions.youtube_channels.can_view) %}
         {% set can_view_youtube_videos = is_admin or (permissions and permissions.youtube_videos.can_view) %}
         {% set can_view_youtube_ingestion = is_admin or (permissions and permissions.youtube_ingestion.can_view) %}
-        {% set show_data_section = can_view_players or can_view_news_sources or can_view_news_ingestion or can_view_images or can_view_podcasts or can_view_podcast_ingestion or can_view_youtube_channels or can_view_youtube_videos or can_view_youtube_ingestion %}
+        {% set can_view_big_boards = is_admin or (permissions and permissions.big_boards.can_view) %}
+        {% set show_data_section = can_view_players or can_view_news_sources or can_view_news_ingestion or can_view_images or can_view_podcasts or can_view_podcast_ingestion or can_view_youtube_channels or can_view_youtube_videos or can_view_youtube_ingestion or can_view_big_boards %}
         {% if show_data_section %}
         <li class="admin-sidebar__nav-divider"></li>
         <li class="admin-sidebar__nav-section">Data Management</li>
@@ -94,6 +95,13 @@
         <li class="admin-sidebar__nav-item">
           <a href="/admin/youtube-videos" class="admin-sidebar__nav-link{% if active_nav == 'youtube-videos' %} admin-sidebar__nav-link--active{% endif %}">
             Film Room Videos
+          </a>
+        </li>
+        {% endif %}
+        {% if can_view_big_boards %}
+        <li class="admin-sidebar__nav-item">
+          <a href="/admin/big-boards" class="admin-sidebar__nav-link{% if active_nav == 'big-boards' %} admin-sidebar__nav-link--active{% endif %}">
+            Big Boards
           </a>
         </li>
         {% endif %}

--- a/app/templates/admin/big-boards/detail.html
+++ b/app/templates/admin/big-boards/detail.html
@@ -1,0 +1,140 @@
+{% extends "admin/base.html" %}
+
+{% set page_title = "Big Board" %}
+{% set active_nav = "big-boards" %}
+
+{% block admin_content %}
+<header class="admin-main__header">
+  <h1 class="admin-main__title">
+    {{ source.display_name if source else board.news_source_id }}
+    <span class="admin-text--muted">&middot; {{ board.draft_year }}</span>
+  </h1>
+  <p class="admin-main__subtitle">
+    Published {{ board.published_at.strftime('%Y-%m-%d') }} &middot;
+    Status:
+    {% if board.status.value == 'APPROVED' %}
+    <span class="admin-badge admin-badge--active">{{ board.status.value }}</span>
+    {% elif board.status.value == 'REJECTED' %}
+    <span class="admin-badge admin-badge--inactive">{{ board.status.value }}</span>
+    {% else %}
+    <span class="admin-badge">{{ board.status.value }}</span>
+    {% endif %}
+    &middot; {{ board.board_size }} player{{ '' if board.board_size == 1 else 's' }}
+  </p>
+</header>
+
+<div class="admin-card">
+  <div class="admin-card__header">
+    <h2 class="admin-card__title">Entries</h2>
+    {% if is_pending %}
+    <div style="display: flex; gap: 0.5rem;">
+      <form method="post" action="/admin/big-boards/{{ board.id }}/approve" class="admin-form--inline">
+        <button type="submit" class="admin-btn admin-btn--primary admin-btn--small">Approve</button>
+      </form>
+      <form method="post" action="/admin/big-boards/{{ board.id }}/reject" class="admin-form--inline"
+            onsubmit="return confirm('Reject this board? It will be locked but kept for audit.');">
+        <button type="submit" class="admin-btn admin-btn--secondary admin-btn--small">Reject</button>
+      </form>
+      <form method="post" action="/admin/big-boards/{{ board.id }}/delete" class="admin-form--inline"
+            onsubmit="return confirm('Permanently delete this board and all entries? No audit record will be kept.');">
+        <button type="submit" class="admin-btn admin-btn--small">Delete</button>
+      </form>
+    </div>
+    {% endif %}
+  </div>
+
+  {% if entries %}
+  <table class="admin-table">
+    <thead>
+      <tr>
+        <th style="width: 4rem;">Rank</th>
+        <th>Player</th>
+        <th>School</th>
+        <th style="width: 5rem;">Tier</th>
+        {% if is_pending %}
+        <th style="width: 14rem;">Actions</th>
+        {% endif %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for entry in entries %}
+      {% set player = players_by_id.get(entry.player_id) %}
+      <tr>
+        <td><strong>{{ entry.rank }}</strong></td>
+        <td>{{ player.display_name if player else '(unknown player)' }}</td>
+        <td>{{ player.school if player else '' }}</td>
+        <td>{{ entry.tier if entry.tier is not none else '—' }}</td>
+        {% if is_pending %}
+        <td>
+          <form method="post"
+                action="/admin/big-boards/{{ board.id }}/entries/{{ entry.id }}/update"
+                class="admin-form--inline"
+                style="display: flex; gap: 0.25rem;">
+            <input class="admin-form__input" type="number" name="rank" value="{{ entry.rank }}"
+                   min="1" required style="width: 4.5rem;" />
+            <input class="admin-form__input" type="number" name="tier"
+                   value="{{ entry.tier if entry.tier is not none else '' }}"
+                   placeholder="tier" style="width: 4.5rem;" />
+            <button type="submit" class="admin-btn admin-btn--small">Save</button>
+          </form>
+          <form method="post"
+                action="/admin/big-boards/{{ board.id }}/entries/{{ entry.id }}/delete"
+                class="admin-form--inline"
+                onsubmit="return confirm('Delete this entry?');">
+            <button type="submit" class="admin-btn admin-btn--small">Remove</button>
+          </form>
+        </td>
+        {% endif %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="admin-text--muted">No entries yet.</p>
+  {% endif %}
+
+  {% if is_pending %}
+  <div class="admin-card__header" style="margin-top: 1.5rem;">
+    <h3 class="admin-card__title">Add Entry</h3>
+  </div>
+  <form
+    id="big-board-add-entry"
+    class="admin-form"
+    method="post"
+    action="/admin/big-boards/{{ board.id }}/entries"
+    style="display: grid; grid-template-columns: 5rem 1fr 5rem auto; gap: 0.75rem; align-items: end;"
+  >
+    <div class="admin-form__field" style="margin: 0;">
+      <label class="admin-form__label" for="rank">Rank</label>
+      <input class="admin-form__input" id="rank" name="rank" type="number" min="1" required />
+    </div>
+    <div class="admin-form__field" style="margin: 0; position: relative;">
+      <label class="admin-form__label" for="player-search">Player</label>
+      <input
+        class="admin-form__input"
+        id="player-search"
+        type="text"
+        placeholder="Type a player name..."
+        autocomplete="off"
+        required
+      />
+      <input type="hidden" id="player_id" name="player_id" required />
+      <ul id="player-autocomplete" class="admin-autocomplete" hidden></ul>
+    </div>
+    <div class="admin-form__field" style="margin: 0;">
+      <label class="admin-form__label" for="tier">Tier</label>
+      <input class="admin-form__input" id="tier" name="tier" type="number" placeholder="optional" />
+    </div>
+    <div class="admin-form__field" style="margin: 0;">
+      <button type="submit" class="admin-btn admin-btn--primary">Add</button>
+    </div>
+  </form>
+  {% endif %}
+</div>
+{% endblock %}
+
+{% block admin_js %}
+{% if is_pending %}
+<script src="/static/big-boards-detail.js"></script>
+{% endif %}
+{% endblock %}

--- a/app/templates/admin/big-boards/index.html
+++ b/app/templates/admin/big-boards/index.html
@@ -1,0 +1,82 @@
+{% extends "admin/base.html" %}
+
+{% set page_title = "Big Boards" %}
+{% set active_nav = "big-boards" %}
+
+{% block admin_content %}
+<header class="admin-main__header">
+  <h1 class="admin-main__title">Big Boards</h1>
+  <p class="admin-main__subtitle">
+    Per-source talent rankings. Approved boards feed the consensus.
+  </p>
+</header>
+
+<div class="admin-card">
+  <div class="admin-card__header">
+    <h2 class="admin-card__title">All Boards</h2>
+    <div style="display: flex; gap: 0.5rem; align-items: center;">
+      <form method="get" action="/admin/big-boards" class="admin-form--inline">
+        <select class="admin-form__select" name="status" onchange="this.form.submit()">
+          <option value="">All statuses</option>
+          {% for s in statuses %}
+          <option value="{{ s }}" {% if status_filter == s %}selected{% endif %}>{{ s }}</option>
+          {% endfor %}
+        </select>
+      </form>
+      <a href="/admin/big-boards/new" class="admin-btn admin-btn--primary admin-btn--small">
+        New Board
+      </a>
+    </div>
+  </div>
+
+  {% if boards %}
+  <table class="admin-table">
+    <thead>
+      <tr>
+        <th>Source</th>
+        <th>Year</th>
+        <th>Published</th>
+        <th>Size</th>
+        <th>Status</th>
+        <th>Approved</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for board in boards %}
+      <tr>
+        <td>
+          {% set src = sources_by_id.get(board.news_source_id) %}
+          <strong>{{ src.display_name if src else board.news_source_id }}</strong>
+        </td>
+        <td>{{ board.draft_year }}</td>
+        <td>{{ board.published_at.strftime('%Y-%m-%d') }}</td>
+        <td>{{ board.board_size }}</td>
+        <td>
+          {% if board.status.value == 'APPROVED' %}
+          <span class="admin-badge admin-badge--active">{{ board.status.value }}</span>
+          {% elif board.status.value == 'REJECTED' %}
+          <span class="admin-badge admin-badge--inactive">{{ board.status.value }}</span>
+          {% else %}
+          <span class="admin-badge">{{ board.status.value }}</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if board.approved_at %}
+          {{ board.approved_at.strftime('%Y-%m-%d') }}
+          {% else %}
+          &mdash;
+          {% endif %}
+        </td>
+        <td>
+          <a href="/admin/big-boards/{{ board.id }}" class="admin-btn admin-btn--small">View</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="admin-text--muted">No big boards yet. Create one to get started.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/app/templates/admin/big-boards/new.html
+++ b/app/templates/admin/big-boards/new.html
@@ -1,0 +1,59 @@
+{% extends "admin/base.html" %}
+
+{% set page_title = "New Big Board" %}
+{% set active_nav = "big-boards" %}
+
+{% block admin_content %}
+<header class="admin-main__header">
+  <h1 class="admin-main__title">New Big Board</h1>
+  <p class="admin-main__subtitle">
+    Create the board shell first; you'll add the ranked players on the next screen.
+  </p>
+</header>
+
+<div class="admin-card admin-card--medium">
+  <form class="admin-form" method="post" action="/admin/big-boards">
+    <div class="admin-form__field">
+      <label class="admin-form__label" for="news_source_id">Source</label>
+      <select class="admin-form__select" id="news_source_id" name="news_source_id" required>
+        <option value="">-- Pick a source --</option>
+        {% for source in sources %}
+        <option value="{{ source.id }}">{{ source.display_name }}</option>
+        {% endfor %}
+      </select>
+      <span class="admin-form__help">Active news sources only.</span>
+    </div>
+
+    <div class="admin-form__field">
+      <label class="admin-form__label" for="draft_year">Draft Year</label>
+      <input
+        class="admin-form__input"
+        id="draft_year"
+        name="draft_year"
+        type="number"
+        min="2024"
+        max="2035"
+        value="{{ default_draft_year }}"
+        required
+      />
+    </div>
+
+    <div class="admin-form__field">
+      <label class="admin-form__label" for="published_at">Published</label>
+      <input
+        class="admin-form__input"
+        id="published_at"
+        name="published_at"
+        type="date"
+        required
+      />
+      <span class="admin-form__help">When the analyst published the board.</span>
+    </div>
+
+    <div class="admin-form__actions">
+      <button type="submit" class="admin-btn admin-btn--primary">Create Board</button>
+      <a href="/admin/big-boards" class="admin-btn admin-btn--secondary">Cancel</a>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/tests/integration/test_admin_big_boards.py
+++ b/tests/integration/test_admin_big_boards.py
@@ -1,0 +1,340 @@
+"""HTTP-level integration tests for the admin big-boards routes."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.big_boards import BigBoard, BigBoardEntry, BoardStatus
+from app.schemas.news_sources import FeedType, NewsSource
+from app.schemas.players_master import PlayerMaster
+from tests.integration.auth_helpers import create_auth_user, login_staff
+from tests.integration.conftest import make_player
+
+
+ADMIN_EMAIL = "bigboard-admin@example.com"
+ADMIN_PASSWORD = "admin-password-123"
+
+
+@pytest_asyncio.fixture
+async def admin_logged_in(
+    app_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Create an admin user and log into ``app_client`` so the session cookie is set."""
+    await create_auth_user(
+        db_session,
+        email=ADMIN_EMAIL,
+        role="admin",
+        password=ADMIN_PASSWORD,
+    )
+    await login_staff(app_client, email=ADMIN_EMAIL, password=ADMIN_PASSWORD)
+
+
+@pytest_asyncio.fixture
+async def big_board_source(db_session: AsyncSession) -> NewsSource:
+    """A unique active news source available to the new-board form."""
+    source = NewsSource(
+        name="big-board-source",
+        display_name="Big Board Test Source",
+        feed_type=FeedType.RSS,
+        feed_url="https://example.com/bb-test-feed.xml",
+        is_active=True,
+        fetch_interval_minutes=30,
+    )
+    db_session.add(source)
+    await db_session.commit()
+    await db_session.refresh(source)
+    assert source.id is not None
+    return source
+
+
+@pytest_asyncio.fixture
+async def sample_players(db_session: AsyncSession) -> list[PlayerMaster]:
+    rows = [
+        make_player("Cooper", "Flagg", school="Duke"),
+        make_player("Dylan", "Harper", school="Rutgers"),
+        make_player("Ace", "Bailey", school="Rutgers"),
+    ]
+    for p in rows:
+        db_session.add(p)
+    await db_session.commit()
+    for p in rows:
+        await db_session.refresh(p)
+    return rows
+
+
+@pytest.mark.asyncio
+class TestBigBoardAccess:
+    """Access control: unauthenticated users are redirected to login."""
+
+    async def test_list_requires_login(self, app_client: AsyncClient):
+        """GET /admin/big-boards redirects when logged out."""
+        response = await app_client.get(
+            "/admin/big-boards", follow_redirects=False
+        )
+        assert response.status_code in {302, 303}
+        assert "/admin/login" in response.headers.get("location", "")
+
+    async def test_create_requires_login(self, app_client: AsyncClient):
+        """POST /admin/big-boards redirects when logged out."""
+        response = await app_client.post(
+            "/admin/big-boards",
+            data={
+                "news_source_id": "1",
+                "draft_year": "2026",
+                "published_at": "2026-05-01",
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code in {302, 303}
+        assert "/admin/login" in response.headers.get("location", "")
+
+
+@pytest.mark.asyncio
+class TestBigBoardLifecycle:
+    """End-to-end flow: create, add entry, edit entry, approve, immutability."""
+
+    async def test_full_create_approve_flow(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_logged_in: None,
+        big_board_source: NewsSource,
+        sample_players: list[PlayerMaster],
+    ):
+        """Create empty board, add two entries, edit one, approve, confirm DB state."""
+        _ = admin_logged_in
+        assert big_board_source.id is not None
+
+        # 1. Create board
+        create_resp = await app_client.post(
+            "/admin/big-boards",
+            data={
+                "news_source_id": str(big_board_source.id),
+                "draft_year": "2026",
+                "published_at": "2026-05-01",
+            },
+            follow_redirects=False,
+        )
+        assert create_resp.status_code == 303
+        location = create_resp.headers["location"]
+        assert location.startswith("/admin/big-boards/")
+        board_id = int(location.split("/")[-1].split("?")[0])
+
+        board_row = await db_session.get(BigBoard, board_id)
+        assert board_row is not None
+        assert board_row.status is BoardStatus.PENDING
+        assert board_row.board_size == 0
+
+        # 2. Add first entry
+        first_player_id = sample_players[0].id
+        add_resp = await app_client.post(
+            f"/admin/big-boards/{board_id}/entries",
+            data={
+                "player_id": str(first_player_id),
+                "rank": "1",
+                "tier": "1",
+            },
+            follow_redirects=False,
+        )
+        assert add_resp.status_code == 303
+
+        # 3. Add second entry
+        second_player_id = sample_players[1].id
+        add_resp_2 = await app_client.post(
+            f"/admin/big-boards/{board_id}/entries",
+            data={
+                "player_id": str(second_player_id),
+                "rank": "2",
+            },
+            follow_redirects=False,
+        )
+        assert add_resp_2.status_code == 303
+
+        # Verify board_size + entries
+        await db_session.refresh(board_row)
+        assert board_row.board_size == 2
+        entries = (
+            await db_session.execute(
+                select(BigBoardEntry)  # type: ignore[call-overload]
+                .where(BigBoardEntry.board_id == board_id)  # type: ignore[arg-type]
+                .order_by(BigBoardEntry.rank)  # type: ignore[arg-type]
+            )
+        ).scalars().all()
+        assert [(e.player_id, e.rank, e.tier) for e in entries] == [
+            (first_player_id, 1, 1),
+            (second_player_id, 2, None),
+        ]
+
+        # 4. Edit the second entry (set tier=2)
+        edit_resp = await app_client.post(
+            f"/admin/big-boards/{board_id}/entries/{entries[1].id}/update",
+            data={"rank": "2", "tier": "2"},
+            follow_redirects=False,
+        )
+        assert edit_resp.status_code == 303
+        edited_id = entries[1].id
+        edited = await db_session.get(
+            BigBoardEntry, edited_id, populate_existing=True
+        )
+        assert edited is not None
+        assert edited.tier == 2
+
+        # 5. Approve
+        approve_resp = await app_client.post(
+            f"/admin/big-boards/{board_id}/approve", follow_redirects=False
+        )
+        assert approve_resp.status_code == 303
+        await db_session.refresh(board_row)
+        assert board_row.status is BoardStatus.APPROVED
+        assert board_row.approved_at is not None
+
+        # 6. Post-approval edits redirect with an error and do not mutate
+        post_approve_resp = await app_client.post(
+            f"/admin/big-boards/{board_id}/entries",
+            data={
+                "player_id": str(sample_players[2].id),
+                "rank": "3",
+            },
+            follow_redirects=False,
+        )
+        assert post_approve_resp.status_code == 303
+        assert "error=" in post_approve_resp.headers["location"]
+        await db_session.refresh(board_row)
+        assert board_row.board_size == 2
+
+    async def test_reject_flow_preserves_row_for_audit(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_logged_in: None,
+        big_board_source: NewsSource,
+        sample_players: list[PlayerMaster],
+    ):
+        """Rejection locks the board but leaves the row in place."""
+        _ = admin_logged_in
+        assert big_board_source.id is not None
+
+        create_resp = await app_client.post(
+            "/admin/big-boards",
+            data={
+                "news_source_id": str(big_board_source.id),
+                "draft_year": "2026",
+                "published_at": "2026-05-01",
+            },
+            follow_redirects=False,
+        )
+        board_id = int(
+            create_resp.headers["location"].split("/")[-1].split("?")[0]
+        )
+
+        # Add one entry so reject is non-trivial
+        await app_client.post(
+            f"/admin/big-boards/{board_id}/entries",
+            data={
+                "player_id": str(sample_players[0].id),
+                "rank": "1",
+            },
+            follow_redirects=False,
+        )
+
+        reject_resp = await app_client.post(
+            f"/admin/big-boards/{board_id}/reject", follow_redirects=False
+        )
+        assert reject_resp.status_code == 303
+
+        board_row = await db_session.get(BigBoard, board_id)
+        assert board_row is not None
+        assert board_row.status is BoardStatus.REJECTED
+        assert board_row.approved_at is None
+
+        # Approve a rejected board should error
+        approve_again = await app_client.post(
+            f"/admin/big-boards/{board_id}/approve", follow_redirects=False
+        )
+        assert approve_again.status_code == 303
+        assert "error=" in approve_again.headers["location"]
+
+    async def test_delete_pending_board_removes_row(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_logged_in: None,
+        big_board_source: NewsSource,
+    ):
+        """Hard-delete on a PENDING board removes it entirely."""
+        _ = admin_logged_in
+        assert big_board_source.id is not None
+
+        create_resp = await app_client.post(
+            "/admin/big-boards",
+            data={
+                "news_source_id": str(big_board_source.id),
+                "draft_year": "2026",
+                "published_at": "2026-05-01",
+            },
+            follow_redirects=False,
+        )
+        board_id = int(
+            create_resp.headers["location"].split("/")[-1].split("?")[0]
+        )
+
+        del_resp = await app_client.post(
+            f"/admin/big-boards/{board_id}/delete", follow_redirects=False
+        )
+        assert del_resp.status_code == 303
+        assert del_resp.headers["location"].startswith("/admin/big-boards")
+
+        assert await db_session.get(BigBoard, board_id) is None
+
+
+@pytest.mark.asyncio
+class TestBigBoardListing:
+    """List endpoint filters and renders without crashing."""
+
+    async def test_list_renders_with_status_filter(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_logged_in: None,
+        big_board_source: NewsSource,
+        sample_players: list[PlayerMaster],
+    ):
+        """A PENDING board appears on the unfiltered list AND on ?status=PENDING."""
+        _ = admin_logged_in
+        assert big_board_source.id is not None
+
+        # Seed one board directly so we don't depend on the create flow here
+        published = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
+            days=1
+        )
+        board = BigBoard(
+            news_source_id=big_board_source.id,
+            draft_year=2026,
+            published_at=published,
+            board_size=1,
+            status=BoardStatus.PENDING,
+        )
+        db_session.add(board)
+        await db_session.flush()
+        db_session.add(
+            BigBoardEntry(
+                board_id=board.id,
+                player_id=sample_players[0].id,
+                rank=1,
+            )
+        )
+        await db_session.commit()
+
+        all_resp = await app_client.get("/admin/big-boards")
+        assert all_resp.status_code == 200
+        assert "Big Board Test Source" in all_resp.text
+
+        pending_resp = await app_client.get("/admin/big-boards?status=PENDING")
+        assert pending_resp.status_code == 200
+        assert "Big Board Test Source" in pending_resp.text

--- a/tests/integration/test_big_board_service.py
+++ b/tests/integration/test_big_board_service.py
@@ -1,0 +1,336 @@
+"""Integration tests for the big board service layer.
+
+These exercise the service against a live test DB session so the unique
+constraints and status guards behave the way the routes will rely on.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.big_boards import BigBoard, BigBoardEntry, BoardStatus
+from app.schemas.news_sources import NewsSource
+from app.schemas.players_master import PlayerMaster
+from app.services import big_board_service as svc
+from tests.integration.conftest import make_player
+
+
+@pytest_asyncio.fixture()
+async def players(db_session: AsyncSession) -> list[PlayerMaster]:
+    """Three persisted players we can rank on a board."""
+    rows = [
+        make_player("Cooper", "Flagg", school="Duke"),
+        make_player("Dylan", "Harper", school="Rutgers"),
+        make_player("Ace", "Bailey", school="Rutgers"),
+    ]
+    for p in rows:
+        db_session.add(p)
+    await db_session.flush()
+    return rows
+
+
+def _published_at() -> datetime:
+    """Naive UTC timestamp suitable for the schema's timestamp column."""
+    return datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=1)
+
+
+@pytest.mark.asyncio
+async def test_create_board_persists_pending_board_and_entries(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """create_board writes PENDING board + ordered entries; board_size matches."""
+    assert news_source.id is not None
+    board = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at(),
+        entries=[
+            svc.EntryInput(player_id=players[0].id, rank=1, tier=1),  # type: ignore[arg-type]
+            svc.EntryInput(player_id=players[1].id, rank=2, tier=1),  # type: ignore[arg-type]
+            svc.EntryInput(player_id=players[2].id, rank=3, tier=2),  # type: ignore[arg-type]
+        ],
+    )
+    await db_session.commit()
+
+    assert board.status is BoardStatus.PENDING
+    assert board.approved_at is None
+    assert board.board_size == 3
+
+    _, entries = await svc.get_board_with_entries(db_session, board.id)  # type: ignore[arg-type]
+    assert [(e.rank, e.player_id, e.tier) for e in entries] == [
+        (1, players[0].id, 1),
+        (2, players[1].id, 1),
+        (3, players[2].id, 2),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_board_rejects_duplicate_rank(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """Two entries at rank 1 on the same board raises DuplicateRankError."""
+    assert news_source.id is not None
+    with pytest.raises(svc.DuplicateRankError):
+        await svc.create_board(
+            db_session,
+            news_source_id=news_source.id,
+            draft_year=2026,
+            published_at=_published_at(),
+            entries=[
+                svc.EntryInput(player_id=players[0].id, rank=1),  # type: ignore[arg-type]
+                svc.EntryInput(player_id=players[1].id, rank=1),  # type: ignore[arg-type]
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_board_rejects_duplicate_player(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """Same player twice on the same board raises DuplicatePlayerError."""
+    assert news_source.id is not None
+    with pytest.raises(svc.DuplicatePlayerError):
+        await svc.create_board(
+            db_session,
+            news_source_id=news_source.id,
+            draft_year=2026,
+            published_at=_published_at(),
+            entries=[
+                svc.EntryInput(player_id=players[0].id, rank=1),  # type: ignore[arg-type]
+                svc.EntryInput(player_id=players[0].id, rank=2),  # type: ignore[arg-type]
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_add_update_delete_entry_on_pending_board(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """A PENDING board accepts add, update, and delete on its entries."""
+    assert news_source.id is not None
+    board = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at(),
+        entries=[svc.EntryInput(player_id=players[0].id, rank=1)],  # type: ignore[arg-type]
+    )
+    await db_session.commit()
+
+    added = await svc.add_entry(
+        db_session,
+        board_id=board.id,  # type: ignore[arg-type]
+        player_id=players[1].id,  # type: ignore[arg-type]
+        rank=2,
+    )
+    await db_session.commit()
+    assert board.board_size == 2
+
+    await svc.update_entry(
+        db_session, entry_id=added.id, rank=5, tier=3  # type: ignore[arg-type]
+    )
+    await db_session.commit()
+    refreshed = await db_session.get(BigBoardEntry, added.id)
+    assert refreshed is not None
+    assert refreshed.rank == 5
+    assert refreshed.tier == 3
+
+    await svc.delete_entry(db_session, entry_id=added.id)  # type: ignore[arg-type]
+    await db_session.commit()
+    assert await db_session.get(BigBoardEntry, added.id) is None
+    refreshed_board = await db_session.get(BigBoard, board.id)
+    assert refreshed_board is not None
+    assert refreshed_board.board_size == 1
+
+
+@pytest.mark.asyncio
+async def test_approved_board_is_immutable(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """After approval, every mutating service call raises BoardNotEditableError."""
+    assert news_source.id is not None
+    board = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at(),
+        entries=[svc.EntryInput(player_id=players[0].id, rank=1)],  # type: ignore[arg-type]
+    )
+    await db_session.commit()
+
+    approved = await svc.approve_board(db_session, board_id=board.id)  # type: ignore[arg-type]
+    await db_session.commit()
+    assert approved.status is BoardStatus.APPROVED
+    assert approved.approved_at is not None
+
+    entry_id = (
+        await db_session.execute(
+            select(BigBoardEntry.id).where(  # type: ignore[call-overload]
+                BigBoardEntry.board_id == board.id  # type: ignore[arg-type]
+            )
+        )
+    ).scalar_one()
+
+    with pytest.raises(svc.BoardNotEditableError):
+        await svc.add_entry(
+            db_session,
+            board_id=board.id,  # type: ignore[arg-type]
+            player_id=players[1].id,  # type: ignore[arg-type]
+            rank=2,
+        )
+    with pytest.raises(svc.BoardNotEditableError):
+        await svc.update_entry(db_session, entry_id=entry_id, rank=99)
+    with pytest.raises(svc.BoardNotEditableError):
+        await svc.delete_entry(db_session, entry_id=entry_id)
+    with pytest.raises(svc.BoardNotEditableError):
+        await svc.delete_board(db_session, board_id=board.id)  # type: ignore[arg-type]
+    with pytest.raises(svc.BoardNotEditableError):
+        await svc.approve_board(db_session, board_id=board.id)  # type: ignore[arg-type]
+    with pytest.raises(svc.BoardNotEditableError):
+        await svc.reject_board(db_session, board_id=board.id)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_rejected_board_is_immutable(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """Rejected boards are preserved as an audit record and locked from edits."""
+    assert news_source.id is not None
+    board = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at(),
+        entries=[svc.EntryInput(player_id=players[0].id, rank=1)],  # type: ignore[arg-type]
+    )
+    await db_session.commit()
+
+    rejected = await svc.reject_board(db_session, board_id=board.id)  # type: ignore[arg-type]
+    await db_session.commit()
+    assert rejected.status is BoardStatus.REJECTED
+    assert rejected.approved_at is None
+
+    with pytest.raises(svc.BoardNotEditableError):
+        await svc.approve_board(db_session, board_id=board.id)  # type: ignore[arg-type]
+    with pytest.raises(svc.BoardNotEditableError):
+        await svc.delete_board(db_session, board_id=board.id)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_delete_pending_board_cascades_entries(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """Hard-deleting a PENDING board removes its entries via the FK cascade."""
+    assert news_source.id is not None
+    board = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at(),
+        entries=[
+            svc.EntryInput(player_id=players[0].id, rank=1),  # type: ignore[arg-type]
+            svc.EntryInput(player_id=players[1].id, rank=2),  # type: ignore[arg-type]
+        ],
+    )
+    await db_session.commit()
+    board_id = board.id
+
+    await svc.delete_board(db_session, board_id=board_id)  # type: ignore[arg-type]
+    await db_session.commit()
+
+    assert await db_session.get(BigBoard, board_id) is None
+    remaining = (
+        await db_session.execute(
+            select(BigBoardEntry).where(  # type: ignore[call-overload]
+                BigBoardEntry.board_id == board_id  # type: ignore[arg-type]
+            )
+        )
+    ).scalars().all()
+    assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_list_boards_filters_by_status_source_and_year(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """list_boards filters compose; results sorted by published_at desc."""
+    assert news_source.id is not None
+    other_source = NewsSource(
+        name="Other Source",
+        display_name="Other Source",
+        feed_url="https://example.com/other-feed",
+    )
+    db_session.add(other_source)
+    await db_session.flush()
+    assert other_source.id is not None
+
+    # Two PENDING from news_source, one APPROVED from news_source (different
+    # year), one PENDING from other_source.
+    pending_now = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=datetime.utcnow(),
+        entries=[svc.EntryInput(player_id=players[0].id, rank=1)],  # type: ignore[arg-type]
+    )
+    pending_older = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=datetime.utcnow() - timedelta(days=2),
+        entries=[svc.EntryInput(player_id=players[1].id, rank=1)],  # type: ignore[arg-type]
+    )
+    approved_other_year = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2025,
+        published_at=datetime.utcnow() - timedelta(days=10),
+        entries=[svc.EntryInput(player_id=players[2].id, rank=1)],  # type: ignore[arg-type]
+    )
+    await svc.approve_board(db_session, board_id=approved_other_year.id)  # type: ignore[arg-type]
+    other_source_board = await svc.create_board(
+        db_session,
+        news_source_id=other_source.id,
+        draft_year=2026,
+        published_at=datetime.utcnow() - timedelta(days=1),
+        entries=[],
+    )
+    await db_session.commit()
+
+    pending_2026 = await svc.list_boards(
+        db_session, status=BoardStatus.PENDING, draft_year=2026
+    )
+    assert [b.id for b in pending_2026] == [
+        pending_now.id,
+        other_source_board.id,
+        pending_older.id,
+    ]
+
+    only_news_source = await svc.list_boards(
+        db_session, news_source_id=news_source.id
+    )
+    assert {b.id for b in only_news_source} == {
+        pending_now.id,
+        pending_older.id,
+        approved_other_year.id,
+    }


### PR DESCRIPTION
## Summary

Slice 2 of the consensus mock / big board project (Phase 1 manual-entry track from `docs/consensus_mock_plan.md`). Builds on the schema landed in #192 by giving admins an end-to-end UI to enter, review, and lock in big boards from each source.

Workflow:
1. Admin creates a PENDING board (source + draft year + published date).
2. On the detail page, admin adds ranked players one at a time via an autocomplete entry form (reuses the existing `/players/search` endpoint).
3. Admin can edit rank/tier or remove entries while the board is PENDING.
4. Admin approves or rejects. APPROVED and REJECTED boards are immutable — they preserve a faithful record of the analyst's rankings for downstream consensus computation.
5. Hard-delete is reserved for PENDING typos; reject is for real submissions that should remain in the audit trail.

## What's in the PR

**Service** (`app/services/big_board_service.py`):
- `create_board`, `add_entry` / `update_entry` / `delete_entry`, `delete_board` (PENDING-only), `approve_board`, `reject_board`, `list_boards` (filter by status / source / year), `get_board_with_entries`.
- Translates DB unique-constraint violations into typed `DuplicateRankError` / `DuplicatePlayerError` so route handlers can surface clean error messages.
- Routes own transactions via `async with db.begin():`; the service does not commit or rollback (enforced by `tests/unit/test_transaction_policy.py`).

**Routes** (`app/routes/admin/big_boards.py`, wired in `admin/__init__.py`):

| Method | Path | Purpose |
|---|---|---|
| GET  | `/admin/big-boards` | List with status filter |
| GET  | `/admin/big-boards/new` | Create form |
| POST | `/admin/big-boards` | Create empty PENDING board |
| GET  | `/admin/big-boards/{id}` | Detail with entries + actions |
| POST | `/admin/big-boards/{id}/entries` | Add entry |
| POST | `/admin/big-boards/{id}/entries/{entry_id}/update` | Edit rank/tier |
| POST | `/admin/big-boards/{id}/entries/{entry_id}/delete` | Remove entry |
| POST | `/admin/big-boards/{id}/approve` | Approve |
| POST | `/admin/big-boards/{id}/reject` | Reject (audit-preserving) |
| POST | `/admin/big-boards/{id}/delete` | Hard-delete PENDING board |

**UI**: Three Jinja templates under `templates/admin/big-boards/` (index, new, detail). Vanilla JS autocomplete at `app/static/big-boards-detail.js`. Dropdown styles appended to `app/static/css/admin.css`. New sidebar nav entry gated by the `big_boards` permission.

**Schema fix**: `BigBoardEntry.board_id` now declares `ondelete=\"CASCADE\"` on the SQLModel side so `SQLModel.metadata.create_all` (used by integration tests) matches the migration that already shipped on main in #192. Closes the drift between the Python schema and the live DB.

## Test plan

- [x] `make precommit` clean (ruff + ruff-format + mypy + the custom transaction-policy hook)
- [x] `mypy app --ignore-missing-imports` clean across 128 source files
- [x] `pytest tests/unit -q` — 255 passed
- [x] `pytest tests/integration -q` — 333 passed, including:
  - `test_big_board_service.py` (8): create, duplicate rank, duplicate player, add/update/delete entries on PENDING, immutability after APPROVED and REJECTED, cascade-delete on PENDING boards, list filters
  - `test_admin_big_boards.py` (6): access control, full create → add → edit → approve flow, reject preserves row, delete-pending removes row, list with status filter
- [ ] Reviewer: spin up `make dev`, create a source if needed, walk through the full create → add → approve flow in the admin UI