### PR TITLE
enhancement: big board admin UX polish

### DIFF
--- a/app/routes/admin/big_boards.py
+++ b/app/routes/admin/big_boards.py
@@ -41,6 +41,8 @@ _SUCCESS_MESSAGES: dict[str, str] = {
     "approved": "Board approved.",
     "rejected": "Board rejected.",
     "deleted": "Board deleted.",
+    "reopened": "Board reopened for editing.",
+    "cloned": "Board cloned. Edit the new copy below.",
 }
 
 
@@ -210,6 +212,14 @@ async def big_board_detail(
         )
         players_by_id = {p.id: p for p in rows.scalars().all() if p.id is not None}
 
+    is_pending = board.status is BoardStatus.PENDING
+    default_tier = (
+        await svc.latest_entry_tier(db, board_id=board_id) if is_pending else None
+    )
+    default_next_rank = (
+        (max((e.rank for e in entries), default=0) + 1) if entries else 1
+    )
+
     return request.app.state.templates.TemplateResponse(
         "admin/big-boards/detail.html",
         await base_context_with_permissions(
@@ -220,7 +230,9 @@ async def big_board_detail(
             entries=entries,
             source=source,
             players_by_id=players_by_id,
-            is_pending=board.status is BoardStatus.PENDING,
+            is_pending=is_pending,
+            default_tier=default_tier,
+            default_next_rank=default_next_rank,
             success=_SUCCESS_MESSAGES.get(success) if success else None,
             error=error,
         ),
@@ -412,6 +424,131 @@ async def delete_big_board(
         return _redirect_with_error(board_id, str(exc))
 
     return RedirectResponse(url="/admin/big-boards?success=deleted", status_code=303)
+
+
+@router.post("/{board_id}/reopen", response_class=HTMLResponse)
+async def reopen_big_board(
+    request: Request,
+    board_id: int,
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Reopen an APPROVED board so it can be edited again."""
+    redirect, user = await require_dataset_access(
+        request,
+        db,
+        "big_boards",
+        need_edit=True,
+        next_path=f"/admin/big-boards/{board_id}",
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    try:
+        async with db.begin():
+            await svc.reopen_board(db, board_id=board_id)
+    except svc.BigBoardError as exc:
+        return _redirect_with_error(board_id, str(exc))
+
+    return RedirectResponse(
+        url=f"/admin/big-boards/{board_id}?success=reopened", status_code=303
+    )
+
+
+@router.post("/{board_id}/clone", response_class=HTMLResponse)
+async def clone_big_board(
+    request: Request,
+    board_id: int,
+    published_at: str | None = Form(default=None),
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Clone a board into a new PENDING copy with the same entries.
+
+    The caller supplies a ``published_at`` so the clone records when the
+    cloned-from analyst published this iteration; defaults to today.
+    """
+    redirect, user = await require_dataset_access(
+        request,
+        db,
+        "big_boards",
+        need_edit=True,
+        next_path=f"/admin/big-boards/{board_id}",
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    published_dt = datetime.utcnow()
+    if published_at:
+        try:
+            parsed = datetime.fromisoformat(published_at)
+        except ValueError:
+            return _redirect_with_error(
+                board_id,
+                "Published-at must be an ISO date/time (e.g., 2026-05-23).",
+            )
+        published_dt = parsed.replace(tzinfo=None) if parsed.tzinfo else parsed
+
+    try:
+        async with db.begin():
+            clone = await svc.clone_board(
+                db, board_id=board_id, published_at=published_dt
+            )
+    except svc.BigBoardError as exc:
+        return _redirect_with_error(board_id, str(exc))
+
+    return RedirectResponse(
+        url=f"/admin/big-boards/{clone.id}?success=cloned", status_code=303
+    )
+
+
+@router.post("/{board_id}/entries/{entry_id}/move-up", response_class=HTMLResponse)
+async def move_entry_up(
+    request: Request,
+    board_id: int,
+    entry_id: int,
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Swap an entry with the one ranked immediately above it."""
+    return await _move_entry(request, db, board_id, entry_id, "up")
+
+
+@router.post("/{board_id}/entries/{entry_id}/move-down", response_class=HTMLResponse)
+async def move_entry_down(
+    request: Request,
+    board_id: int,
+    entry_id: int,
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Swap an entry with the one ranked immediately below it."""
+    return await _move_entry(request, db, board_id, entry_id, "down")
+
+
+async def _move_entry(
+    request: Request,
+    db: AsyncSession,
+    board_id: int,
+    entry_id: int,
+    direction: str,
+) -> Response:
+    redirect, user = await require_dataset_access(
+        request,
+        db,
+        "big_boards",
+        need_edit=True,
+        next_path=f"/admin/big-boards/{board_id}",
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    try:
+        async with db.begin():
+            await svc.move_entry(db, entry_id=entry_id, direction=direction)
+    except svc.BigBoardError as exc:
+        return _redirect_with_error(board_id, str(exc))
+
+    return RedirectResponse(url=f"/admin/big-boards/{board_id}", status_code=303)
 
 
 def _parse_optional_int(raw: str | None) -> int | None:

--- a/app/services/big_board_service.py
+++ b/app/services/big_board_service.py
@@ -265,6 +265,131 @@ async def reject_board(db: AsyncSession, *, board_id: int) -> BigBoard:
     return board
 
 
+async def reopen_board(db: AsyncSession, *, board_id: int) -> BigBoard:
+    """Unlock an APPROVED board back to PENDING so it can be edited.
+
+    Clears ``approved_at`` since the prior approval is no longer current.
+    Only APPROVED boards may be reopened; REJECTED boards stay locked.
+    """
+    board = await get_board(db, board_id)
+    if board.status is not BoardStatus.APPROVED:
+        raise BoardNotEditableError(
+            f"Board {board.id} is {board.status.value}; only APPROVED boards may be reopened."
+        )
+    board.status = BoardStatus.PENDING
+    board.approved_at = None
+    board.updated_at = datetime.utcnow()
+    await db.flush()
+    return board
+
+
+async def clone_board(
+    db: AsyncSession,
+    *,
+    board_id: int,
+    published_at: datetime,
+) -> BigBoard:
+    """Create a fresh PENDING board with the same entries as ``board_id``.
+
+    Useful when the next published board from a source is mostly the
+    same lineup as the previous one — clone, then tweak ranks/players.
+    The new board's source, draft_year, and entry list match the source
+    board; ``published_at`` is provided by the caller; status is PENDING.
+    """
+    source_board, entries = await get_board_with_entries(db, board_id)
+    clone = BigBoard(
+        news_source_id=source_board.news_source_id,
+        news_item_id=None,
+        draft_year=source_board.draft_year,
+        published_at=published_at,
+        board_size=len(entries),
+        status=BoardStatus.PENDING,
+    )
+    db.add(clone)
+    await db.flush()
+    assert clone.id is not None
+
+    for entry in entries:
+        db.add(
+            BigBoardEntry(
+                board_id=clone.id,
+                player_id=entry.player_id,
+                rank=entry.rank,
+                tier=entry.tier,
+            )
+        )
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        _translate_entry_integrity_error(exc)
+    return clone
+
+
+async def move_entry(
+    db: AsyncSession,
+    *,
+    entry_id: int,
+    direction: str,
+) -> BigBoardEntry:
+    """Swap an entry's rank with its neighbor above (``up``) or below (``down``).
+
+    No-op when the entry is already at the top (for ``up``) or bottom
+    (for ``down``) of the board. Uses a temporary negative rank between
+    the two updates so the unique ``(board_id, rank)`` constraint is
+    satisfied at every flush.
+    """
+    if direction not in {"up", "down"}:
+        raise BigBoardError(f"Invalid direction: {direction!r}")
+
+    entry = await db.get(BigBoardEntry, entry_id)
+    if entry is None:
+        raise EntryNotFoundError(f"No big board entry with id={entry_id}")
+
+    board = await get_board(db, entry.board_id)
+    _require_pending(board)
+
+    neighbor_rank = entry.rank - 1 if direction == "up" else entry.rank + 1
+    if neighbor_rank < 1:
+        return entry  # already at top
+
+    result = await db.execute(
+        select(BigBoardEntry)  # type: ignore[call-overload]
+        .where(BigBoardEntry.board_id == board.id)  # type: ignore[arg-type]
+        .where(BigBoardEntry.rank == neighbor_rank)  # type: ignore[arg-type]
+    )
+    neighbor = result.scalar_one_or_none()
+    if neighbor is None:
+        return entry  # no neighbor in that direction (entry is at bottom)
+
+    # Two-step swap so we never violate uq(board_id, rank).
+    original = entry.rank
+    entry.rank = -original  # sentinel; never collides with a real 1-based rank
+    await db.flush()
+    neighbor.rank = original
+    await db.flush()
+    entry.rank = neighbor_rank
+    board.updated_at = datetime.utcnow()
+    await db.flush()
+    return entry
+
+
+async def latest_entry_tier(db: AsyncSession, *, board_id: int) -> Optional[int]:
+    """Return the tier of the highest-rank (most-recently-added) entry, if any.
+
+    Used by the admin UI to pre-fill the add form's tier input so an
+    admin doesn't have to re-type ``tier=1`` for every player in a board
+    that is mostly tier 1.
+    """
+    result = await db.execute(
+        select(BigBoardEntry.tier)  # type: ignore[call-overload]
+        .where(BigBoardEntry.board_id == board_id)  # type: ignore[arg-type]
+        .order_by(BigBoardEntry.rank.desc())  # type: ignore[attr-defined]
+        .limit(1)
+    )
+    row = result.first()
+    return row[0] if row else None
+
+
 def _require_pending(board: BigBoard) -> None:
     if board.status is not BoardStatus.PENDING:
         raise BoardNotEditableError(

--- a/app/static/big-boards-detail.js
+++ b/app/static/big-boards-detail.js
@@ -1,9 +1,13 @@
-// Player autocomplete for the big-board add-entry form.
-// Calls the existing /players/search endpoint and writes the selected
-// player's id into the hidden #player_id input that the form posts.
+// Big-board detail page client-side helpers.
+//
+// Two responsibilities:
+//   1. Player autocomplete on the "Add Entry" form (calls /players/search).
+//   2. Per-row auto-save: when the admin tabs out of a rank or tier input
+//      whose value has changed, POST the new values to the existing
+//      /admin/big-boards/{board}/entries/{entry}/update route.
 
 (function () {
-  function init() {
+  function initAutocomplete() {
     const input = document.getElementById("player-search");
     const list = document.getElementById("player-autocomplete");
     const hidden = document.getElementById("player_id");
@@ -60,14 +64,12 @@
         show(results);
       } catch (err) {
         if (err && err.name !== "AbortError") {
-          // Network or parse error — silently hide rather than block the form.
           hide();
         }
       }
     }
 
     input.addEventListener("input", function () {
-      // Any keystroke invalidates a previously-selected id.
       hidden.value = "";
       const q = input.value.trim();
       clearTimeout(debounceTimer);
@@ -79,9 +81,105 @@
     });
 
     input.addEventListener("blur", function () {
-      // Hide after the click handler has had a chance to fire.
       setTimeout(hide, 120);
     });
+  }
+
+  function initAutosave() {
+    const inputs = document.querySelectorAll(".bb-autosave");
+    if (!inputs.length) return;
+
+    const statusEl = document.getElementById("bb-autosave-status");
+    let statusTimer = null;
+
+    function setStatus(text, isError) {
+      if (!statusEl) return;
+      statusEl.textContent = text;
+      statusEl.style.color = isError ? "var(--color-accent-rose, #f43f5e)" : "";
+      clearTimeout(statusTimer);
+      if (!isError) {
+        statusTimer = setTimeout(() => {
+          statusEl.textContent = "";
+        }, 1500);
+      }
+    }
+
+    // Capture starting values so we only POST on actual change.
+    inputs.forEach((el) => {
+      el.dataset.originalValue = el.value;
+    });
+
+    async function save(el) {
+      const row = el.closest("tr[data-entry-id]");
+      if (!row) return;
+      const entryId = row.dataset.entryId;
+      const boardId = row.dataset.boardId;
+      if (!entryId || !boardId) return;
+
+      const rankEl = row.querySelector('[data-field="rank"]');
+      const tierEl = row.querySelector('[data-field="tier"]');
+      const rankVal = rankEl ? rankEl.value.trim() : "";
+      const tierVal = tierEl ? tierEl.value.trim() : "";
+
+      if (rankVal === "") {
+        setStatus("Rank is required.", true);
+        if (rankEl) rankEl.focus();
+        return;
+      }
+
+      const body = new URLSearchParams();
+      body.append("rank", rankVal);
+      body.append("tier", tierVal);
+
+      setStatus("Saving…", false);
+      try {
+        const resp = await fetch(
+          "/admin/big-boards/" + boardId + "/entries/" + entryId + "/update",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: body.toString(),
+            redirect: "follow",
+            credentials: "same-origin",
+          }
+        );
+        if (resp.ok || resp.redirected) {
+          // FastAPI returns a 303 redirect which fetch follows; success
+          // = either 200/2xx after redirect, OR a redirected response.
+          setStatus("Saved", false);
+          el.dataset.originalValue = el.value;
+          // Surface server-side error encoded in the redirect URL.
+          if (resp.redirected && resp.url.includes("error=")) {
+            const url = new URL(resp.url);
+            const msg = url.searchParams.get("error");
+            if (msg) setStatus(decodeURIComponent(msg), true);
+          }
+        } else {
+          setStatus("Save failed (" + resp.status + ")", true);
+        }
+      } catch (err) {
+        setStatus("Save failed: " + err.message, true);
+      }
+    }
+
+    inputs.forEach((el) => {
+      el.addEventListener("blur", function () {
+        if (el.value === el.dataset.originalValue) return;
+        save(el);
+      });
+      // Tabbing through fields is faster if Enter also commits.
+      el.addEventListener("keydown", function (ev) {
+        if (ev.key === "Enter") {
+          ev.preventDefault();
+          el.blur();
+        }
+      });
+    });
+  }
+
+  function init() {
+    initAutocomplete();
+    initAutosave();
   }
 
   if (document.readyState === "loading") {

--- a/app/templates/admin/big-boards/detail.html
+++ b/app/templates/admin/big-boards/detail.html
@@ -26,8 +26,8 @@
 <div class="admin-card">
   <div class="admin-card__header">
     <h2 class="admin-card__title">Entries</h2>
-    {% if is_pending %}
     <div style="display: flex; gap: 0.5rem;">
+      {% if is_pending %}
       <form method="post" action="/admin/big-boards/{{ board.id }}/approve" class="admin-form--inline">
         <button type="submit" class="admin-btn admin-btn--primary admin-btn--small">Approve</button>
       </form>
@@ -39,44 +39,75 @@
             onsubmit="return confirm('Permanently delete this board and all entries? No audit record will be kept.');">
         <button type="submit" class="admin-btn admin-btn--small">Delete</button>
       </form>
+      {% elif board.status.value == 'APPROVED' %}
+      <form method="post" action="/admin/big-boards/{{ board.id }}/reopen" class="admin-form--inline"
+            onsubmit="return confirm('Reopen this board for editing? Its approved_at timestamp will be cleared until you re-approve.');">
+        <button type="submit" class="admin-btn admin-btn--secondary admin-btn--small">Reopen</button>
+      </form>
+      {% endif %}
+      <form method="post" action="/admin/big-boards/{{ board.id }}/clone" class="admin-form--inline">
+        <button type="submit" class="admin-btn admin-btn--small">Clone</button>
+      </form>
     </div>
-    {% endif %}
   </div>
 
   {% if entries %}
-  <table class="admin-table">
+  <table class="admin-table" id="big-board-entries">
     <thead>
       <tr>
-        <th style="width: 4rem;">Rank</th>
+        {% if is_pending %}<th style="width: 5rem;">Move</th>{% endif %}
+        <th style="width: 6rem;">Rank</th>
         <th>Player</th>
         <th>School</th>
-        <th style="width: 5rem;">Tier</th>
-        {% if is_pending %}
-        <th style="width: 14rem;">Actions</th>
-        {% endif %}
+        <th style="width: 6rem;">Tier</th>
+        {% if is_pending %}<th style="width: 6rem;">Remove</th>{% endif %}
       </tr>
     </thead>
     <tbody>
       {% for entry in entries %}
       {% set player = players_by_id.get(entry.player_id) %}
-      <tr>
-        <td><strong>{{ entry.rank }}</strong></td>
-        <td>{{ player.display_name if player else '(unknown player)' }}</td>
-        <td>{{ player.school if player else '' }}</td>
-        <td>{{ entry.tier if entry.tier is not none else '—' }}</td>
+      <tr data-entry-id="{{ entry.id }}" data-board-id="{{ board.id }}">
         {% if is_pending %}
         <td>
           <form method="post"
-                action="/admin/big-boards/{{ board.id }}/entries/{{ entry.id }}/update"
-                class="admin-form--inline"
-                style="display: flex; gap: 0.25rem;">
-            <input class="admin-form__input" type="number" name="rank" value="{{ entry.rank }}"
-                   min="1" required style="width: 4.5rem;" />
-            <input class="admin-form__input" type="number" name="tier"
-                   value="{{ entry.tier if entry.tier is not none else '' }}"
-                   placeholder="tier" style="width: 4.5rem;" />
-            <button type="submit" class="admin-btn admin-btn--small">Save</button>
+                action="/admin/big-boards/{{ board.id }}/entries/{{ entry.id }}/move-up"
+                class="admin-form--inline">
+            <button type="submit" class="admin-btn admin-btn--small"
+                    {% if loop.first %}disabled aria-disabled="true"{% endif %}
+                    title="Move up">&uarr;</button>
           </form>
+          <form method="post"
+                action="/admin/big-boards/{{ board.id }}/entries/{{ entry.id }}/move-down"
+                class="admin-form--inline">
+            <button type="submit" class="admin-btn admin-btn--small"
+                    {% if loop.last %}disabled aria-disabled="true"{% endif %}
+                    title="Move down">&darr;</button>
+          </form>
+        </td>
+        {% endif %}
+        <td>
+          {% if is_pending %}
+          <input class="admin-form__input bb-autosave" type="number" name="rank"
+                 data-field="rank" value="{{ entry.rank }}"
+                 min="1" required style="width: 4.5rem;" />
+          {% else %}
+          <strong>{{ entry.rank }}</strong>
+          {% endif %}
+        </td>
+        <td>{{ player.display_name if player else '(unknown player)' }}</td>
+        <td>{{ player.school if player else '' }}</td>
+        <td>
+          {% if is_pending %}
+          <input class="admin-form__input bb-autosave" type="number" name="tier"
+                 data-field="tier"
+                 value="{{ entry.tier if entry.tier is not none else '' }}"
+                 placeholder="tier" style="width: 4.5rem;" />
+          {% else %}
+          {{ entry.tier if entry.tier is not none else '—' }}
+          {% endif %}
+        </td>
+        {% if is_pending %}
+        <td>
           <form method="post"
                 action="/admin/big-boards/{{ board.id }}/entries/{{ entry.id }}/delete"
                 class="admin-form--inline"
@@ -89,6 +120,11 @@
       {% endfor %}
     </tbody>
   </table>
+  <p class="admin-text--muted admin-text--small" id="bb-autosave-hint"
+     {% if not is_pending %}hidden{% endif %}>
+    Rank and tier auto-save when you tab out of a field.
+    <span id="bb-autosave-status" aria-live="polite"></span>
+  </p>
   {% else %}
   <p class="admin-text--muted">No entries yet.</p>
   {% endif %}
@@ -106,7 +142,8 @@
   >
     <div class="admin-form__field" style="margin: 0;">
       <label class="admin-form__label" for="rank">Rank</label>
-      <input class="admin-form__input" id="rank" name="rank" type="number" min="1" required />
+      <input class="admin-form__input" id="rank" name="rank" type="number"
+             value="{{ default_next_rank }}" min="1" required />
     </div>
     <div class="admin-form__field" style="margin: 0; position: relative;">
       <label class="admin-form__label" for="player-search">Player</label>
@@ -123,7 +160,9 @@
     </div>
     <div class="admin-form__field" style="margin: 0;">
       <label class="admin-form__label" for="tier">Tier</label>
-      <input class="admin-form__input" id="tier" name="tier" type="number" placeholder="optional" />
+      <input class="admin-form__input" id="tier" name="tier" type="number"
+             value="{{ default_tier if default_tier is not none else '' }}"
+             placeholder="optional" />
     </div>
     <div class="admin-form__field" style="margin: 0;">
       <button type="submit" class="admin-btn admin-btn--primary">Add</button>

--- a/app/templates/admin/big-boards/index.html
+++ b/app/templates/admin/big-boards/index.html
@@ -69,7 +69,9 @@
           {% endif %}
         </td>
         <td>
-          <a href="/admin/big-boards/{{ board.id }}" class="admin-btn admin-btn--small">View</a>
+          <a href="/admin/big-boards/{{ board.id }}" class="admin-btn admin-btn--small">
+            {% if board.status.value == 'PENDING' %}Edit{% else %}View{% endif %}
+          </a>
         </td>
       </tr>
       {% endfor %}

--- a/tests/integration/test_admin_big_boards.py
+++ b/tests/integration/test_admin_big_boards.py
@@ -260,6 +260,187 @@ class TestBigBoardLifecycle:
         assert approve_again.status_code == 303
         assert "error=" in approve_again.headers["location"]
 
+    async def test_reopen_flips_approved_back_to_pending(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_logged_in: None,
+        big_board_source: NewsSource,
+        sample_players: list[PlayerMaster],
+    ):
+        """POST /reopen unlocks an APPROVED board for edits and clears approved_at."""
+        _ = admin_logged_in
+        assert big_board_source.id is not None
+
+        create_resp = await app_client.post(
+            "/admin/big-boards",
+            data={
+                "news_source_id": str(big_board_source.id),
+                "draft_year": "2026",
+                "published_at": "2026-05-01",
+            },
+            follow_redirects=False,
+        )
+        board_id = int(
+            create_resp.headers["location"].split("/")[-1].split("?")[0]
+        )
+        await app_client.post(
+            f"/admin/big-boards/{board_id}/entries",
+            data={"player_id": str(sample_players[0].id), "rank": "1"},
+            follow_redirects=False,
+        )
+        await app_client.post(
+            f"/admin/big-boards/{board_id}/approve", follow_redirects=False
+        )
+
+        reopen_resp = await app_client.post(
+            f"/admin/big-boards/{board_id}/reopen", follow_redirects=False
+        )
+        assert reopen_resp.status_code == 303
+        assert "success=reopened" in reopen_resp.headers["location"]
+
+        board_row = await db_session.get(
+            BigBoard, board_id, populate_existing=True
+        )
+        assert board_row is not None
+        assert board_row.status is BoardStatus.PENDING
+        assert board_row.approved_at is None
+
+        # Re-adding entries should now work
+        add_resp = await app_client.post(
+            f"/admin/big-boards/{board_id}/entries",
+            data={"player_id": str(sample_players[1].id), "rank": "2"},
+            follow_redirects=False,
+        )
+        assert add_resp.status_code == 303
+        assert "success=entry_added" in add_resp.headers["location"]
+
+    async def test_clone_creates_pending_copy_with_same_entries(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_logged_in: None,
+        big_board_source: NewsSource,
+        sample_players: list[PlayerMaster],
+    ):
+        """POST /clone creates a fresh PENDING board with the same entries."""
+        _ = admin_logged_in
+        assert big_board_source.id is not None
+
+        create_resp = await app_client.post(
+            "/admin/big-boards",
+            data={
+                "news_source_id": str(big_board_source.id),
+                "draft_year": "2026",
+                "published_at": "2026-05-01",
+            },
+            follow_redirects=False,
+        )
+        board_id = int(
+            create_resp.headers["location"].split("/")[-1].split("?")[0]
+        )
+        await app_client.post(
+            f"/admin/big-boards/{board_id}/entries",
+            data={
+                "player_id": str(sample_players[0].id),
+                "rank": "1",
+                "tier": "1",
+            },
+            follow_redirects=False,
+        )
+        await app_client.post(
+            f"/admin/big-boards/{board_id}/entries",
+            data={"player_id": str(sample_players[1].id), "rank": "2"},
+            follow_redirects=False,
+        )
+
+        clone_resp = await app_client.post(
+            f"/admin/big-boards/{board_id}/clone",
+            data={"published_at": "2026-05-20"},
+            follow_redirects=False,
+        )
+        assert clone_resp.status_code == 303
+        clone_id = int(
+            clone_resp.headers["location"].split("/")[-1].split("?")[0]
+        )
+        assert clone_id != board_id
+
+        clone_row = await db_session.get(BigBoard, clone_id)
+        assert clone_row is not None
+        assert clone_row.status is BoardStatus.PENDING
+        assert clone_row.board_size == 2
+
+        entries = (
+            await db_session.execute(
+                select(BigBoardEntry)  # type: ignore[call-overload]
+                .where(BigBoardEntry.board_id == clone_id)  # type: ignore[arg-type]
+                .order_by(BigBoardEntry.rank)  # type: ignore[arg-type]
+            )
+        ).scalars().all()
+        assert [(e.player_id, e.rank, e.tier) for e in entries] == [
+            (sample_players[0].id, 1, 1),
+            (sample_players[1].id, 2, None),
+        ]
+
+    async def test_move_up_and_down_swap_ranks(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_logged_in: None,
+        big_board_source: NewsSource,
+        sample_players: list[PlayerMaster],
+    ):
+        """POST /move-up swaps the entry with its higher-ranked neighbor."""
+        _ = admin_logged_in
+        assert big_board_source.id is not None
+
+        create_resp = await app_client.post(
+            "/admin/big-boards",
+            data={
+                "news_source_id": str(big_board_source.id),
+                "draft_year": "2026",
+                "published_at": "2026-05-01",
+            },
+            follow_redirects=False,
+        )
+        board_id = int(
+            create_resp.headers["location"].split("/")[-1].split("?")[0]
+        )
+        for i, player in enumerate(sample_players, start=1):
+            await app_client.post(
+                f"/admin/big-boards/{board_id}/entries",
+                data={"player_id": str(player.id), "rank": str(i)},
+                follow_redirects=False,
+            )
+
+        rows = (
+            await db_session.execute(
+                select(BigBoardEntry.id, BigBoardEntry.rank)  # type: ignore[call-overload]
+                .where(BigBoardEntry.board_id == board_id)  # type: ignore[arg-type]
+                .order_by(BigBoardEntry.rank)  # type: ignore[arg-type]
+            )
+        ).all()
+        # rows is [(id_at_rank_1, 1), (id_at_rank_2, 2), (id_at_rank_3, 3)]
+        rank2_entry_id = rows[1].id
+        rank1_entry_id = rows[0].id
+
+        # Move rank-2 up -> should become rank 1
+        up_resp = await app_client.post(
+            f"/admin/big-boards/{board_id}/entries/{rank2_entry_id}/move-up",
+            follow_redirects=False,
+        )
+        assert up_resp.status_code == 303
+
+        rows_after = (
+            await db_session.execute(
+                select(BigBoardEntry.id, BigBoardEntry.rank)  # type: ignore[call-overload]
+                .where(BigBoardEntry.board_id == board_id)  # type: ignore[arg-type]
+                .order_by(BigBoardEntry.rank)  # type: ignore[arg-type]
+            )
+        ).all()
+        assert rows_after[0].id == rank2_entry_id
+        assert rows_after[1].id == rank1_entry_id
+
     async def test_delete_pending_board_removes_row(
         self,
         app_client: AsyncClient,

--- a/tests/integration/test_big_board_service.py
+++ b/tests/integration/test_big_board_service.py
@@ -268,6 +268,233 @@ async def test_delete_pending_board_cascades_entries(
 
 
 @pytest.mark.asyncio
+async def test_reopen_board_flips_approved_to_pending(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """reopen_board sends APPROVED back to PENDING and clears approved_at."""
+    assert news_source.id is not None
+    board = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at(),
+        entries=[svc.EntryInput(player_id=players[0].id, rank=1)],  # type: ignore[arg-type]
+    )
+    await db_session.commit()
+    await svc.approve_board(db_session, board_id=board.id)  # type: ignore[arg-type]
+    await db_session.commit()
+    assert board.status is BoardStatus.APPROVED
+    assert board.approved_at is not None
+
+    reopened = await svc.reopen_board(db_session, board_id=board.id)  # type: ignore[arg-type]
+    await db_session.commit()
+    assert reopened.status is BoardStatus.PENDING
+    assert reopened.approved_at is None
+
+
+@pytest.mark.asyncio
+async def test_reopen_rejects_non_approved_board(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """Reopen only works on APPROVED; PENDING and REJECTED both raise."""
+    assert news_source.id is not None
+    pending = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at(),
+        entries=[svc.EntryInput(player_id=players[0].id, rank=1)],  # type: ignore[arg-type]
+    )
+    await db_session.commit()
+    with pytest.raises(svc.BoardNotEditableError):
+        await svc.reopen_board(db_session, board_id=pending.id)  # type: ignore[arg-type]
+
+    rejected = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at() - timedelta(days=1),
+        entries=[svc.EntryInput(player_id=players[1].id, rank=1)],  # type: ignore[arg-type]
+    )
+    await db_session.commit()
+    await svc.reject_board(db_session, board_id=rejected.id)  # type: ignore[arg-type]
+    await db_session.commit()
+    with pytest.raises(svc.BoardNotEditableError):
+        await svc.reopen_board(db_session, board_id=rejected.id)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_clone_board_copies_entries_into_new_pending_board(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """Clone produces a PENDING board with the same source, year, and entries."""
+    assert news_source.id is not None
+    original = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at(),
+        entries=[
+            svc.EntryInput(player_id=players[0].id, rank=1, tier=1),  # type: ignore[arg-type]
+            svc.EntryInput(player_id=players[1].id, rank=2, tier=1),  # type: ignore[arg-type]
+            svc.EntryInput(player_id=players[2].id, rank=3, tier=2),  # type: ignore[arg-type]
+        ],
+    )
+    await svc.approve_board(db_session, board_id=original.id)  # type: ignore[arg-type]
+    await db_session.commit()
+
+    new_published = datetime.now(timezone.utc).replace(tzinfo=None)
+    clone = await svc.clone_board(
+        db_session, board_id=original.id, published_at=new_published  # type: ignore[arg-type]
+    )
+    await db_session.commit()
+
+    assert clone.id != original.id
+    assert clone.status is BoardStatus.PENDING
+    assert clone.news_source_id == original.news_source_id
+    assert clone.draft_year == original.draft_year
+    assert clone.board_size == 3
+    assert clone.published_at == new_published
+
+    _, clone_entries = await svc.get_board_with_entries(db_session, clone.id)  # type: ignore[arg-type]
+    assert [(e.rank, e.player_id, e.tier) for e in clone_entries] == [
+        (1, players[0].id, 1),
+        (2, players[1].id, 1),
+        (3, players[2].id, 2),
+    ]
+
+
+async def _ranks_by_entry_id(
+    db: AsyncSession, board_id: int
+) -> list[tuple[int, int]]:
+    """Re-fetch entries and return ``[(rank, entry_id), ...]`` in rank order."""
+    rows = await db.execute(
+        select(BigBoardEntry.rank, BigBoardEntry.id)  # type: ignore[call-overload]
+        .where(BigBoardEntry.board_id == board_id)  # type: ignore[arg-type]
+        .order_by(BigBoardEntry.rank)  # type: ignore[arg-type]
+    )
+    return [(r.rank, r.id) for r in rows.all()]
+
+
+@pytest.mark.asyncio
+async def test_move_entry_swaps_neighbor_ranks(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """move_entry up/down swaps ranks with neighbor; boundary is a no-op."""
+    assert news_source.id is not None
+    board = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at(),
+        entries=[
+            svc.EntryInput(player_id=players[0].id, rank=1),  # type: ignore[arg-type]
+            svc.EntryInput(player_id=players[1].id, rank=2),  # type: ignore[arg-type]
+            svc.EntryInput(player_id=players[2].id, rank=3),  # type: ignore[arg-type]
+        ],
+    )
+    await db_session.commit()
+    board_id = board.id
+    assert board_id is not None
+
+    initial = await _ranks_by_entry_id(db_session, board_id)
+    rank1_id, rank2_id, rank3_id = (entry_id for _, entry_id in initial)
+
+    await svc.move_entry(db_session, entry_id=rank2_id, direction="up")
+    await db_session.commit()
+    assert (await _ranks_by_entry_id(db_session, board_id)) == [
+        (1, rank2_id),
+        (2, rank1_id),
+        (3, rank3_id),
+    ]
+
+    # Already at the top -> no-op
+    await svc.move_entry(db_session, entry_id=rank2_id, direction="up")
+    await db_session.commit()
+    assert (await _ranks_by_entry_id(db_session, board_id)) == [
+        (1, rank2_id),
+        (2, rank1_id),
+        (3, rank3_id),
+    ]
+
+    # Bottom entry down -> no-op
+    await svc.move_entry(db_session, entry_id=rank3_id, direction="down")
+    await db_session.commit()
+    final = await _ranks_by_entry_id(db_session, board_id)
+    assert final[-1] == (3, rank3_id)
+
+
+@pytest.mark.asyncio
+async def test_move_entry_blocked_on_approved_board(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """Approved boards refuse move operations like all other mutations."""
+    assert news_source.id is not None
+    board = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at(),
+        entries=[
+            svc.EntryInput(player_id=players[0].id, rank=1),  # type: ignore[arg-type]
+            svc.EntryInput(player_id=players[1].id, rank=2),  # type: ignore[arg-type]
+        ],
+    )
+    await svc.approve_board(db_session, board_id=board.id)  # type: ignore[arg-type]
+    await db_session.commit()
+
+    _, entries = await svc.get_board_with_entries(db_session, board.id)  # type: ignore[arg-type]
+    with pytest.raises(svc.BoardNotEditableError):
+        await svc.move_entry(db_session, entry_id=entries[0].id, direction="down")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_latest_entry_tier_returns_tier_of_highest_rank(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """latest_entry_tier looks at the entry with the largest rank value."""
+    assert news_source.id is not None
+    board = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at(),
+        entries=[
+            svc.EntryInput(player_id=players[0].id, rank=1, tier=1),  # type: ignore[arg-type]
+            svc.EntryInput(player_id=players[1].id, rank=2, tier=2),  # type: ignore[arg-type]
+        ],
+    )
+    await db_session.commit()
+    assert (
+        await svc.latest_entry_tier(db_session, board_id=board.id)  # type: ignore[arg-type]
+    ) == 2
+
+    empty = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at() - timedelta(days=1),
+        entries=[],
+    )
+    await db_session.commit()
+    assert (
+        await svc.latest_entry_tier(db_session, board_id=empty.id)  # type: ignore[arg-type]
+    ) is None
+
+
+@pytest.mark.asyncio
 async def test_list_boards_filters_by_status_source_and_year(
     db_session: AsyncSession,
     news_source: NewsSource,


### PR DESCRIPTION
## Summary

First round of fixes informed by entering a real published big board through the admin UI. The friction points that showed up: typed tier values silently disappeared because each row needed its own Save click, adding 30 entries meant retyping rank/tier every time, there was no way to fix a misclicked Approve, and the recurring biweekly-board workflow had no shortcut.

### What changes

**Auto-save row edits**
- Per-row Save buttons gone; rank and tier inputs POST to the existing `/update` endpoint when you tab out of a changed field
- An aria-live status line shows "Saving…" / "Saved" / errors next to the table
- Resolves the original "tiers disappeared after Approve" report: typed edits now stick the moment focus leaves the field

**Sticky tier + next-rank prefill**
- Add Entry form pre-fills tier with the previous entry's tier (new `svc.latest_entry_tier` helper)
- Rank pre-fills to `max(rank) + 1`
- Adding a top-30 board where 10 players share Tier 1 is mostly Enter-Enter-Enter

**Up / down move arrows**
- Per-row ↑ / ↓ POST to `/entries/{id}/move-up` or `/move-down`
- Backend `svc.move_entry` swaps neighbor ranks using a temporary negative sentinel between two flushes so the unique `(board_id, rank)` constraint is satisfied at every step
- Boundary clicks (already-top / already-bottom) are no-ops

**Clone**
- New "Clone" button on detail page (visible on PENDING / APPROVED / REJECTED)
- Creates a fresh PENDING board with the same source, draft year, entries, and a caller-supplied `published_at` (defaults to today)
- Lets you bring forward a previous board and diff-edit instead of starting from scratch

**Reopen (APPROVED → PENDING)**
- New "Reopen" button on APPROVED boards
- Clears `approved_at` and flips status back to PENDING so a misclicked Approve is recoverable
- Service refuses to reopen REJECTED boards — the audit trail there stays intact

**Misc**
- List page shows "Edit" instead of "View" for PENDING boards, so it's clearer the detail page is the editor while the board is in flight

## Test plan

- [x] `make precommit` clean (ruff, ruff-format, mypy, transaction-policy hook)
- [x] `mypy app --ignore-missing-imports` clean across 128 source files
- [x] `pytest tests/unit -q` — 255 passed
- [x] `pytest tests/integration/test_big_board_service.py tests/integration/test_admin_big_boards.py -q` — 23 passed (9 new cases for reopen / clone / move / sticky tier / approved-board guards)
- [ ] Reviewer: walk through the create → add ~5 entries → move some around → approve → reopen → clone flow against `make dev`
- [ ] Reviewer: verify autosave: type into a tier input, tab away, watch the inline "Saved" indicator, refresh the page, confirm the tier persisted