### PR TITLE
fix: flush pending autosaves before any big-board form submits

### DIFF
--- a/app/static/big-boards-detail.js
+++ b/app/static/big-boards-detail.js
@@ -91,6 +91,10 @@
 
     const statusEl = document.getElementById("bb-autosave-status");
     let statusTimer = null;
+    // In-flight save promises. Flushed before any form on the page submits
+    // so Approve/Reject/Reopen/Clone/Move/Delete can't race past a pending
+    // autosave and overwrite or lose typed-but-not-yet-POSTed changes.
+    const inFlight = new Set();
 
     function setStatus(text, isError) {
       if (!statusEl) return;
@@ -162,10 +166,26 @@
       }
     }
 
+    function trackedSave(el) {
+      const p = save(el).finally(() => inFlight.delete(p));
+      inFlight.add(p);
+      return p;
+    }
+
+    async function flushPending() {
+      const dirty = [];
+      document.querySelectorAll(".bb-autosave").forEach((el) => {
+        if (el.value !== el.dataset.originalValue) dirty.push(el);
+      });
+      dirty.forEach((el) => trackedSave(el));
+      if (inFlight.size === 0) return;
+      await Promise.allSettled(Array.from(inFlight));
+    }
+
     inputs.forEach((el) => {
       el.addEventListener("blur", function () {
         if (el.value === el.dataset.originalValue) return;
-        save(el);
+        trackedSave(el);
       });
       // Tabbing through fields is faster if Enter also commits.
       el.addEventListener("keydown", function (ev) {
@@ -175,6 +195,37 @@
         }
       });
     });
+
+    // Intercept every POST form on the page (Approve, Reject, Delete,
+    // Reopen, Clone, Move up/down, Remove entry, Add entry) and flush
+    // any pending autosaves before allowing the navigation. This closes
+    // a race where the in-flight tier/rank POST got cancelled by the
+    // browser when the action form submitted and navigated away.
+    function hasPendingWork() {
+      if (inFlight.size > 0) return true;
+      for (const el of document.querySelectorAll(".bb-autosave")) {
+        if (el.value !== el.dataset.originalValue) return true;
+      }
+      return false;
+    }
+
+    document.addEventListener(
+      "submit",
+      function (ev) {
+        const form = ev.target;
+        if (!(form instanceof HTMLFormElement)) return;
+        if (form.method.toLowerCase() !== "post") return;
+        if (form.dataset.bbFlushed === "1") return; // already flushed; let through
+        if (!hasPendingWork()) return; // nothing to flush; normal submit
+        ev.preventDefault();
+        setStatus("Saving changes…", false);
+        flushPending().then(() => {
+          form.dataset.bbFlushed = "1";
+          form.submit();
+        });
+      },
+      true
+    );
   }
 
   function init() {

--- a/app/static/big-boards-detail.js
+++ b/app/static/big-boards-detail.js
@@ -209,6 +209,29 @@
       return false;
     }
 
+    // Move inline `onsubmit="return confirm('...')"` to data-bb-confirm so
+    // confirmation runs once in the capture-phase submit listener. Without
+    // this, form.submit() (called after flushPending resolves) bypasses
+    // the inline onsubmit handler and a clicked-Cancel would still execute
+    // the destructive POST. The inline attribute stays as the JS-disabled
+    // fallback at template render time but is detached during init.
+    document
+      .querySelectorAll("form[onsubmit]")
+      .forEach(function (form) {
+        const raw = form.getAttribute("onsubmit") || "";
+        const match = raw.match(/confirm\(['"]([\s\S]*?)['"]\)/);
+        if (match) {
+          form.dataset.bbConfirm = match[1].replace(/\\'/g, "'");
+          form.removeAttribute("onsubmit");
+        }
+      });
+
+    function userConfirmed(form) {
+      const msg = form.dataset.bbConfirm;
+      if (!msg) return true;
+      return window.confirm(msg);
+    }
+
     document.addEventListener(
       "submit",
       function (ev) {
@@ -216,6 +239,15 @@
         if (!(form instanceof HTMLFormElement)) return;
         if (form.method.toLowerCase() !== "post") return;
         if (form.dataset.bbFlushed === "1") return; // already flushed; let through
+
+        // Run any confirmation gate FIRST so a clicked-Cancel cleanly
+        // cancels the navigation regardless of whether there's pending
+        // autosave work to flush.
+        if (!userConfirmed(form)) {
+          ev.preventDefault();
+          return;
+        }
+
         if (!hasPendingWork()) return; // nothing to flush; normal submit
         ev.preventDefault();
         setStatus("Saving changes…", false);


### PR DESCRIPTION
## Symptom

User reopened an APPROVED big board, typed tier values into the row-level inputs, clicked Approve at the top, and every typed tier was silently lost (except an earlier one that had already been saved).

## Root cause — race condition in the JS

1. User clicks Approve (a regular `<form method=\"post\">` submit button)
2. The browser blurs the currently-focused tier input → blur handler fires `save(el)`
3. `save()` is `async` and **isn't awaited** by the blur handler — the fetch goes out but the promise resolves later
4. The Approve form submits **synchronously**, the browser navigates to the redirect target, and the browser cancels the in-flight tier POST

This was true for **every** action button on the detail page (Approve, Reject, Delete, Reopen, Clone, Move up/down, Remove entry) — any one of them could race past pending autosaves.

## Fix

Capture-phase `submit` interceptor on `document`:

- Returns early (no-op) when nothing is dirty and no save is in flight — single-click feel preserved for clean boards
- Otherwise: `ev.preventDefault()`, kicks off saves for any dirty `.bb-autosave` inputs, awaits `Promise.allSettled(inFlight)`, then re-submits the form programmatically via `form.submit()` (which bypasses listeners, so a single navigation)
- An aria-live \"Saving changes…\" status appears next to the entries table during the flush

Tracking of in-flight saves uses a `Set` so concurrent blurs and submits coordinate correctly.

## Why no new tests

The race is JS-only; backend behavior is unchanged. The existing 23 big-board tests (route + service) still pass; verifying the race fix would require a browser harness that drives blur-then-click timing, which the repo doesn't have for these admin pages today. Manual repro path described in the test plan.

## Test plan

- [x] `make precommit` clean
- [x] `pytest tests/integration/test_admin_big_boards.py tests/integration/test_big_board_service.py -q` — 23 passed
- [ ] **Reviewer (manual)**: Reopen an APPROVED board, type tier values into 3+ rows in quick succession, click Approve **without tabbing out of the last input**. Confirm the board approves with all tiers persisted, and that you briefly see \"Saving changes…\" before the navigation.