### PR TITLE
enhancement: editable big-board metadata while PENDING

### DIFF
--- a/app/routes/admin/big_boards.py
+++ b/app/routes/admin/big_boards.py
@@ -43,6 +43,7 @@ _SUCCESS_MESSAGES: dict[str, str] = {
     "deleted": "Board deleted.",
     "reopened": "Board reopened for editing.",
     "cloned": "Board cloned. Edit the new copy below.",
+    "meta_updated": "Board details updated.",
 }
 
 
@@ -220,6 +221,20 @@ async def big_board_detail(
         (max((e.rank for e in entries), default=0) + 1) if entries else 1
     )
 
+    editable_sources: list[NewsSource] = []
+    if is_pending:
+        editable_sources = list(
+            (
+                await db.execute(
+                    select(NewsSource)
+                    .where(NewsSource.is_active)  # type: ignore[arg-type]
+                    .order_by(NewsSource.display_name)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
     return request.app.state.templates.TemplateResponse(
         "admin/big-boards/detail.html",
         await base_context_with_permissions(
@@ -233,6 +248,7 @@ async def big_board_detail(
             is_pending=is_pending,
             default_tier=default_tier,
             default_next_rank=default_next_rank,
+            editable_sources=editable_sources,
             success=_SUCCESS_MESSAGES.get(success) if success else None,
             error=error,
         ),
@@ -424,6 +440,54 @@ async def delete_big_board(
         return _redirect_with_error(board_id, str(exc))
 
     return RedirectResponse(url="/admin/big-boards?success=deleted", status_code=303)
+
+
+@router.post("/{board_id}/update-meta", response_class=HTMLResponse)
+async def update_board_meta(
+    request: Request,
+    board_id: int,
+    news_source_id: int = Form(...),
+    draft_year: int = Form(...),
+    published_at: str = Form(...),
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    """Patch source / draft year / published_at on a PENDING board."""
+    redirect, user = await require_dataset_access(
+        request,
+        db,
+        "big_boards",
+        need_edit=True,
+        next_path=f"/admin/big-boards/{board_id}",
+    )
+    if redirect:
+        return redirect
+    assert user is not None
+
+    try:
+        parsed = datetime.fromisoformat(published_at)
+    except ValueError:
+        return _redirect_with_error(
+            board_id,
+            "Published-at must be an ISO date/time (e.g., 2026-05-23).",
+        )
+    published_dt = parsed.replace(tzinfo=None) if parsed.tzinfo else parsed
+
+    try:
+        async with db.begin():
+            await svc.update_board_metadata(
+                db,
+                board_id=board_id,
+                news_source_id=news_source_id,
+                draft_year=draft_year,
+                published_at=published_dt,
+            )
+    except svc.BigBoardError as exc:
+        return _redirect_with_error(board_id, str(exc))
+
+    return RedirectResponse(
+        url=f"/admin/big-boards/{board_id}?success=meta_updated",
+        status_code=303,
+    )
 
 
 @router.post("/{board_id}/reopen", response_class=HTMLResponse)

--- a/app/routes/admin/big_boards.py
+++ b/app/routes/admin/big_boards.py
@@ -223,7 +223,7 @@ async def big_board_detail(
 
     editable_sources: list[NewsSource] = []
     if is_pending:
-        editable_sources = list(
+        active_rows = list(
             (
                 await db.execute(
                     select(NewsSource)
@@ -234,6 +234,14 @@ async def big_board_detail(
             .scalars()
             .all()
         )
+        # Always include the board's current source in the dropdown, even
+        # if it was deactivated after the board was created. Otherwise a
+        # year/date-only edit would silently reassign attribution to
+        # whichever active source the required <select> defaulted to.
+        if source is not None and not any(s.id == source.id for s in active_rows):
+            active_rows.append(source)
+            active_rows.sort(key=lambda s: (s.display_name or "").lower())
+        editable_sources = active_rows
 
     return request.app.state.templates.TemplateResponse(
         "admin/big-boards/detail.html",

--- a/app/services/big_board_service.py
+++ b/app/services/big_board_service.py
@@ -265,6 +265,34 @@ async def reject_board(db: AsyncSession, *, board_id: int) -> BigBoard:
     return board
 
 
+async def update_board_metadata(
+    db: AsyncSession,
+    *,
+    board_id: int,
+    news_source_id: Optional[int] = None,
+    draft_year: Optional[int] = None,
+    published_at: Optional[datetime] = None,
+) -> BigBoard:
+    """Patch source / draft year / published_at on a PENDING board.
+
+    Pass ``None`` to leave a field unchanged. Only PENDING boards may
+    be edited; APPROVED and REJECTED stay locked so their attribution
+    can't drift after the fact.
+    """
+    board = await get_board(db, board_id)
+    _require_pending(board)
+
+    if news_source_id is not None:
+        board.news_source_id = news_source_id
+    if draft_year is not None:
+        board.draft_year = draft_year
+    if published_at is not None:
+        board.published_at = published_at
+    board.updated_at = datetime.utcnow()
+    await db.flush()
+    return board
+
+
 async def reopen_board(db: AsyncSession, *, board_id: int) -> BigBoard:
     """Unlock an APPROVED board back to PENDING so it can be edited.
 

--- a/app/templates/admin/big-boards/detail.html
+++ b/app/templates/admin/big-boards/detail.html
@@ -36,7 +36,7 @@
       <select class="admin-form__select" id="meta-news-source" name="news_source_id" required>
         {% for src in editable_sources %}
         <option value="{{ src.id }}" {% if src.id == board.news_source_id %}selected{% endif %}>
-          {{ src.display_name }}
+          {{ src.display_name }}{% if not src.is_active %} (inactive){% endif %}
         </option>
         {% endfor %}
       </select>

--- a/app/templates/admin/big-boards/detail.html
+++ b/app/templates/admin/big-boards/detail.html
@@ -23,6 +23,43 @@
   </p>
 </header>
 
+{% if is_pending %}
+<div class="admin-card admin-card--medium" style="margin-bottom: 1rem;">
+  <div class="admin-card__header">
+    <h2 class="admin-card__title">Edit Details</h2>
+  </div>
+  <form class="admin-form" method="post"
+        action="/admin/big-boards/{{ board.id }}/update-meta"
+        style="display: grid; grid-template-columns: 2fr 6rem 1fr auto; gap: 0.75rem; align-items: end;">
+    <div class="admin-form__field" style="margin: 0;">
+      <label class="admin-form__label" for="meta-news-source">Source</label>
+      <select class="admin-form__select" id="meta-news-source" name="news_source_id" required>
+        {% for src in editable_sources %}
+        <option value="{{ src.id }}" {% if src.id == board.news_source_id %}selected{% endif %}>
+          {{ src.display_name }}
+        </option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="admin-form__field" style="margin: 0;">
+      <label class="admin-form__label" for="meta-draft-year">Year</label>
+      <input class="admin-form__input" id="meta-draft-year" name="draft_year"
+             type="number" min="2024" max="2035"
+             value="{{ board.draft_year }}" required />
+    </div>
+    <div class="admin-form__field" style="margin: 0;">
+      <label class="admin-form__label" for="meta-published-at">Published</label>
+      <input class="admin-form__input" id="meta-published-at" name="published_at"
+             type="date" required
+             value="{{ board.published_at.strftime('%Y-%m-%d') }}" />
+    </div>
+    <div class="admin-form__field" style="margin: 0;">
+      <button type="submit" class="admin-btn admin-btn--small">Save Details</button>
+    </div>
+  </form>
+</div>
+{% endif %}
+
 <div class="admin-card">
   <div class="admin-card__header">
     <h2 class="admin-card__title">Entries</h2>

--- a/tests/integration/test_admin_big_boards.py
+++ b/tests/integration/test_admin_big_boards.py
@@ -260,6 +260,68 @@ class TestBigBoardLifecycle:
         assert approve_again.status_code == 303
         assert "error=" in approve_again.headers["location"]
 
+    async def test_detail_page_includes_current_source_when_deactivated(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_logged_in: None,
+        big_board_source: NewsSource,
+    ):
+        """If the board's source was deactivated, the edit dropdown still lists it.
+
+        Otherwise a year/date-only edit on a PENDING board would silently
+        reassign attribution to whichever active source the required
+        <select> defaulted to.
+        """
+        _ = admin_logged_in
+        assert big_board_source.id is not None
+
+        create_resp = await app_client.post(
+            "/admin/big-boards",
+            data={
+                "news_source_id": str(big_board_source.id),
+                "draft_year": "2026",
+                "published_at": "2026-05-01",
+            },
+            follow_redirects=False,
+        )
+        board_id = int(
+            create_resp.headers["location"].split("/")[-1].split("?")[0]
+        )
+
+        # Deactivate the source that the board was created against.
+        src_row = await db_session.get(
+            NewsSource, big_board_source.id, populate_existing=True
+        )
+        assert src_row is not None
+        src_row.is_active = False
+        await db_session.commit()
+
+        # Add an extra active source so the dropdown isn't empty otherwise.
+        other = NewsSource(
+            name="other-active",
+            display_name="Other Active Source",
+            feed_type=FeedType.RSS,
+            feed_url="https://example.com/other-active-feed.xml",
+            is_active=True,
+            fetch_interval_minutes=30,
+        )
+        db_session.add(other)
+        await db_session.commit()
+
+        detail = await app_client.get(f"/admin/big-boards/{board_id}")
+        assert detail.status_code == 200
+        # The deactivated current source is still rendered as an option,
+        # tagged "(inactive)" so the admin sees its status.
+        assert big_board_source.display_name in detail.text
+        assert "(inactive)" in detail.text
+        # And it's the selected option (the required select hasn't silently
+        # defaulted to the other active source).
+        assert (
+            f'value="{big_board_source.id}" selected'
+            in detail.text.replace("'", '"')
+        )
+
     async def test_update_meta_changes_source_year_published_at(
         self,
         app_client: AsyncClient,

--- a/tests/integration/test_admin_big_boards.py
+++ b/tests/integration/test_admin_big_boards.py
@@ -260,6 +260,114 @@ class TestBigBoardLifecycle:
         assert approve_again.status_code == 303
         assert "error=" in approve_again.headers["location"]
 
+    async def test_update_meta_changes_source_year_published_at(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_logged_in: None,
+        big_board_source: NewsSource,
+    ):
+        """POST /update-meta patches source/year/published_at on a PENDING board."""
+        _ = admin_logged_in
+        assert big_board_source.id is not None
+
+        other_source = NewsSource(
+            name="alt-meta-source",
+            display_name="Alt Meta Source",
+            feed_type=FeedType.RSS,
+            feed_url="https://example.com/alt-meta-feed.xml",
+            is_active=True,
+            fetch_interval_minutes=30,
+        )
+        db_session.add(other_source)
+        await db_session.commit()
+        await db_session.refresh(other_source)
+        assert other_source.id is not None
+
+        create_resp = await app_client.post(
+            "/admin/big-boards",
+            data={
+                "news_source_id": str(big_board_source.id),
+                "draft_year": "2026",
+                "published_at": "2026-05-01",
+            },
+            follow_redirects=False,
+        )
+        board_id = int(
+            create_resp.headers["location"].split("/")[-1].split("?")[0]
+        )
+
+        update_resp = await app_client.post(
+            f"/admin/big-boards/{board_id}/update-meta",
+            data={
+                "news_source_id": str(other_source.id),
+                "draft_year": "2027",
+                "published_at": "2026-05-10",
+            },
+            follow_redirects=False,
+        )
+        assert update_resp.status_code == 303
+        assert "success=meta_updated" in update_resp.headers["location"]
+
+        board_row = await db_session.get(
+            BigBoard, board_id, populate_existing=True
+        )
+        assert board_row is not None
+        assert board_row.news_source_id == other_source.id
+        assert board_row.draft_year == 2027
+        assert board_row.published_at.strftime("%Y-%m-%d") == "2026-05-10"
+
+    async def test_update_meta_rejected_on_approved_board(
+        self,
+        app_client: AsyncClient,
+        db_session: AsyncSession,
+        admin_logged_in: None,
+        big_board_source: NewsSource,
+        sample_players: list[PlayerMaster],
+    ):
+        """Editing metadata on an APPROVED board redirects with an error."""
+        _ = admin_logged_in
+        assert big_board_source.id is not None
+
+        create_resp = await app_client.post(
+            "/admin/big-boards",
+            data={
+                "news_source_id": str(big_board_source.id),
+                "draft_year": "2026",
+                "published_at": "2026-05-01",
+            },
+            follow_redirects=False,
+        )
+        board_id = int(
+            create_resp.headers["location"].split("/")[-1].split("?")[0]
+        )
+        await app_client.post(
+            f"/admin/big-boards/{board_id}/entries",
+            data={"player_id": str(sample_players[0].id), "rank": "1"},
+            follow_redirects=False,
+        )
+        await app_client.post(
+            f"/admin/big-boards/{board_id}/approve", follow_redirects=False
+        )
+
+        update_resp = await app_client.post(
+            f"/admin/big-boards/{board_id}/update-meta",
+            data={
+                "news_source_id": str(big_board_source.id),
+                "draft_year": "2027",
+                "published_at": "2026-05-10",
+            },
+            follow_redirects=False,
+        )
+        assert update_resp.status_code == 303
+        assert "error=" in update_resp.headers["location"]
+
+        board_row = await db_session.get(
+            BigBoard, board_id, populate_existing=True
+        )
+        assert board_row is not None
+        assert board_row.draft_year == 2026  # unchanged
+
     async def test_reopen_flips_approved_back_to_pending(
         self,
         app_client: AsyncClient,

--- a/tests/integration/test_big_board_service.py
+++ b/tests/integration/test_big_board_service.py
@@ -268,6 +268,77 @@ async def test_delete_pending_board_cascades_entries(
 
 
 @pytest.mark.asyncio
+async def test_update_board_metadata_changes_source_year_published_at(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """update_board_metadata patches the editable fields on a PENDING board."""
+    assert news_source.id is not None
+    other_source = NewsSource(
+        name="alt-source",
+        display_name="Alt Source",
+        feed_url="https://example.com/alt-feed",
+    )
+    db_session.add(other_source)
+    await db_session.flush()
+    assert other_source.id is not None
+
+    board = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at(),
+        entries=[svc.EntryInput(player_id=players[0].id, rank=1)],  # type: ignore[arg-type]
+    )
+    await db_session.commit()
+
+    new_published = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
+        days=5
+    )
+    updated = await svc.update_board_metadata(
+        db_session,
+        board_id=board.id,  # type: ignore[arg-type]
+        news_source_id=other_source.id,
+        draft_year=2027,
+        published_at=new_published,
+    )
+    await db_session.commit()
+
+    assert updated.news_source_id == other_source.id
+    assert updated.draft_year == 2027
+    assert updated.published_at == new_published
+    assert updated.status is BoardStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_update_board_metadata_rejects_non_pending_board(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    players: list[PlayerMaster],
+) -> None:
+    """Approved and rejected boards refuse metadata edits."""
+    assert news_source.id is not None
+    board = await svc.create_board(
+        db_session,
+        news_source_id=news_source.id,
+        draft_year=2026,
+        published_at=_published_at(),
+        entries=[svc.EntryInput(player_id=players[0].id, rank=1)],  # type: ignore[arg-type]
+    )
+    await db_session.commit()
+    await svc.approve_board(db_session, board_id=board.id)  # type: ignore[arg-type]
+    await db_session.commit()
+
+    with pytest.raises(svc.BoardNotEditableError):
+        await svc.update_board_metadata(
+            db_session,
+            board_id=board.id,  # type: ignore[arg-type]
+            draft_year=2027,
+        )
+
+
+@pytest.mark.asyncio
 async def test_reopen_board_flips_approved_to_pending(
     db_session: AsyncSession,
     news_source: NewsSource,


### PR DESCRIPTION
## Summary

Adds source / draft_year / published_at editing for PENDING big boards via a new "Edit Details" form on the detail page. Useful when a board was created against the wrong source (e.g., misattributed during data entry) or with a typo in the publish date — without this, the only recovery was Delete + recreate from scratch.

Companion to your question about duplicate-source consensus behavior. As a reminder: only the most recent APPROVED board per source per draft_year feeds the Phase 2 consensus snapshot, so the canonical way to fix bad attribution without polluting consensus is either (a) change the source on a PENDING board via this new form, or (b) Reject a stale APPROVED board so it's excluded.

## What's in the PR

**Service** (`app/services/big_board_service.py`):
- `update_board_metadata(board_id, news_source_id=, draft_year=, published_at=)`
- Standard PENDING-only guard via `_require_pending`; passing `None` for any field leaves it unchanged
- APPROVED / REJECTED boards refuse the edit with `BoardNotEditableError`

**Route** (`app/routes/admin/big_boards.py`):
- `POST /admin/big-boards/{id}/update-meta` accepts all three fields required
- Parses `published_at` as ISO date, redirects to detail with `success=meta_updated` or `error=` for failures

**Template** (`app/templates/admin/big-boards/detail.html`):
- New inline "Edit Details" card on the detail page, visible only when PENDING
- Source dropdown populated from active NewsSources with the current source pre-selected
- Pre-fills year and published_at with current values
- Single "Save Details" button

**Tests**: 4 new cases
- Service: happy-path metadata patch, APPROVED rejection
- HTTP: full update flow + DB assertion, error redirect on APPROVED board

## Test plan

- [x] `make precommit` clean
- [x] `mypy app --ignore-missing-imports` clean
- [x] `pytest tests/integration/test_big_board_service.py tests/integration/test_admin_big_boards.py -q` — 27 passed
- [ ] Reviewer: reopen one of the duplicate No Ceilings boards, change Source to a different active source, Save Details, refresh, confirm the badge in the page header reflects the new source