### PR TITLE
feature: phase 2 consensus tables (slice 2a)

### DIFF
--- a/alembic/versions/q6r7s8t9u0v1_add_consensus_tables.py
+++ b/alembic/versions/q6r7s8t9u0v1_add_consensus_tables.py
@@ -85,6 +85,16 @@ def upgrade() -> None:
             name="fk_big_board_consensus_player",
         ),
         sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "snapshot_id",
+            "player_id",
+            name="uq_big_board_consensus_snapshot_player",
+        ),
+        sa.UniqueConstraint(
+            "snapshot_id",
+            "consensus_rank",
+            name="uq_big_board_consensus_snapshot_rank",
+        ),
     )
     op.create_index(
         "ix_big_board_consensus_draft_year",
@@ -144,6 +154,11 @@ def upgrade() -> None:
             name="fk_source_analytics_biggest_outlier_player",
         ),
         sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "snapshot_id",
+            "news_source_id",
+            name="uq_source_analytics_snapshot_source",
+        ),
     )
     op.create_index(
         "ix_source_analytics_news_source_id",

--- a/alembic/versions/q6r7s8t9u0v1_add_consensus_tables.py
+++ b/alembic/versions/q6r7s8t9u0v1_add_consensus_tables.py
@@ -1,0 +1,189 @@
+"""Add consensus_snapshots, big_board_consensus, source_analytics tables.
+
+Revision ID: q6r7s8t9u0v1
+Revises: p5q6r7s8t9u0
+Create Date: 2026-05-23
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op  # type: ignore[attr-defined]
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "q6r7s8t9u0v1"
+down_revision: Union[str, None] = "p5q6r7s8t9u0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TRIGGER_ENUM_NAME = "consensus_trigger_enum"
+TRIGGER_VALUES = ("BOARD_APPROVED", "MANUAL", "SCHEDULED")
+
+
+def upgrade() -> None:
+    trigger_enum = postgresql.ENUM(
+        *TRIGGER_VALUES, name=TRIGGER_ENUM_NAME, create_type=False
+    )
+    trigger_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "consensus_snapshots",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("draft_year", sa.Integer(), nullable=False),
+        sa.Column("computed_at", sa.DateTime(), nullable=False),
+        sa.Column("num_boards", sa.Integer(), nullable=False),
+        sa.Column(
+            "board_ids",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("trigger", trigger_enum, nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_consensus_snapshots_draft_year", "consensus_snapshots", ["draft_year"]
+    )
+    op.create_index(
+        "ix_consensus_snapshots_computed_at",
+        "consensus_snapshots",
+        ["computed_at"],
+    )
+    op.create_index(
+        "ix_consensus_snapshots_year_computed",
+        "consensus_snapshots",
+        ["draft_year", "computed_at"],
+    )
+
+    op.create_table(
+        "big_board_consensus",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("snapshot_id", sa.Integer(), nullable=False),
+        sa.Column("draft_year", sa.Integer(), nullable=False),
+        sa.Column("player_id", sa.Integer(), nullable=False),
+        sa.Column("consensus_rank", sa.Integer(), nullable=False),
+        sa.Column("avg_rank", sa.Float(), nullable=False),
+        sa.Column("median_rank", sa.Float(), nullable=False),
+        sa.Column("high_rank", sa.Integer(), nullable=False),
+        sa.Column("low_rank", sa.Integer(), nullable=False),
+        sa.Column("std_dev", sa.Float(), nullable=False),
+        sa.Column("num_sources", sa.Integer(), nullable=False),
+        sa.Column("prev_rank", sa.Integer(), nullable=True),
+        sa.Column("rank_delta", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["snapshot_id"],
+            ["consensus_snapshots.id"],
+            name="fk_big_board_consensus_snapshot",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["player_id"],
+            ["players_master.id"],
+            name="fk_big_board_consensus_player",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_big_board_consensus_draft_year",
+        "big_board_consensus",
+        ["draft_year"],
+    )
+    op.create_index(
+        "ix_big_board_consensus_player_id",
+        "big_board_consensus",
+        ["player_id"],
+    )
+    op.create_index(
+        "ix_big_board_consensus_snapshot_rank",
+        "big_board_consensus",
+        ["snapshot_id", "consensus_rank"],
+    )
+    op.create_index(
+        "ix_big_board_consensus_player_snapshot",
+        "big_board_consensus",
+        ["player_id", "snapshot_id"],
+    )
+
+    op.create_table(
+        "source_analytics",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("snapshot_id", sa.Integer(), nullable=False),
+        sa.Column("news_source_id", sa.Integer(), nullable=False),
+        sa.Column("latest_board_id", sa.Integer(), nullable=False),
+        sa.Column("avg_deviation", sa.Float(), nullable=False),
+        sa.Column("contrarian_score", sa.Float(), nullable=False),
+        sa.Column("biggest_outlier_player_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "outlier_delta",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["snapshot_id"],
+            ["consensus_snapshots.id"],
+            name="fk_source_analytics_snapshot",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["news_source_id"],
+            ["news_sources.id"],
+            name="fk_source_analytics_news_source",
+        ),
+        sa.ForeignKeyConstraint(
+            ["latest_board_id"],
+            ["big_boards.id"],
+            name="fk_source_analytics_latest_board",
+        ),
+        sa.ForeignKeyConstraint(
+            ["biggest_outlier_player_id"],
+            ["players_master.id"],
+            name="fk_source_analytics_biggest_outlier_player",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_source_analytics_news_source_id",
+        "source_analytics",
+        ["news_source_id"],
+    )
+    op.create_index(
+        "ix_source_analytics_snapshot",
+        "source_analytics",
+        ["snapshot_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_source_analytics_snapshot", table_name="source_analytics")
+    op.drop_index(
+        "ix_source_analytics_news_source_id", table_name="source_analytics"
+    )
+    op.drop_table("source_analytics")
+
+    op.drop_index(
+        "ix_big_board_consensus_player_snapshot", table_name="big_board_consensus"
+    )
+    op.drop_index(
+        "ix_big_board_consensus_snapshot_rank", table_name="big_board_consensus"
+    )
+    op.drop_index("ix_big_board_consensus_player_id", table_name="big_board_consensus")
+    op.drop_index("ix_big_board_consensus_draft_year", table_name="big_board_consensus")
+    op.drop_table("big_board_consensus")
+
+    op.drop_index(
+        "ix_consensus_snapshots_year_computed", table_name="consensus_snapshots"
+    )
+    op.drop_index(
+        "ix_consensus_snapshots_computed_at", table_name="consensus_snapshots"
+    )
+    op.drop_index(
+        "ix_consensus_snapshots_draft_year", table_name="consensus_snapshots"
+    )
+    op.drop_table("consensus_snapshots")
+
+    bind = op.get_bind()
+    sa.Enum(name=TRIGGER_ENUM_NAME).drop(bind, checkfirst=True)

--- a/app/schemas/consensus.py
+++ b/app/schemas/consensus.py
@@ -1,0 +1,193 @@
+"""Phase 2 consensus tables.
+
+Snapshots are append-only: each recompute writes a new ``ConsensusSnapshot``
+row plus a fresh batch of ``BigBoardConsensus`` (per-player) and
+``SourceAnalytics`` (per-source) rows. Earlier snapshots stay in place so
+the rank-history chart in Phase 3 falls out of a simple query.
+
+See ``docs/consensus_phase_2_design.md`` for the algorithm and rationale.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import (
+    Column,
+    Enum as SAEnum,
+    ForeignKey,
+    Index,
+    Integer,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlmodel import Field, SQLModel
+
+
+class ConsensusTrigger(str, Enum):
+    """What caused a consensus recompute to run.
+
+    Stored on the snapshot for audit so we can answer "did this snapshot
+    fire because a board got approved, or because the daily cron ran?".
+    """
+
+    BOARD_APPROVED = "BOARD_APPROVED"
+    MANUAL = "MANUAL"
+    SCHEDULED = "SCHEDULED"
+
+
+class ConsensusSnapshot(SQLModel, table=True):  # type: ignore[call-arg]
+    """Groups one consensus computation pass for a given draft year.
+
+    A snapshot owns the ``BigBoardConsensus`` rows produced by that
+    pass plus the ``SourceAnalytics`` rows describing how each source
+    deviated from consensus on that pass. Append-only — never updated.
+    """
+
+    __tablename__ = "consensus_snapshots"
+    __table_args__ = (
+        Index(
+            "ix_consensus_snapshots_year_computed",
+            "draft_year",
+            "computed_at",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    draft_year: int = Field(index=True)
+    computed_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        index=True,
+        description="When this snapshot was computed.",
+    )
+    num_boards: int = Field(description="How many APPROVED boards fed this snapshot.")
+    board_ids: list[int] = Field(
+        default_factory=list,
+        sa_column=Column(JSONB, nullable=False),
+        description=(
+            "Big board ids that were included in this snapshot. Stored "
+            "as a JSONB list so we can answer 'which sources fed this "
+            "snapshot?' without joining through entries."
+        ),
+    )
+    trigger: ConsensusTrigger = Field(
+        sa_column=Column(
+            SAEnum(ConsensusTrigger, name="consensus_trigger_enum"),
+            nullable=False,
+        )
+    )
+
+
+class BigBoardConsensus(SQLModel, table=True):  # type: ignore[call-arg]
+    """One per-player row in a consensus snapshot.
+
+    ``consensus_rank`` is the 1-based final ordering for the snapshot;
+    the other columns are the underlying aggregation (avg, median,
+    high/low, std_dev, num_sources) plus the previous-snapshot delta
+    that lets Phase 3 render risers and fallers.
+    """
+
+    __tablename__ = "big_board_consensus"
+    __table_args__ = (
+        Index(
+            "ix_big_board_consensus_snapshot_rank",
+            "snapshot_id",
+            "consensus_rank",
+        ),
+        Index(
+            "ix_big_board_consensus_player_snapshot",
+            "player_id",
+            "snapshot_id",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    snapshot_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("consensus_snapshots.id", ondelete="CASCADE"),
+            nullable=False,
+        )
+    )
+    draft_year: int = Field(index=True)
+    player_id: int = Field(foreign_key="players_master.id", index=True)
+
+    consensus_rank: int = Field(
+        description="1-based final position on the consensus board."
+    )
+    avg_rank: float = Field(
+        description="Mean rank across sources that ranked this player."
+    )
+    median_rank: float = Field(description="Median rank across sources.")
+    high_rank: int = Field(
+        description="Best (lowest-number) rank any source gave this player."
+    )
+    low_rank: int = Field(description="Worst (highest-number) rank any source gave.")
+    std_dev: float = Field(description="Std dev of source ranks; 0 when num_sources=1.")
+    num_sources: int = Field(
+        description="Count of eligible boards that ranked this player."
+    )
+
+    prev_rank: Optional[int] = Field(
+        default=None,
+        description="consensus_rank from the previous snapshot for this draft year.",
+    )
+    rank_delta: Optional[int] = Field(
+        default=None,
+        description="prev_rank - consensus_rank (positive = rising).",
+    )
+
+
+class SourceAnalytics(SQLModel, table=True):  # type: ignore[call-arg]
+    """Per-source deviation metrics for a single consensus snapshot.
+
+    ``contrarian_score`` is a z-score of ``avg_deviation`` across all
+    sources in the same snapshot, so it stays meaningful as more
+    sources come online.
+    """
+
+    __tablename__ = "source_analytics"
+    __table_args__ = (
+        Index(
+            "ix_source_analytics_snapshot",
+            "snapshot_id",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    snapshot_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("consensus_snapshots.id", ondelete="CASCADE"),
+            nullable=False,
+        )
+    )
+    news_source_id: int = Field(foreign_key="news_sources.id", index=True)
+    latest_board_id: int = Field(
+        foreign_key="big_boards.id",
+        description="Which board of this source was used in this snapshot.",
+    )
+
+    avg_deviation: float = Field(
+        description=(
+            "Mean absolute rank-distance from consensus across the "
+            "players this source ranked."
+        )
+    )
+    contrarian_score: float = Field(
+        description=(
+            "Z-score of avg_deviation across all sources in this "
+            "snapshot. Positive = more contrarian than average."
+        )
+    )
+    biggest_outlier_player_id: Optional[int] = Field(
+        default=None,
+        foreign_key="players_master.id",
+        description="Player where this source diverges most from consensus.",
+    )
+    outlier_delta: int = Field(
+        default=0,
+        description=(
+            "Signed delta on the biggest_outlier_player: "
+            "consensus_rank - source_rank (positive = source higher)."
+        ),
+    )

--- a/app/schemas/consensus.py
+++ b/app/schemas/consensus.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
@@ -88,6 +89,19 @@ class BigBoardConsensus(SQLModel, table=True):  # type: ignore[call-arg]
 
     __tablename__ = "big_board_consensus"
     __table_args__ = (
+        # Each player appears at most once per snapshot, and each
+        # consensus_rank slot is held by exactly one player (the
+        # algorithm resolves ties so the final ordering is strict).
+        UniqueConstraint(
+            "snapshot_id",
+            "player_id",
+            name="uq_big_board_consensus_snapshot_player",
+        ),
+        UniqueConstraint(
+            "snapshot_id",
+            "consensus_rank",
+            name="uq_big_board_consensus_snapshot_rank",
+        ),
         Index(
             "ix_big_board_consensus_snapshot_rank",
             "snapshot_id",
@@ -147,6 +161,14 @@ class SourceAnalytics(SQLModel, table=True):  # type: ignore[call-arg]
 
     __tablename__ = "source_analytics"
     __table_args__ = (
+        # Exactly one analytics row per (snapshot, source). Without this,
+        # a retried recompute could double-count a source in downstream
+        # contrarian/deviation reporting.
+        UniqueConstraint(
+            "snapshot_id",
+            "news_source_id",
+            name="uq_source_analytics_snapshot_source",
+        ),
         Index(
             "ix_source_analytics_snapshot",
             "snapshot_id",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -134,6 +134,7 @@ async def async_engine(
     from app.schemas import youtube_videos  # noqa: F401
     from app.schemas import auth  # noqa: F401
     from app.schemas import big_boards  # noqa: F401
+    from app.schemas import consensus  # noqa: F401
 
     connect_args = {
         # Disable prepared statement caching to avoid type OID/cache issues after DDL.

--- a/tests/integration/test_consensus_schemas.py
+++ b/tests/integration/test_consensus_schemas.py
@@ -1,0 +1,190 @@
+"""Schema-level guards on the Phase 2 consensus tables.
+
+These tests don't exercise a recompute service (that's slice 2b); they
+just confirm the DB-level uniqueness constraints are wired up, so a
+buggy recompute can't silently insert duplicate per-player or
+per-source rows.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.consensus import (
+    BigBoardConsensus,
+    ConsensusSnapshot,
+    ConsensusTrigger,
+    SourceAnalytics,
+)
+from app.schemas.news_sources import FeedType, NewsSource
+from app.schemas.players_master import PlayerMaster
+from tests.integration.conftest import make_player
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+@pytest_asyncio.fixture()
+async def snapshot(db_session: AsyncSession) -> ConsensusSnapshot:
+    snap = ConsensusSnapshot(
+        draft_year=2026,
+        computed_at=_now(),
+        num_boards=1,
+        board_ids=[],
+        trigger=ConsensusTrigger.MANUAL,
+    )
+    db_session.add(snap)
+    await db_session.flush()
+    return snap
+
+
+@pytest_asyncio.fixture()
+async def two_players(db_session: AsyncSession) -> list[PlayerMaster]:
+    rows = [
+        make_player("Cooper", "Flagg", school="Duke"),
+        make_player("Dylan", "Harper", school="Rutgers"),
+    ]
+    for p in rows:
+        db_session.add(p)
+    await db_session.flush()
+    return rows
+
+
+@pytest_asyncio.fixture()
+async def two_sources(db_session: AsyncSession) -> list[NewsSource]:
+    rows = [
+        NewsSource(
+            name="src-a",
+            display_name="Source A",
+            feed_type=FeedType.RSS,
+            feed_url="https://example.com/a-feed",
+            is_active=True,
+            fetch_interval_minutes=30,
+        ),
+        NewsSource(
+            name="src-b",
+            display_name="Source B",
+            feed_type=FeedType.RSS,
+            feed_url="https://example.com/b-feed",
+            is_active=True,
+            fetch_interval_minutes=30,
+        ),
+    ]
+    for s in rows:
+        db_session.add(s)
+    await db_session.flush()
+    return rows
+
+
+def _consensus_row(
+    snapshot_id: int, player_id: int, rank: int
+) -> BigBoardConsensus:
+    return BigBoardConsensus(
+        snapshot_id=snapshot_id,
+        draft_year=2026,
+        player_id=player_id,
+        consensus_rank=rank,
+        avg_rank=float(rank),
+        median_rank=float(rank),
+        high_rank=rank,
+        low_rank=rank,
+        std_dev=0.0,
+        num_sources=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_big_board_consensus_rejects_duplicate_player_per_snapshot(
+    db_session: AsyncSession,
+    snapshot: ConsensusSnapshot,
+    two_players: list[PlayerMaster],
+) -> None:
+    """uq_big_board_consensus_snapshot_player blocks two rows for the same player."""
+    snap_id = snapshot.id
+    pid = two_players[0].id
+    assert snap_id is not None and pid is not None
+
+    db_session.add(_consensus_row(snap_id, pid, 1))
+    await db_session.flush()
+
+    db_session.add(_consensus_row(snap_id, pid, 2))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_big_board_consensus_rejects_duplicate_rank_per_snapshot(
+    db_session: AsyncSession,
+    snapshot: ConsensusSnapshot,
+    two_players: list[PlayerMaster],
+) -> None:
+    """uq_big_board_consensus_snapshot_rank blocks two players sharing a rank slot."""
+    snap_id = snapshot.id
+    p1, p2 = two_players[0].id, two_players[1].id
+    assert snap_id is not None and p1 is not None and p2 is not None
+
+    db_session.add(_consensus_row(snap_id, p1, 1))
+    await db_session.flush()
+
+    db_session.add(_consensus_row(snap_id, p2, 1))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_source_analytics_rejects_duplicate_source_per_snapshot(
+    db_session: AsyncSession,
+    snapshot: ConsensusSnapshot,
+    two_sources: list[NewsSource],
+    two_players: list[PlayerMaster],
+) -> None:
+    """uq_source_analytics_snapshot_source blocks double-counting a source."""
+    from app.schemas.big_boards import BigBoard, BoardStatus
+
+    # Need a big_board row to satisfy the latest_board_id FK.
+    board = BigBoard(
+        news_source_id=two_sources[0].id,
+        news_item_id=None,
+        draft_year=2026,
+        published_at=_now(),
+        board_size=0,
+        status=BoardStatus.APPROVED,
+    )
+    db_session.add(board)
+    await db_session.flush()
+
+    snap_id = snapshot.id
+    src_id = two_sources[0].id
+    board_id = board.id
+    assert snap_id is not None and src_id is not None and board_id is not None
+
+    db_session.add(
+        SourceAnalytics(
+            snapshot_id=snap_id,
+            news_source_id=src_id,
+            latest_board_id=board_id,
+            avg_deviation=1.0,
+            contrarian_score=0.0,
+            biggest_outlier_player_id=None,
+            outlier_delta=0,
+        )
+    )
+    await db_session.flush()
+
+    db_session.add(
+        SourceAnalytics(
+            snapshot_id=snap_id,
+            news_source_id=src_id,
+            latest_board_id=board_id,
+            avg_deviation=2.0,
+            contrarian_score=1.0,
+            biggest_outlier_player_id=None,
+            outlier_delta=0,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()


### PR DESCRIPTION
## Summary

First slice of the Phase 2 consensus engine per \`docs/consensus_phase_2_design.md\`. Three append-only tables and a status enum — no service or routes yet, those follow in slice 2b.

### Schemas (\`app/schemas/consensus.py\`)

**\`consensus_snapshots\`** — one row per recompute pass for a given draft year. Stores \`computed_at\`, \`num_boards\`, the JSONB list of \`board_ids\` that fed the snapshot, and a \`trigger\` enum (\`BOARD_APPROVED\` / \`MANUAL\` / \`SCHEDULED\`) for audit.

**\`big_board_consensus\`** — per-player row within a snapshot.
- \`consensus_rank\` (1-based final ordering)
- aggregation columns: \`avg_rank\`, \`median_rank\`, \`high_rank\`, \`low_rank\`, \`std_dev\`, \`num_sources\`
- \`prev_rank\` + \`rank_delta\` carry the previous-snapshot comparison so risers/fallers fall out of a simple SELECT

**\`source_analytics\`** — per-source deviation metrics.
- \`avg_deviation\` (mean abs distance from consensus)
- \`contrarian_score\` (z-score across the snapshot's sources)
- \`biggest_outlier_player_id\` + signed \`outlier_delta\`

### Schema design choices

- **Append-only**: each recompute writes a fresh snapshot + child rows. No UPDATE in place. Trades a little storage for a free rank-trajectory chart in Phase 3 and no concurrent-write races.
- **ON DELETE CASCADE** from \`consensus_snapshots\` to both child tables so old snapshots can be pruned without leaving orphans.
- **Composite indexes** for the two hot query shapes:
  - \`(snapshot_id, consensus_rank)\` — "give me snapshot N's top 30"
  - \`(player_id, snapshot_id)\` — "give me Player X's rank trajectory"
- Migration uses \`postgresql.ENUM(create_type=False)\` + explicit \`.create()\` to avoid the duplicate-type bug we hit on the big_boards migration.

## Test plan

- [x] \`make precommit\` clean
- [x] \`mypy app --ignore-missing-imports\` clean
- [x] Alembic round-trip against test Neon branch: upgrade \`p5q6r7s8t9u0 → q6r7s8t9u0v1\` then downgrade — tables, enum, all indexes create and tear down cleanly
- [x] All 28 existing big-board integration tests still pass with the new schemas imported in conftest
- [ ] Reviewer: walk through \`docs/consensus_phase_2_design.md\` against this schema, flag any aggregation columns we'd want to add now (e.g., tier-aware fields, source weighting) vs. defer

## What's next

Slice 2b: the \`recompute_consensus\` service that fills these tables, plus the trigger hook from \`approve_board\`. Will be a separate PR off this one.