### PR TITLE
feature: add test coverage reporting via Codecov

### DIFF
--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -87,7 +87,15 @@ jobs:
         run: alembic upgrade head
 
       - name: Run tests
-        run: pytest -q --ignore=tests/visual
+        run: pytest -q --ignore=tests/visual --cov=app --cov-report=xml --cov-report=term
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          flags: tests-fork
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   tests-secrets:
     # Same-repo PRs: use environment secrets from draft-app-stage
@@ -170,4 +178,12 @@ jobs:
         run: alembic upgrade head
 
       - name: Run tests
-        run: pytest -q --ignore=tests/visual
+        run: pytest -q --ignore=tests/visual --cov=app --cov-report=xml --cov-report=term
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          flags: tests-secrets
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ bio.ingest:
 	$(PYTHON) scripts/ingest_player_bios.py --file $(BBIO) --cache-dir $(CACHE) $(if $(DRY),--dry-run,) $(if $(VERBOSE),--verbose,) $(if $(OVERWRITE_MASTER),--overwrite-master,) $(if $(CREATE_MISSING),--create-missing,) $(if $(FIX),--fix-ambiguities $(FIX),)
 
 # Lint & format
-.PHONY: fmt lint fix precommit test visual visual.headed
+.PHONY: fmt lint fix precommit test coverage visual visual.headed
 fmt:
 	ruff format .
 
@@ -136,6 +136,15 @@ precommit:
 # Run unit tests
 test:
 	pytest tests/unit -q
+
+# Run tests with coverage report (terminal + HTML)
+# Usage:
+#   make coverage              # unit + integration with terminal + HTML report
+#   make coverage TESTS=tests/unit  # narrower scope
+TESTS ?= tests/unit tests/integration
+coverage:
+	pytest $(TESTS) -q --cov=app --cov-report=term-missing --cov-report=html
+	@echo "HTML report: open htmlcov/index.html"
 
 # Run visual tests (requires server running on TEST_BASE_URL or localhost:8000)
 # Usage:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Draft Guru
 
+[![PR Tests](https://github.com/JonathanBechtel/draft-app/actions/workflows/run-tests-on-pr.yml/badge.svg?branch=main)](https://github.com/JonathanBechtel/draft-app/actions/workflows/run-tests-on-pr.yml)
+[![codecov](https://codecov.io/gh/JonathanBechtel/draft-app/branch/main/graph/badge.svg)](https://codecov.io/gh/JonathanBechtel/draft-app)
+
 FastAPI + SQLModel skeleton for a draft analytics app. Async DB access, clean startup/shutdown, and simple Players endpoints and complete Ci/Cd workflow.
 
 ## Quick Start

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  status:
+    project: off
+    patch: off
+
+  precision: 1
+  round: nearest
+  range: "60...90"
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "tests/**"
+  - "alembic/**"
+  - "scripts/**"
+  - "app/**/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 dev = [
     "pytest==8.4.2",
     "pytest-asyncio==1.2.0",
+    "pytest-cov==5.0.0",
     "httpx==0.28.1",
     "ruff==0.13.0",
     "mypy==1.18.1",
@@ -61,3 +62,22 @@ ignore = ["D100", "D101", "D102", "D103", "D104", "D105", "D106", "D107"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.coverage.run]
+source = ["app"]
+branch = true
+omit = [
+    "app/__init__.py",
+    "app/*/__init__.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+]
+show_missing = true
+skip_covered = false
+precision = 1


### PR DESCRIPTION
## Summary

Wires up test-coverage measurement into PR CI and adds a Codecov badge to the README. Report-only on PRs (no status-check enforcement) so we can establish a baseline before deciding on thresholds.

- **Coverage tool:** `pytest-cov` added to `[dev]` deps; configured via `[tool.coverage]` in `pyproject.toml` (source = `app/`, branch coverage on, sensible line/path excludes).
- **CI:** `pytest -q --ignore=tests/visual` now also emits `coverage.xml`; both `tests-fork` and `tests-secrets` jobs upload to Codecov via `codecov/codecov-action@v4`. Reads `CODECOV_TOKEN` from GitHub Actions secrets.
- **Local:** new `make coverage` target runs unit + integration with terminal + HTML output (`htmlcov/index.html`).
- **Codecov config:** `codecov.yml` disables `project` and `patch` status checks so PRs are never blocked by coverage; ignores `tests/`, `alembic/`, `scripts/`, `__init__.py`. Enables PR comment showing per-file diff.
- **README:** PR-tests + Codecov badges added at the top.

Local smoke test: unit tests alone hit 20.5% coverage. The full CI run (unit + integration via FastAPI/HTTPX) will be substantially higher.

## Prerequisite (already done by repo owner)

`CODECOV_TOKEN` secret has been added to the repo's GitHub Actions secrets. After this PR merges, the badge in the README will populate on the first push to `main`.

## Test plan

- [ ] CI green on this PR (both `tests-fork` and `tests-secrets` jobs)
- [ ] Codecov PR comment posts with coverage summary + per-file diff
- [ ] After merge, badge in README resolves and shows the coverage number
- [ ] Local: `make coverage` runs cleanly and emits `htmlcov/`

## Follow-ups (out of scope for this PR)

- Once we have a few weeks of data and know the typical coverage range, decide whether to flip on `project` / `patch` status checks in `codecov.yml` (currently both `off`).
- Could expand coverage to `scripts/` if those become long-lived rather than one-off jobs.