### PR TITLE
fix: let CI integration tests run against shared service-container DB

### DIFF
--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -42,6 +42,9 @@ jobs:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draftguru_test
       TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draftguru_test
       PYTEST_ALLOW_DB: "1"
+      # CI runs against an ephemeral service container, so DATABASE_URL and
+      # TEST_DATABASE_URL intentionally point at the same DB. Allow it.
+      PYTEST_ALLOW_TEST_DB_EQUALS_DATABASE_URL: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -125,6 +128,9 @@ jobs:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draftguru_test
       TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draftguru_test
       PYTEST_ALLOW_DB: "1"
+      # CI runs against an ephemeral service container, so DATABASE_URL and
+      # TEST_DATABASE_URL intentionally point at the same DB. Allow it.
+      PYTEST_ALLOW_TEST_DB_EQUALS_DATABASE_URL: "1"
       # SECRET_KEY may be provided by the environment; default to test if missing
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
     steps:


### PR DESCRIPTION
## Summary

Follow-up to #201 (coverage reporting). With coverage now visible, we noticed the CI run was reporting only **21.3%** because **350 of 605 tests were being skipped**.

## Root cause

`tests/integration/conftest.py:41-69` has a safety guard that skips when `TEST_DATABASE_URL` and `DATABASE_URL` resolve to the same Postgres instance. This protects against accidentally pointing tests at a real app DB in local/dev environments.

In CI, both env vars intentionally point at the same ephemeral service-container DB (see `.github/workflows/run-tests-on-pr.yml`). So the guard tripped on every CI run, the session-scoped `database_url` fixture skipped, and every integration test transitively dependent on it skipped — silently.

## Fix

Set `PYTEST_ALLOW_TEST_DB_EQUALS_DATABASE_URL=1` in both jobs. This is exactly the escape hatch the conftest provides for this situation. It's safe in CI because the "DB" is a fresh Postgres service container that gets torn down at the end of the run.

## Expected impact

- Test count: 255 passed → ~605 passed
- Coverage: 21.3% → likely 50–70% (the real number)
- CI runtime: slightly longer (more tests actually run)

## Test plan

- [ ] CI green; both `tests-fork` and `tests-secrets` jobs run all integration tests
- [ ] Codecov reports a substantially higher coverage number on this PR
- [ ] No tests fail that were previously passing