### PR TITLE
feature: consensus recompute service + approve_board hook (slice 2b)

### DIFF
--- a/app/services/big_board_service.py
+++ b/app/services/big_board_service.py
@@ -239,8 +239,20 @@ async def delete_board(db: AsyncSession, *, board_id: int) -> None:
     await db.flush()
 
 
-async def approve_board(db: AsyncSession, *, board_id: int) -> BigBoard:
-    """Transition a PENDING board to APPROVED and stamp ``approved_at``."""
+async def approve_board(
+    db: AsyncSession,
+    *,
+    board_id: int,
+    recompute_consensus: bool = True,
+) -> BigBoard:
+    """Transition a PENDING board to APPROVED and stamp ``approved_at``.
+
+    When ``recompute_consensus`` is True (the default), this also kicks
+    off a fresh consensus snapshot for the board's ``draft_year`` so
+    the rest of the app sees up-to-date rankings. The recompute shares
+    the caller's transaction — if it fails, the approval rolls back.
+    Tests/admin paths that don't want this side-effect can pass False.
+    """
     board = await get_board(db, board_id)
     _require_pending(board)
     now = datetime.utcnow()
@@ -248,6 +260,20 @@ async def approve_board(db: AsyncSession, *, board_id: int) -> BigBoard:
     board.approved_at = now
     board.updated_at = now
     await db.flush()
+
+    if recompute_consensus:
+        # Local import to avoid a top-of-module dependency cycle between
+        # big_board_service and consensus_service (consensus_service
+        # already imports the BigBoard schema).
+        from app.services.consensus_service import (
+            ConsensusTrigger,
+            recompute_consensus as _recompute,
+        )
+
+        await _recompute(
+            db, draft_year=board.draft_year, trigger=ConsensusTrigger.BOARD_APPROVED
+        )
+
     return board
 
 

--- a/app/services/consensus_service.py
+++ b/app/services/consensus_service.py
@@ -1,0 +1,389 @@
+"""Phase 2 consensus computation service.
+
+Aggregates the most recent APPROVED big board per source into a single
+ranked consensus board for a draft year, plus per-source deviation
+analytics. Append-only snapshots so rank trajectory falls out of a
+simple query in Phase 3.
+
+See ``docs/consensus_phase_2_design.md`` for the algorithm rationale.
+Tier values stored on big_board_entries are intentionally ignored in
+the aggregation — tier is admin-side transcription fidelity, not a
+consensus signal in v1.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.big_boards import BigBoard, BigBoardEntry, BoardStatus
+from app.schemas.consensus import (
+    BigBoardConsensus,
+    ConsensusSnapshot,
+    ConsensusTrigger,
+    SourceAnalytics,
+)
+
+
+# Players ranked by fewer than this many eligible boards are excluded
+# from the consensus output. Keeps a single contrarian source from
+# seeding fringe slots on the consensus board. Revisit this floor as
+# more sources come online (see docs/consensus_phase_2_design.md).
+MIN_SOURCES = 2
+
+
+@dataclass(frozen=True)
+class _PlayerAggregate:
+    """Intermediate per-player rollup before consensus_rank is assigned."""
+
+    player_id: int
+    ranks: list[int]
+    avg: float
+    median: float
+    high: int  # best rank any source gave (numerically smallest)
+    low: int  # worst rank any source gave
+    std_dev: float
+
+    @property
+    def num_sources(self) -> int:
+        return len(self.ranks)
+
+
+async def recompute_consensus(
+    db: AsyncSession,
+    *,
+    draft_year: int,
+    trigger: ConsensusTrigger,
+) -> ConsensusSnapshot:
+    """Run a full recompute for one draft year and persist a new snapshot.
+
+    Args:
+        db: Async session; caller owns the surrounding transaction.
+        draft_year: Year to aggregate APPROVED boards for.
+        trigger: What caused this recompute, stored on the snapshot.
+
+    Returns:
+        The newly-inserted ``ConsensusSnapshot``. Its ``id`` is
+        populated. Per-player and per-source rows are written before
+        return; query them via ``snapshot.id``.
+
+    Notes:
+        Eligible boards = the most recent APPROVED board per source for
+        the draft year. Earlier boards from the same source are not
+        counted (so a source that publishes weekly doesn't get extra
+        weight). ``MIN_SOURCES`` gates inclusion in the consensus
+        output, not in the analytics math (sources still get analytics
+        for any player they ranked, even if that player didn't clear
+        the floor).
+    """
+    eligible_boards = await _select_eligible_boards(db, draft_year=draft_year)
+
+    snapshot = ConsensusSnapshot(
+        draft_year=draft_year,
+        computed_at=datetime.utcnow(),
+        num_boards=len(eligible_boards),
+        board_ids=[b.id for b in eligible_boards if b.id is not None],
+        trigger=trigger,
+    )
+    db.add(snapshot)
+    await db.flush()
+    assert snapshot.id is not None
+
+    if not eligible_boards:
+        # Empty year: snapshot stands as an audit marker (num_boards=0)
+        # with no child rows. Callers can still query it.
+        return snapshot
+
+    # Gather all entries from eligible boards in a single query.
+    board_ids = [b.id for b in eligible_boards if b.id is not None]
+    entry_rows = (
+        await db.execute(
+            select(  # type: ignore[call-overload]
+                BigBoardEntry.board_id, BigBoardEntry.player_id, BigBoardEntry.rank
+            ).where(BigBoardEntry.board_id.in_(board_ids))  # type: ignore[attr-defined]
+        )
+    ).all()
+
+    # ranks_by_player: player_id -> list of (board_id, rank)
+    ranks_by_player: dict[int, list[tuple[int, int]]] = defaultdict(list)
+    for row in entry_rows:
+        ranks_by_player[row.player_id].append((row.board_id, row.rank))
+
+    aggregates = _build_aggregates(ranks_by_player)
+    included = [a for a in aggregates if a.num_sources >= MIN_SOURCES]
+    sorted_aggregates = sorted(included, key=_consensus_sort_key)
+
+    prev_ranks = await _previous_snapshot_ranks(
+        db, draft_year=draft_year, exclude_snapshot_id=snapshot.id
+    )
+
+    for consensus_rank, agg in enumerate(sorted_aggregates, start=1):
+        prev = prev_ranks.get(agg.player_id)
+        delta = (prev - consensus_rank) if prev is not None else None
+        db.add(
+            BigBoardConsensus(
+                snapshot_id=snapshot.id,
+                draft_year=draft_year,
+                player_id=agg.player_id,
+                consensus_rank=consensus_rank,
+                avg_rank=agg.avg,
+                median_rank=agg.median,
+                high_rank=agg.high,
+                low_rank=agg.low,
+                std_dev=agg.std_dev,
+                num_sources=agg.num_sources,
+                prev_rank=prev,
+                rank_delta=delta,
+            )
+        )
+    await db.flush()
+
+    await _write_source_analytics(
+        db,
+        snapshot_id=snapshot.id,
+        eligible_boards=eligible_boards,
+        ranks_by_player=ranks_by_player,
+        consensus_by_player={
+            a.player_id: i + 1 for i, a in enumerate(sorted_aggregates)
+        },
+    )
+    await db.flush()
+
+    return snapshot
+
+
+async def get_latest_consensus(
+    db: AsyncSession,
+    *,
+    draft_year: int,
+    limit: Optional[int] = None,
+) -> list[BigBoardConsensus]:
+    """Return the most recent snapshot's consensus rows ordered by rank."""
+    latest_snapshot_id = await db.scalar(
+        select(ConsensusSnapshot.id)  # type: ignore[call-overload]
+        .where(ConsensusSnapshot.draft_year == draft_year)  # type: ignore[arg-type]
+        .order_by(ConsensusSnapshot.computed_at.desc())  # type: ignore[attr-defined]
+        .limit(1)
+    )
+    if latest_snapshot_id is None:
+        return []
+    stmt = (
+        select(BigBoardConsensus)  # type: ignore[call-overload]
+        .where(BigBoardConsensus.snapshot_id == latest_snapshot_id)  # type: ignore[arg-type]
+        .order_by(BigBoardConsensus.consensus_rank)  # type: ignore[arg-type]
+    )
+    if limit is not None:
+        stmt = stmt.limit(limit)
+    rows = await db.execute(stmt)
+    return list(rows.scalars().all())
+
+
+async def get_player_rank_history(
+    db: AsyncSession,
+    *,
+    player_id: int,
+    draft_year: int,
+) -> list[BigBoardConsensus]:
+    """Return all snapshot rows for one player, oldest-first.
+
+    Feeds the Phase 3 trajectory chart on the player detail page.
+    """
+    rows = await db.execute(
+        select(BigBoardConsensus)  # type: ignore[call-overload]
+        .join(
+            ConsensusSnapshot,
+            ConsensusSnapshot.id == BigBoardConsensus.snapshot_id,  # type: ignore[arg-type]
+        )
+        .where(BigBoardConsensus.player_id == player_id)  # type: ignore[arg-type]
+        .where(BigBoardConsensus.draft_year == draft_year)  # type: ignore[arg-type]
+        .order_by(ConsensusSnapshot.computed_at)  # type: ignore[arg-type]
+    )
+    return list(rows.scalars().all())
+
+
+async def _select_eligible_boards(
+    db: AsyncSession, *, draft_year: int
+) -> list[BigBoard]:
+    """Return the most recent APPROVED board per source for the year."""
+    # Postgres DISTINCT ON (news_source_id) ORDER BY published_at DESC
+    # selects exactly one row per source — the most recent.
+    stmt = (
+        select(BigBoard)  # type: ignore[call-overload]
+        .where(BigBoard.status == BoardStatus.APPROVED)  # type: ignore[arg-type]
+        .where(BigBoard.draft_year == draft_year)  # type: ignore[arg-type]
+        .distinct(BigBoard.news_source_id)  # type: ignore[arg-type]
+        .order_by(BigBoard.news_source_id, BigBoard.published_at.desc())  # type: ignore[arg-type,attr-defined]
+    )
+    rows = await db.execute(stmt)
+    return list(rows.scalars().all())
+
+
+def _build_aggregates(
+    ranks_by_player: dict[int, list[tuple[int, int]]],
+) -> list[_PlayerAggregate]:
+    out: list[_PlayerAggregate] = []
+    for player_id, board_rank_pairs in ranks_by_player.items():
+        ranks = [r for _, r in board_rank_pairs]
+        std = statistics.stdev(ranks) if len(ranks) > 1 else 0.0
+        out.append(
+            _PlayerAggregate(
+                player_id=player_id,
+                ranks=ranks,
+                avg=statistics.mean(ranks),
+                median=statistics.median(ranks),
+                high=min(ranks),
+                low=max(ranks),
+                std_dev=std,
+            )
+        )
+    return out
+
+
+def _consensus_sort_key(agg: _PlayerAggregate) -> tuple[float, float, int, int]:
+    """Tie-breaker order: avg → median → high (best individual) → player_id.
+
+    player_id is the stable final key so two snapshots over identical
+    aggregate inputs produce identical orderings.
+    """
+    return (agg.avg, agg.median, agg.high, agg.player_id)
+
+
+async def _previous_snapshot_ranks(
+    db: AsyncSession,
+    *,
+    draft_year: int,
+    exclude_snapshot_id: int,
+) -> dict[int, int]:
+    """Return ``player_id -> consensus_rank`` from the prior snapshot.
+
+    Used to populate ``prev_rank`` and ``rank_delta`` so the
+    trajectory chart and rising/falling badges fall out of a simple
+    SELECT in Phase 3.
+    """
+    prior_id = await db.scalar(
+        select(ConsensusSnapshot.id)  # type: ignore[call-overload]
+        .where(ConsensusSnapshot.draft_year == draft_year)  # type: ignore[arg-type]
+        .where(ConsensusSnapshot.id != exclude_snapshot_id)  # type: ignore[arg-type]
+        .order_by(ConsensusSnapshot.computed_at.desc())  # type: ignore[attr-defined]
+        .limit(1)
+    )
+    if prior_id is None:
+        return {}
+    rows = await db.execute(
+        select(BigBoardConsensus.player_id, BigBoardConsensus.consensus_rank).where(  # type: ignore[call-overload]
+            BigBoardConsensus.snapshot_id == prior_id
+        )  # type: ignore[arg-type]
+    )
+    return {r.player_id: r.consensus_rank for r in rows.all()}
+
+
+async def _write_source_analytics(
+    db: AsyncSession,
+    *,
+    snapshot_id: int,
+    eligible_boards: list[BigBoard],
+    ranks_by_player: dict[int, list[tuple[int, int]]],
+    consensus_by_player: dict[int, int],
+) -> None:
+    """Write one SourceAnalytics row per eligible board in the snapshot.
+
+    avg_deviation only counts players that cleared MIN_SOURCES (i.e.,
+    players that are on the consensus output). Sources that ranked a
+    bunch of fringe one-source players don't get punished for them.
+    """
+    board_lookup = {b.id: b for b in eligible_boards if b.id is not None}
+
+    # Per-source: list of (player_id, source_rank, consensus_rank).
+    per_source: dict[int, list[tuple[int, int, int]]] = defaultdict(list)
+    for player_id, board_rank_pairs in ranks_by_player.items():
+        consensus_rank = consensus_by_player.get(player_id)
+        if consensus_rank is None:
+            continue  # player didn't clear MIN_SOURCES
+        for board_id, source_rank in board_rank_pairs:
+            board = board_lookup.get(board_id)
+            if board is None or board.news_source_id is None:
+                continue
+            per_source[board.news_source_id].append(
+                (player_id, source_rank, consensus_rank)
+            )
+
+    # First pass: compute avg_deviation + biggest_outlier per source.
+    raw_by_source: dict[int, tuple[float, int, Optional[int], int]] = {}
+    for source_id, triples in per_source.items():
+        deviations = [abs(src - cons) for _, src, cons in triples]
+        avg_dev = statistics.mean(deviations) if deviations else 0.0
+        # Biggest outlier: the player with the largest absolute distance.
+        # outlier_delta is consensus_rank - source_rank so positive means
+        # the source ranked the player higher (lower number) than consensus.
+        outlier_pid: Optional[int] = None
+        outlier_delta = 0
+        if triples:
+            outlier_player_id, outlier_src, outlier_cons = max(
+                triples, key=lambda t: abs(t[1] - t[2])
+            )
+            outlier_pid = outlier_player_id
+            outlier_delta = outlier_cons - outlier_src
+
+        latest_board_id = next(
+            (
+                b.id
+                for b in eligible_boards
+                if b.news_source_id == source_id and b.id is not None
+            ),
+            None,
+        )
+        if latest_board_id is None:
+            continue
+        raw_by_source[source_id] = (
+            avg_dev,
+            latest_board_id,
+            outlier_pid,
+            outlier_delta,
+        )
+
+    if not raw_by_source:
+        return
+
+    # Second pass: normalize avg_deviation into a contrarian z-score
+    # across the sources in this snapshot. Positive = more contrarian
+    # than the snapshot's average; zero when only one source is in play.
+    avgs = [tup[0] for tup in raw_by_source.values()]
+    mean_avg = statistics.mean(avgs)
+    stdev_avg = statistics.stdev(avgs) if len(avgs) > 1 else 0.0
+
+    for source_id, (
+        avg_dev,
+        latest_board_id,
+        outlier_pid,
+        outlier_delta,
+    ) in raw_by_source.items():
+        score = (avg_dev - mean_avg) / stdev_avg if stdev_avg > 0 else 0.0
+        db.add(
+            SourceAnalytics(
+                snapshot_id=snapshot_id,
+                news_source_id=source_id,
+                latest_board_id=latest_board_id,
+                avg_deviation=avg_dev,
+                contrarian_score=score,
+                biggest_outlier_player_id=outlier_pid,
+                outlier_delta=outlier_delta,
+            )
+        )
+
+
+async def delete_snapshot(db: AsyncSession, *, snapshot_id: int) -> None:
+    """Remove a snapshot and its child rows.
+
+    Useful for ops cleanup (e.g., pruning old snapshots). The FK
+    cascade handles the child rows, but the explicit DELETE here keeps
+    the audit trail consistent with what the service intends.
+    """
+    await db.execute(
+        delete(ConsensusSnapshot).where(ConsensusSnapshot.id == snapshot_id)  # type: ignore[arg-type]
+    )

--- a/app/services/consensus_service.py
+++ b/app/services/consensus_service.py
@@ -210,15 +210,27 @@ async def get_player_rank_history(
 async def _select_eligible_boards(
     db: AsyncSession, *, draft_year: int
 ) -> list[BigBoard]:
-    """Return the most recent APPROVED board per source for the year."""
-    # Postgres DISTINCT ON (news_source_id) ORDER BY published_at DESC
-    # selects exactly one row per source — the most recent.
+    """Return the most recent APPROVED board per source for the year.
+
+    Tie-breakers on identical ``published_at`` are deterministic so a
+    re-run over unchanged data produces the same eligible-board set
+    (and therefore the same consensus output and rank deltas):
+        1. published_at DESC  -- the actual recency signal
+        2. approved_at DESC   -- which board got approved later wins
+        3. id DESC            -- final stable break, in case of identical
+                                 approval timestamps from a batch import
+    """
     stmt = (
         select(BigBoard)  # type: ignore[call-overload]
         .where(BigBoard.status == BoardStatus.APPROVED)  # type: ignore[arg-type]
         .where(BigBoard.draft_year == draft_year)  # type: ignore[arg-type]
         .distinct(BigBoard.news_source_id)  # type: ignore[arg-type]
-        .order_by(BigBoard.news_source_id, BigBoard.published_at.desc())  # type: ignore[arg-type,attr-defined]
+        .order_by(
+            BigBoard.news_source_id,  # type: ignore[arg-type]
+            BigBoard.published_at.desc(),  # type: ignore[attr-defined]
+            BigBoard.approved_at.desc(),  # type: ignore[union-attr]
+            BigBoard.id.desc(),  # type: ignore[union-attr]
+        )
     )
     rows = await db.execute(stmt)
     return list(rows.scalars().all())
@@ -293,29 +305,55 @@ async def _write_source_analytics(
 ) -> None:
     """Write one SourceAnalytics row per eligible board in the snapshot.
 
-    avg_deviation only counts players that cleared MIN_SOURCES (i.e.,
-    players that are on the consensus output). Sources that ranked a
-    bunch of fringe one-source players don't get punished for them.
+    Every eligible source gets a row, even when MIN_SOURCES gates all
+    of its players out of the consensus (e.g., early in the season
+    when only one board is approved). In that case ``avg_deviation``
+    is 0.0 and ``biggest_outlier_player_id`` is NULL — the row stands
+    as a "we saw this source but had nothing to compare against"
+    marker so the per-source-per-snapshot invariant holds.
+
+    ``avg_deviation`` only counts players that cleared MIN_SOURCES so
+    sources aren't penalized for ranking fringe one-board players.
     """
     board_lookup = {b.id: b for b in eligible_boards if b.id is not None}
 
+    # Pre-build the per-source skeleton from eligible_boards so every
+    # eligible source ends up with a row, even if it has no players
+    # in the consensus output.
+    source_to_board: dict[int, int] = {}
+    for board in eligible_boards:
+        if board.id is None or board.news_source_id is None:
+            continue
+        # eligible_boards is one row per source already (DISTINCT ON),
+        # so the first hit is the only hit.
+        source_to_board.setdefault(board.news_source_id, board.id)
+
+    if not source_to_board:
+        return
+
     # Per-source: list of (player_id, source_rank, consensus_rank).
+    # Only triples for players that cleared MIN_SOURCES contribute to
+    # avg_deviation / biggest_outlier; absent sources still get a row
+    # downstream with avg_deviation=0.
     per_source: dict[int, list[tuple[int, int, int]]] = defaultdict(list)
     for player_id, board_rank_pairs in ranks_by_player.items():
         consensus_rank = consensus_by_player.get(player_id)
         if consensus_rank is None:
             continue  # player didn't clear MIN_SOURCES
         for board_id, source_rank in board_rank_pairs:
-            board = board_lookup.get(board_id)
-            if board is None or board.news_source_id is None:
+            entry_board = board_lookup.get(board_id)
+            if entry_board is None or entry_board.news_source_id is None:
                 continue
-            per_source[board.news_source_id].append(
+            per_source[entry_board.news_source_id].append(
                 (player_id, source_rank, consensus_rank)
             )
 
     # First pass: compute avg_deviation + biggest_outlier per source.
+    # Iterate over source_to_board so every eligible source is included,
+    # not just those that contributed to consensus.
     raw_by_source: dict[int, tuple[float, int, Optional[int], int]] = {}
-    for source_id, triples in per_source.items():
+    for source_id, latest_board_id in source_to_board.items():
+        triples = per_source.get(source_id, [])
         deviations = [abs(src - cons) for _, src, cons in triples]
         avg_dev = statistics.mean(deviations) if deviations else 0.0
         # Biggest outlier: the player with the largest absolute distance.
@@ -330,16 +368,6 @@ async def _write_source_analytics(
             outlier_pid = outlier_player_id
             outlier_delta = outlier_cons - outlier_src
 
-        latest_board_id = next(
-            (
-                b.id
-                for b in eligible_boards
-                if b.news_source_id == source_id and b.id is not None
-            ),
-            None,
-        )
-        if latest_board_id is None:
-            continue
         raw_by_source[source_id] = (
             avg_dev,
             latest_board_id,
@@ -347,14 +375,12 @@ async def _write_source_analytics(
             outlier_delta,
         )
 
-    if not raw_by_source:
-        return
-
     # Second pass: normalize avg_deviation into a contrarian z-score
     # across the sources in this snapshot. Positive = more contrarian
-    # than the snapshot's average; zero when only one source is in play.
+    # than the snapshot's average; zero when only one source is in play
+    # or every source has the same (often zero) deviation.
     avgs = [tup[0] for tup in raw_by_source.values()]
-    mean_avg = statistics.mean(avgs)
+    mean_avg = statistics.mean(avgs) if avgs else 0.0
     stdev_avg = statistics.stdev(avgs) if len(avgs) > 1 else 0.0
 
     for source_id, (

--- a/tests/integration/test_consensus_service.py
+++ b/tests/integration/test_consensus_service.py
@@ -332,6 +332,107 @@ async def test_source_analytics_computes_deviation_and_contrarian_score(
 
 
 @pytest.mark.asyncio
+async def test_single_source_still_gets_source_analytics_row(
+    db_session: AsyncSession,
+    players: list[PlayerMaster],
+    three_sources: list[NewsSource],
+) -> None:
+    """With only one approved board, no player clears MIN_SOURCES=2 — but
+    the eligible source still gets a SourceAnalytics row so the
+    per-source-per-snapshot invariant holds."""
+    p1, p2, _p3, _p4 = players
+    s1, _s2, _s3 = three_sources
+    await _make_approved_board(
+        db_session,
+        source=s1,
+        draft_year=2026,
+        published_at=_now(),
+        entries=[(p1, 1), (p2, 2)],
+    )
+    await db_session.commit()
+
+    snap = await svc.recompute_consensus(
+        db_session, draft_year=2026, trigger=ConsensusTrigger.MANUAL
+    )
+    await db_session.commit()
+    assert snap.num_boards == 1
+
+    # Consensus is empty (MIN_SOURCES=2 not met).
+    consensus = await svc.get_latest_consensus(db_session, draft_year=2026)
+    assert consensus == []
+
+    # But the SourceAnalytics row still exists.
+    rows = (
+        await db_session.execute(
+            select(SourceAnalytics).where(SourceAnalytics.snapshot_id == snap.id)  # type: ignore[arg-type]
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.news_source_id == s1.id
+    assert row.avg_deviation == 0.0
+    assert row.contrarian_score == 0.0
+    assert row.biggest_outlier_player_id is None
+
+
+@pytest.mark.asyncio
+async def test_eligible_board_selection_is_deterministic_with_id_tiebreak(
+    db_session: AsyncSession,
+    players: list[PlayerMaster],
+    three_sources: list[NewsSource],
+) -> None:
+    """When two boards from one source share published_at, the higher-id
+    (later-inserted) board wins reproducibly. Without the id tie-break a
+    re-run could pick either one and produce different consensus."""
+    p1, p2, _p3, _p4 = players
+    s1, s2, _s3 = three_sources
+    same_dt = _now()
+
+    older = await _make_approved_board(
+        db_session,
+        source=s1,
+        draft_year=2026,
+        published_at=same_dt,
+        entries=[(p1, 1), (p2, 2)],
+    )
+    newer = await _make_approved_board(
+        db_session,
+        source=s1,
+        draft_year=2026,
+        published_at=same_dt,
+        entries=[(p2, 1), (p1, 2)],  # flipped order
+    )
+    # Second source so MIN_SOURCES=2 lets the players appear on consensus.
+    await _make_approved_board(
+        db_session,
+        source=s2,
+        draft_year=2026,
+        published_at=same_dt,
+        entries=[(p1, 1), (p2, 2)],
+    )
+    await db_session.commit()
+    assert older.id is not None and newer.id is not None
+    assert newer.id > older.id
+
+    # Recompute twice; both should pick the higher-id board.
+    snap_a = await svc.recompute_consensus(
+        db_session, draft_year=2026, trigger=ConsensusTrigger.MANUAL
+    )
+    await db_session.commit()
+    snap_b = await svc.recompute_consensus(
+        db_session, draft_year=2026, trigger=ConsensusTrigger.MANUAL
+    )
+    await db_session.commit()
+
+    assert newer.id in snap_a.board_ids
+    assert older.id not in snap_a.board_ids
+    assert newer.id in snap_b.board_ids
+    assert older.id not in snap_b.board_ids
+    # Same eligible board set across runs.
+    assert sorted(snap_a.board_ids) == sorted(snap_b.board_ids)
+
+
+@pytest.mark.asyncio
 async def test_empty_year_writes_snapshot_with_zero_boards(
     db_session: AsyncSession,
 ) -> None:

--- a/tests/integration/test_consensus_service.py
+++ b/tests/integration/test_consensus_service.py
@@ -1,0 +1,484 @@
+"""Integration tests for the Phase 2 consensus computation service.
+
+Exercises:
+- recompute_consensus happy path with multiple sources and overlapping
+  / non-overlapping players
+- the MIN_SOURCES floor (players ranked by only 1 source are excluded)
+- prev_rank / rank_delta against a prior snapshot
+- per-source analytics (avg_deviation, contrarian z-score, biggest outlier)
+- tie-breakers (avg → median → high_rank → player_id) give a stable order
+- read paths (get_latest_consensus, get_player_rank_history)
+- approve_board hook fires a recompute by default
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.big_boards import BigBoard, BigBoardEntry, BoardStatus
+from app.schemas.consensus import (
+    BigBoardConsensus,
+    ConsensusSnapshot,
+    ConsensusTrigger,
+    SourceAnalytics,
+)
+from app.schemas.news_sources import FeedType, NewsSource
+from app.schemas.players_master import PlayerMaster
+from app.services import big_board_service as bb_svc
+from app.services import consensus_service as svc
+from tests.integration.conftest import make_player
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+async def _make_source(
+    db: AsyncSession, name: str, display: str | None = None
+) -> NewsSource:
+    src = NewsSource(
+        name=name,
+        display_name=display or name,
+        feed_type=FeedType.RSS,
+        feed_url=f"https://example.com/{name}/feed.xml",
+        is_active=True,
+        fetch_interval_minutes=30,
+    )
+    db.add(src)
+    await db.flush()
+    return src
+
+
+async def _make_approved_board(
+    db: AsyncSession,
+    *,
+    source: NewsSource,
+    draft_year: int,
+    published_at: datetime,
+    entries: list[tuple[PlayerMaster, int]],  # (player, rank)
+) -> BigBoard:
+    """Insert a board straight into APPROVED state without running the
+    full create→approve flow (which would trigger a consensus recompute
+    and complicate test setup)."""
+    assert source.id is not None
+    board = BigBoard(
+        news_source_id=source.id,
+        news_item_id=None,
+        draft_year=draft_year,
+        published_at=published_at,
+        board_size=len(entries),
+        status=BoardStatus.APPROVED,
+        approved_at=_now(),
+    )
+    db.add(board)
+    await db.flush()
+    assert board.id is not None
+    for player, rank in entries:
+        assert player.id is not None
+        db.add(
+            BigBoardEntry(
+                board_id=board.id,
+                player_id=player.id,
+                rank=rank,
+            )
+        )
+    await db.flush()
+    return board
+
+
+@pytest_asyncio.fixture()
+async def players(db_session: AsyncSession) -> list[PlayerMaster]:
+    rows = [
+        make_player("Cooper", "Flagg", school="Duke"),
+        make_player("Dylan", "Harper", school="Rutgers"),
+        make_player("Ace", "Bailey", school="Rutgers"),
+        make_player("VJ", "Edgecombe", school="Baylor"),
+    ]
+    for p in rows:
+        db_session.add(p)
+    await db_session.flush()
+    return rows
+
+
+@pytest_asyncio.fixture()
+async def three_sources(db_session: AsyncSession) -> list[NewsSource]:
+    return [
+        await _make_source(db_session, f"src-{i}", display=f"Source {i}")
+        for i in range(1, 4)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_recompute_aggregates_across_sources(
+    db_session: AsyncSession,
+    players: list[PlayerMaster],
+    three_sources: list[NewsSource],
+) -> None:
+    """Three boards rank the same four players differently; consensus picks the average."""
+    # Source 1 ranks 1,2,3,4
+    # Source 2 ranks 2,1,4,3
+    # Source 3 ranks 1,3,2,4
+    p1, p2, p3, p4 = players
+    s1, s2, s3 = three_sources
+    today = _now()
+    await _make_approved_board(
+        db_session,
+        source=s1,
+        draft_year=2026,
+        published_at=today - timedelta(days=2),
+        entries=[(p1, 1), (p2, 2), (p3, 3), (p4, 4)],
+    )
+    await _make_approved_board(
+        db_session,
+        source=s2,
+        draft_year=2026,
+        published_at=today - timedelta(days=1),
+        entries=[(p2, 1), (p1, 2), (p4, 3), (p3, 4)],
+    )
+    await _make_approved_board(
+        db_session,
+        source=s3,
+        draft_year=2026,
+        published_at=today,
+        entries=[(p1, 1), (p3, 2), (p2, 3), (p4, 4)],
+    )
+    await db_session.commit()
+
+    snap = await svc.recompute_consensus(
+        db_session, draft_year=2026, trigger=ConsensusTrigger.MANUAL
+    )
+    await db_session.commit()
+    assert snap.num_boards == 3
+
+    consensus = await svc.get_latest_consensus(db_session, draft_year=2026)
+    assert [c.player_id for c in consensus] == [p1.id, p2.id, p3.id, p4.id]
+    assert all(c.num_sources == 3 for c in consensus)
+
+    by_player = {c.player_id: c for c in consensus}
+    assert p1.id is not None
+    p1_row = by_player[p1.id]
+    assert pytest.approx(p1_row.avg_rank) == 4 / 3  # (1+2+1)/3
+    assert p1_row.high_rank == 1
+    assert p1_row.low_rank == 2
+
+
+@pytest.mark.asyncio
+async def test_min_sources_floor_excludes_solo_picks(
+    db_session: AsyncSession,
+    players: list[PlayerMaster],
+    three_sources: list[NewsSource],
+) -> None:
+    """A player ranked by only one source is excluded from the consensus output."""
+    p1, p2, p3, _p4 = players
+    s1, s2, _s3 = three_sources
+    today = _now()
+    # Two sources cover p1 + p2; only s1 ranks p3.
+    await _make_approved_board(
+        db_session,
+        source=s1,
+        draft_year=2026,
+        published_at=today - timedelta(days=1),
+        entries=[(p1, 1), (p2, 2), (p3, 3)],
+    )
+    await _make_approved_board(
+        db_session,
+        source=s2,
+        draft_year=2026,
+        published_at=today,
+        entries=[(p1, 1), (p2, 2)],
+    )
+    await db_session.commit()
+
+    await svc.recompute_consensus(
+        db_session, draft_year=2026, trigger=ConsensusTrigger.MANUAL
+    )
+    await db_session.commit()
+
+    consensus = await svc.get_latest_consensus(db_session, draft_year=2026)
+    assert {c.player_id for c in consensus} == {p1.id, p2.id}
+    # p3 was on only one board so didn't clear MIN_SOURCES=2.
+
+
+@pytest.mark.asyncio
+async def test_prev_rank_and_rank_delta_from_prior_snapshot(
+    db_session: AsyncSession,
+    players: list[PlayerMaster],
+    three_sources: list[NewsSource],
+) -> None:
+    """A second recompute populates prev_rank and rank_delta from the first."""
+    p1, p2, _p3, _p4 = players
+    s1, s2, _s3 = three_sources
+    today = _now()
+
+    # First state: s1 + s2 both rank p1 #1, p2 #2.
+    board_s1 = await _make_approved_board(
+        db_session,
+        source=s1,
+        draft_year=2026,
+        published_at=today - timedelta(days=5),
+        entries=[(p1, 1), (p2, 2)],
+    )
+    await _make_approved_board(
+        db_session,
+        source=s2,
+        draft_year=2026,
+        published_at=today - timedelta(days=4),
+        entries=[(p1, 1), (p2, 2)],
+    )
+    await db_session.commit()
+    snap1 = await svc.recompute_consensus(
+        db_session, draft_year=2026, trigger=ConsensusTrigger.MANUAL
+    )
+    await db_session.commit()
+    snap1_id = snap1.id
+
+    # s1 publishes a new board flipping p1 and p2.
+    board_s1.id  # touch
+    await _make_approved_board(
+        db_session,
+        source=s1,
+        draft_year=2026,
+        published_at=today,  # newer than the first s1 board
+        entries=[(p2, 1), (p1, 2)],
+    )
+    await db_session.commit()
+    snap2 = await svc.recompute_consensus(
+        db_session, draft_year=2026, trigger=ConsensusTrigger.MANUAL
+    )
+    await db_session.commit()
+    assert snap2.id != snap1_id
+
+    consensus = await svc.get_latest_consensus(db_session, draft_year=2026)
+    by_player = {c.player_id: c for c in consensus}
+    assert p1.id is not None and p2.id is not None
+    p1_id, p2_id = p1.id, p2.id
+
+    # After s1 flips, the avg ranks tie at 1.5 each; tie-breaker
+    # (median → high_rank → player_id) gives the lower player_id the top slot.
+    expected_top = min(p1_id, p2_id)
+    assert by_player[expected_top].consensus_rank == 1
+
+    # prev_rank should come from snap1, where p1 was #1 and p2 was #2.
+    assert by_player[p1_id].prev_rank == 1
+    assert by_player[p2_id].prev_rank == 2
+    # rank_delta = prev_rank - consensus_rank (positive = rising).
+    for pid in (p1_id, p2_id):
+        c = by_player[pid]
+        assert c.prev_rank is not None
+        assert c.rank_delta == (c.prev_rank - c.consensus_rank)
+
+
+@pytest.mark.asyncio
+async def test_source_analytics_computes_deviation_and_contrarian_score(
+    db_session: AsyncSession,
+    players: list[PlayerMaster],
+    three_sources: list[NewsSource],
+) -> None:
+    """Each source gets one analytics row per snapshot; z-scores are normalized across the snapshot."""
+    p1, p2, p3, p4 = players
+    s1, s2, s3 = three_sources
+    today = _now()
+
+    # s1 + s3 agree closely; s2 is the contrarian (flips top 2).
+    await _make_approved_board(
+        db_session,
+        source=s1,
+        draft_year=2026,
+        published_at=today - timedelta(days=2),
+        entries=[(p1, 1), (p2, 2), (p3, 3), (p4, 4)],
+    )
+    await _make_approved_board(
+        db_session,
+        source=s2,
+        draft_year=2026,
+        published_at=today - timedelta(days=1),
+        entries=[(p4, 1), (p3, 2), (p2, 3), (p1, 4)],
+    )
+    await _make_approved_board(
+        db_session,
+        source=s3,
+        draft_year=2026,
+        published_at=today,
+        entries=[(p1, 1), (p2, 2), (p3, 3), (p4, 4)],
+    )
+    await db_session.commit()
+    snap = await svc.recompute_consensus(
+        db_session, draft_year=2026, trigger=ConsensusTrigger.MANUAL
+    )
+    await db_session.commit()
+
+    rows = (
+        await db_session.execute(
+            select(SourceAnalytics).where(SourceAnalytics.snapshot_id == snap.id)  # type: ignore[arg-type]
+        )
+    ).scalars().all()
+    assert len(rows) == 3
+    by_source = {r.news_source_id: r for r in rows}
+    assert s1.id is not None and s2.id is not None and s3.id is not None
+    s1_id, s2_id, s3_id = s1.id, s2.id, s3.id
+
+    # s2 should have the highest avg_deviation (it flipped the order).
+    s2_dev = by_source[s2_id].avg_deviation
+    other_devs = [by_source[s1_id].avg_deviation, by_source[s3_id].avg_deviation]
+    assert s2_dev > max(other_devs)
+    # And the highest contrarian score (positive z-score).
+    assert by_source[s2_id].contrarian_score > 0
+    assert by_source[s1_id].contrarian_score < 0
+
+
+@pytest.mark.asyncio
+async def test_empty_year_writes_snapshot_with_zero_boards(
+    db_session: AsyncSession,
+) -> None:
+    """No APPROVED boards yet → still get a snapshot row (audit marker)."""
+    snap = await svc.recompute_consensus(
+        db_session, draft_year=2099, trigger=ConsensusTrigger.MANUAL
+    )
+    await db_session.commit()
+    assert snap.num_boards == 0
+    assert snap.board_ids == []
+    consensus = await svc.get_latest_consensus(db_session, draft_year=2099)
+    assert consensus == []
+
+
+@pytest.mark.asyncio
+async def test_player_rank_history_returns_oldest_first(
+    db_session: AsyncSession,
+    players: list[PlayerMaster],
+    three_sources: list[NewsSource],
+) -> None:
+    """get_player_rank_history orders snapshots chronologically."""
+    p1, p2, _p3, _p4 = players
+    s1, s2, _s3 = three_sources
+    today = _now()
+    await _make_approved_board(
+        db_session,
+        source=s1,
+        draft_year=2026,
+        published_at=today - timedelta(days=10),
+        entries=[(p1, 1), (p2, 2)],
+    )
+    await _make_approved_board(
+        db_session,
+        source=s2,
+        draft_year=2026,
+        published_at=today - timedelta(days=9),
+        entries=[(p1, 1), (p2, 2)],
+    )
+    await db_session.commit()
+    await svc.recompute_consensus(
+        db_session, draft_year=2026, trigger=ConsensusTrigger.MANUAL
+    )
+    await db_session.commit()
+    await svc.recompute_consensus(
+        db_session, draft_year=2026, trigger=ConsensusTrigger.SCHEDULED
+    )
+    await db_session.commit()
+
+    assert p1.id is not None
+    history = await svc.get_player_rank_history(
+        db_session, player_id=p1.id, draft_year=2026
+    )
+    assert len(history) == 2
+    # snap row.consensus_rank should be 1 across both passes.
+    assert all(c.consensus_rank == 1 for c in history)
+
+
+@pytest.mark.asyncio
+async def test_approve_board_triggers_recompute_by_default(
+    db_session: AsyncSession,
+    players: list[PlayerMaster],
+    three_sources: list[NewsSource],
+) -> None:
+    """approve_board writes a fresh ConsensusSnapshot unless explicitly disabled."""
+    p1, p2, _p3, _p4 = players
+    s1, s2, _s3 = three_sources
+    today = _now()
+
+    # Seed two boards. We'll approve the second through the service so
+    # the hook can fire on its trigger.
+    await _make_approved_board(
+        db_session,
+        source=s1,
+        draft_year=2026,
+        published_at=today - timedelta(days=1),
+        entries=[(p1, 1), (p2, 2)],
+    )
+
+    pending = BigBoard(
+        news_source_id=s2.id,
+        news_item_id=None,
+        draft_year=2026,
+        published_at=today,
+        board_size=2,
+        status=BoardStatus.PENDING,
+    )
+    db_session.add(pending)
+    await db_session.flush()
+    assert pending.id is not None
+    db_session.add(BigBoardEntry(board_id=pending.id, player_id=p1.id, rank=1))
+    db_session.add(BigBoardEntry(board_id=pending.id, player_id=p2.id, rank=2))
+    await db_session.commit()
+
+    snapshots_before = (
+        await db_session.execute(select(ConsensusSnapshot))
+    ).scalars().all()
+    assert snapshots_before == []
+
+    await bb_svc.approve_board(db_session, board_id=pending.id)
+    await db_session.commit()
+
+    snapshots_after = (
+        await db_session.execute(select(ConsensusSnapshot))
+    ).scalars().all()
+    assert len(snapshots_after) == 1
+    assert snapshots_after[0].trigger is ConsensusTrigger.BOARD_APPROVED
+    assert snapshots_after[0].num_boards == 2
+
+    # And the consensus rows actually got written.
+    rows = (
+        await db_session.execute(
+            select(BigBoardConsensus).where(
+                BigBoardConsensus.snapshot_id == snapshots_after[0].id  # type: ignore[arg-type]
+            )
+        )
+    ).scalars().all()
+    assert {r.player_id for r in rows} == {p1.id, p2.id}
+
+
+@pytest.mark.asyncio
+async def test_approve_board_can_skip_recompute(
+    db_session: AsyncSession,
+    players: list[PlayerMaster],
+    three_sources: list[NewsSource],
+) -> None:
+    """approve_board(recompute_consensus=False) is the escape hatch for tests / batch ops."""
+    p1, _p2, _p3, _p4 = players
+    s1, _s2, _s3 = three_sources
+    pending = BigBoard(
+        news_source_id=s1.id,
+        news_item_id=None,
+        draft_year=2026,
+        published_at=_now(),
+        board_size=1,
+        status=BoardStatus.PENDING,
+    )
+    db_session.add(pending)
+    await db_session.flush()
+    assert pending.id is not None
+    db_session.add(BigBoardEntry(board_id=pending.id, player_id=p1.id, rank=1))
+    await db_session.commit()
+
+    await bb_svc.approve_board(
+        db_session, board_id=pending.id, recompute_consensus=False
+    )
+    await db_session.commit()
+    snapshots = (
+        await db_session.execute(select(ConsensusSnapshot))
+    ).scalars().all()
+    assert snapshots == []


### PR DESCRIPTION
## Summary

Second slice of Phase 2: the service that fills the consensus tables landed in #200, plus the trigger hook that fires it from \`big_board_service.approve_board\`. With this, approving a big board automatically produces a fresh consensus snapshot for the year.

### Service (\`app/services/consensus_service.py\`)

**\`recompute_consensus(db, draft_year, trigger)\`** — full aggregation pass:
- Picks the most recent APPROVED board per source (DISTINCT ON \`news_source_id\` ORDER BY \`published_at DESC\`)
- Aggregates ranks per player: avg / median / high / low / std_dev / num_sources
- Applies \`MIN_SOURCES = 2\` floor (module constant; revisit at 5+ sources)
- Assigns \`consensus_rank\` with tie-breakers **avg → median → high_rank → player_id** so the ordering is deterministic
- Populates \`prev_rank\` / \`rank_delta\` from the previous snapshot for the same draft_year (so Phase 3's risers/fallers fall out of a simple SELECT)
- Writes per-source analytics: \`avg_deviation\`, z-scored \`contrarian_score\`, \`biggest_outlier_player_id\` + signed \`outlier_delta\`

**Tier is intentionally ignored in aggregation** per the decision recorded with you — admin-side transcription fidelity, not a consensus signal in v1.

**\`get_latest_consensus\`** and **\`get_player_rank_history\`** are the read paths Phase 3 will use.

### Hook (\`big_board_service.approve_board\`)

Gains \`recompute_consensus: bool = True\`. When True, \`approve_board\` triggers a fresh snapshot with \`trigger=BOARD_APPROVED\`, sharing the caller's transaction — if recompute fails, the approval rolls back. Tests / batch ops can opt out with \`recompute_consensus=False\`. Local import inside the function avoids a top-of-module cycle with \`consensus_service\`.

### Tests (\`tests/integration/test_consensus_service.py\`)

8 new cases:
- Aggregation across 3 sources with overlapping rosters
- MIN_SOURCES floor excludes solo picks
- prev_rank / rank_delta from a prior snapshot
- Per-source analytics math (deviation, contrarian z-score, biggest outlier)
- Empty-year snapshot still written as audit marker
- get_player_rank_history ordering
- approve_board hook fires by default
- approve_board(recompute_consensus=False) is the escape hatch

All 39 big-board + consensus integration tests pass (14 service + 9 admin + 3 schema + 8 new + 5 from prior PRs).

### Sanity check against real data

Ran \`recompute_consensus\` against dev (the 3 seeded prod boards). Numbers match the earlier readiness-query exactly:
- #1 Darryn Peterson avg=2.00
- #2 AJ Dybantsa avg=2.33
- #3 Cameron Boozer avg=2.67
- #4 Caleb Wilson avg=3.00

Source analytics correctly flag **Draft Stack** as the most contrarian (z=+1.15) vs **Prospects & Concepts** (z=-0.67). Tie-breakers active: Acuff (median=5) outranks Flemings (median=6) at #5 despite identical avg=6.00.

## Test plan

- [x] \`make precommit\` clean
- [x] \`mypy app --ignore-missing-imports\` clean (130 source files)
- [x] \`pytest tests/integration/test_consensus_service.py tests/integration/test_big_board_service.py tests/integration/test_admin_big_boards.py tests/integration/test_consensus_schemas.py -q\` — 39 passed
- [ ] Reviewer: walk through \`consensus_service.recompute_consensus\` vs \`docs/consensus_phase_2_design.md\` — flag any aggregation columns or tie-breaker rules that don't match what we agreed
- [ ] Reviewer: react to the MIN_SOURCES=2 constant — whether to make it a per-snapshot column now or wait

## What's next (Slice 2c / 2d)

- **2c**: Admin "Recompute now" button + simple \`/admin/consensus\` page showing the latest snapshot
- **2d**: Daily cron via Fly's release schedule as a safety-net trigger

Both can be smaller follow-up PRs once this lands.