### PR TITLE
feature: AI extraction service for big boards (closes #211)

### DIFF
--- a/app/services/board_extraction_service.py
+++ b/app/services/board_extraction_service.py
@@ -1,0 +1,577 @@
+"""AI-powered board extraction service.
+
+Takes a ``NewsItem`` (tagged BIG_BOARD), fetches the full article page
+(RSS descriptions are too short for a 30+ entry ranking list), passes
+the cleaned article text to Gemini for structured extraction, resolves
+player names to ``players_master`` ids, and persists a PENDING ``Board``
+via ``board_service``.
+
+This is the only path that programmatically creates boards from
+unstructured analyst content. Admin-curated boards bypass this module
+entirely; consensus computation runs only after a human approves
+whatever lands here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import unicodedata
+from datetime import datetime
+from typing import Optional, Protocol
+
+import httpx
+from bs4 import BeautifulSoup
+from google import genai
+from google.genai import types
+from pydantic import BaseModel, Field, ValidationError
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.schemas.boards import Board, BoardKind, BoardStatus
+from app.schemas.news_items import NewsItem
+from app.schemas.player_aliases import PlayerAlias
+from app.schemas.players_master import PlayerMaster
+from app.services import board_service
+
+logger = logging.getLogger(__name__)
+
+_PAGE_FETCH_TIMEOUT = httpx.Timeout(connect=5.0, read=20.0, write=5.0, pool=5.0)
+_PAGE_FETCH_HEADERS = {
+    "User-Agent": "DraftGuru/1.0 (+https://draftguru.dev; board-extraction)",
+}
+_GEMINI_TIMEOUT_SECONDS = 60
+_GEMINI_MODEL = "gemini-3-flash-preview"
+
+# Cap input to Gemini at ~30k chars (~7.5k tokens). Substack articles
+# rarely exceed this; if they do, we lose tail entries gracefully rather
+# than blowing the model's context window.
+_MAX_ARTICLE_CHARS = 30_000
+
+# CSS selectors tried in order to find the main article body. Substack's
+# markup has changed over the years; the first match wins.
+_SUBSTACK_BODY_SELECTORS = (
+    "div.body.markup",
+    "div.single-post-container div.body",
+    "div.markup",
+    "article",
+    "div.main-content",
+    "main",
+)
+
+
+class BoardExtractionError(Exception):
+    """Raised when extraction cannot proceed.
+
+    Examples: fetch failed, no article body, AI returned malformed payload.
+    """
+
+
+class PaywallDetectedError(BoardExtractionError):
+    """Raised when the fetched page looks paywalled / truncated."""
+
+
+# --- Public DTOs returned by the parsing helpers ---------------------------
+
+
+class ExtractedBoardEntry(BaseModel):
+    """One row in a Gemini-parsed big board."""
+
+    player_name: str
+    rank: int = Field(ge=1)
+    tier: Optional[int] = Field(default=None, ge=1)
+
+
+class ExtractedBoard(BaseModel):
+    """Gemini's structured output for a single big board article."""
+
+    draft_year: int = Field(ge=2024, le=2040)
+    published_at: Optional[datetime] = None
+    entries: list[ExtractedBoardEntry] = Field(default_factory=list)
+
+
+# --- Public entry point ----------------------------------------------------
+
+
+async def extract_board(
+    db: AsyncSession,
+    *,
+    news_item_id: int,
+    kind: BoardKind = BoardKind.BIG_BOARD,
+    fetcher: Optional["ArticleFetcher"] = None,
+    ai_client: Optional[genai.Client] = None,
+) -> Optional[Board]:
+    """Extract a board from a NewsItem and persist as PENDING.
+
+    Args:
+        db: Async session; caller owns commit.
+        news_item_id: The article to extract from.
+        kind: Currently only ``BoardKind.BIG_BOARD`` is supported; mock-draft
+            extraction is a follow-up ticket.
+        fetcher: Optional override for the article-fetch step (used in tests
+            to substitute canned HTML without touching the network).
+        ai_client: Optional override for the Gemini client (used in tests to
+            return canned structured output).
+
+    Returns:
+        The persisted Board (PENDING), or ``None`` if extraction yielded no
+        valid entries.
+
+    Raises:
+        BoardExtractionError: For non-retryable failures (no article body,
+            malformed AI response, no resolvable players, etc.).
+        PaywallDetectedError: When the fetched page looks paywalled.
+    """
+    if kind != BoardKind.BIG_BOARD:
+        raise NotImplementedError(
+            "MOCK_DRAFT extraction is a follow-up ticket; only BIG_BOARD "
+            "extraction is supported in this iteration."
+        )
+
+    news_item = await db.get(NewsItem, news_item_id)
+    if news_item is None:
+        raise BoardExtractionError(f"NewsItem {news_item_id} not found")
+
+    # Dedup: skip if a non-PENDING board already exists for this article.
+    existing = await _existing_board_for_news_item(
+        db, news_item_id=news_item_id, kind=kind
+    )
+    if existing is not None and existing.status in (
+        BoardStatus.APPROVED,
+        BoardStatus.REJECTED,
+    ):
+        logger.info(
+            "board.extract.skip news_item_id=%s reason=existing_%s",
+            news_item_id,
+            existing.status.value.lower(),
+        )
+        return existing
+    if existing is not None and existing.status == BoardStatus.PENDING:
+        # Replace path: the spec says we re-extract and update. For this
+        # first iteration, return the existing PENDING board so a human
+        # can decide. Full replace-entries-in-place can come later.
+        logger.info(
+            "board.extract.skip news_item_id=%s reason=existing_pending",
+            news_item_id,
+        )
+        return existing
+
+    # 1. Fetch article HTML and clean it to plain text.
+    fetch = fetcher or _default_fetcher
+    article_text = await fetch(news_item.url)
+
+    # 2. Hand the article text to Gemini and parse the structured response.
+    extracted = await _extract_via_gemini(article_text, client=ai_client)
+    if not extracted.entries:
+        logger.warning(
+            "board.extract.no_entries news_item_id=%s url=%s",
+            news_item_id,
+            news_item.url,
+        )
+        return None
+
+    # 3. Resolve player names → players_master ids (drop unmatched, log them).
+    entries_in: list[board_service.EntryInput] = []
+    unmatched: list[str] = []
+    seen_player_ids: set[int] = set()
+    seen_positions: set[int] = set()
+    for raw in extracted.entries:
+        player_id = await _resolve_player_id(db, raw.player_name)
+        if player_id is None:
+            unmatched.append(raw.player_name)
+            continue
+        if player_id in seen_player_ids or raw.rank in seen_positions:
+            # Gemini occasionally repeats a player or a rank; skip silently.
+            continue
+        seen_player_ids.add(player_id)
+        seen_positions.add(raw.rank)
+        entries_in.append(
+            board_service.EntryInput(
+                player_id=player_id, position=raw.rank, tier=raw.tier
+            )
+        )
+
+    if unmatched:
+        logger.info(
+            "board.extract.unmatched_players news_item_id=%s count=%d names=%s",
+            news_item_id,
+            len(unmatched),
+            unmatched[:10],
+        )
+
+    if not entries_in:
+        logger.warning(
+            "board.extract.no_resolvable_entries news_item_id=%s url=%s",
+            news_item_id,
+            news_item.url,
+        )
+        return None
+
+    # 4. Persist via the existing CRUD service.
+    published_at = extracted.published_at or news_item.published_at or datetime.utcnow()
+    board = await board_service.create_board(
+        db,
+        news_source_id=news_item.source_id,
+        draft_year=extracted.draft_year,
+        published_at=published_at,
+        entries=entries_in,
+        news_item_id=news_item_id,
+    )
+    logger.info(
+        "board.extract.created board_id=%s news_item_id=%s entries=%d unmatched=%d",
+        board.id,
+        news_item_id,
+        len(entries_in),
+        len(unmatched),
+    )
+    return board
+
+
+# --- Article fetching -----------------------------------------------------
+
+
+class ArticleFetcher(Protocol):
+    async def __call__(self, url: str) -> str: ...
+
+
+async def _default_fetcher(url: str) -> str:
+    """Fetch a Substack article URL and return its cleaned body text.
+
+    Raises ``PaywallDetectedError`` if the page's schema.org JSON-LD
+    metadata signals that the article is gated.
+    """
+    html = await _http_get(url)
+    if is_paywalled(html):
+        raise PaywallDetectedError(
+            "Article is paywalled per schema.org isAccessibleForFree; "
+            "refusing to extract from a teaser."
+        )
+    return extract_article_text(html)
+
+
+async def _http_get(url: str) -> str:
+    if not url.startswith(("http://", "https://")):
+        raise BoardExtractionError(f"Refusing to fetch non-http(s) URL: {url}")
+    async with httpx.AsyncClient(
+        timeout=_PAGE_FETCH_TIMEOUT,
+        headers=_PAGE_FETCH_HEADERS,
+        follow_redirects=True,
+    ) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.text
+
+
+def extract_article_text(html: str) -> str:
+    """Pull the main article body out of a Substack page's HTML.
+
+    Strips scripts, styles, nav, footer, and aside content; collapses
+    whitespace; truncates to ``_MAX_ARTICLE_CHARS``.
+
+    Pure function — no IO. Paywall detection lives in ``is_paywalled``;
+    this function only does body extraction so it can run safely on any
+    HTML (including partial / paywalled responses for inspection).
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    for tag_name in ("script", "style", "nav", "footer", "aside", "noscript"):
+        for tag in soup.find_all(tag_name):
+            tag.decompose()
+
+    body = None
+    for selector in _SUBSTACK_BODY_SELECTORS:
+        body = soup.select_one(selector)
+        if body is not None:
+            break
+
+    if body is None:
+        # As a last resort, use the whole document. This is usually wrong
+        # for Substack but keeps the function honest for non-Substack pages.
+        body = soup.body or soup
+
+    text_parts: list[str] = []
+    for node in body.find_all(["h1", "h2", "h3", "p", "li"]):
+        line = node.get_text(" ", strip=True)
+        if line:
+            text_parts.append(line)
+
+    text = "\n".join(text_parts)
+    return text[:_MAX_ARTICLE_CHARS]
+
+
+def is_paywalled(html: str) -> bool:
+    """Return True if the page's schema.org JSON-LD declares the article gated.
+
+    Substack (like most modern publishers) emits a
+    ``<script type="application/ld+json">`` block with a ``NewsArticle``
+    document. The schema.org-standard ``isAccessibleForFree: false``
+    flag is the canonical "this is paywalled" signal — far more reliable
+    than CSS class names or copy keywords, which change with theme tweaks.
+
+    Returns False when no JSON-LD block exists or no NewsArticle blob
+    sets the flag to False (i.e., the page is free or the marker is
+    absent — both are "do not block" cases).
+
+    Pure function — no IO. Unit-tested against fixture HTML.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    for script in soup.find_all("script", attrs={"type": "application/ld+json"}):
+        raw = script.string or script.get_text() or ""
+        if not raw.strip():
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        # JSON-LD can be a single object or a list (or a @graph collection).
+        for blob in _iter_json_ld_blobs(payload):
+            if not isinstance(blob, dict):
+                continue
+            if blob.get("@type") != "NewsArticle":
+                continue
+            # schema.org default is "true" when omitted, so only treat
+            # explicit "false" (or stringified equivalents) as gated.
+            value = blob.get("isAccessibleForFree")
+            if value is False or (isinstance(value, str) and value.lower() == "false"):
+                return True
+    return False
+
+
+def _iter_json_ld_blobs(payload: object):
+    """Yield every JSON-LD blob in a payload (handles single, list, @graph)."""
+    if isinstance(payload, list):
+        for item in payload:
+            yield from _iter_json_ld_blobs(item)
+        return
+    if isinstance(payload, dict):
+        if "@graph" in payload and isinstance(payload["@graph"], list):
+            yield from _iter_json_ld_blobs(payload["@graph"])
+        yield payload
+
+
+# --- Gemini extraction ----------------------------------------------------
+
+
+_BIG_BOARD_EXTRACTION_PROMPT = """You are a structured-data extractor for DraftGuru, an NBA Draft analytics site.
+
+You will be given the cleaned body text of an NBA Draft analyst's "big board" article — a published, ordered ranking of college / international prospects.
+
+Your job is to extract the ranking into a structured JSON payload. Be careful: the article often contains commentary, headers, and unrelated player references. Only include players that appear in the analyst's RANKED LIST, in the order the analyst presents them.
+
+Output strict JSON matching this schema (do NOT wrap in markdown fences):
+
+{
+  "draft_year": <integer, e.g. 2026>,
+  "published_at": <ISO 8601 date string or null>,
+  "entries": [
+    {"player_name": "<full name as written>", "rank": <integer, 1-based>, "tier": <integer or null>}
+  ]
+}
+
+Rules:
+- "rank" is the analyst's position in the ranking (1, 2, 3, ...), not the player's pick projection.
+- "tier" is only present when the analyst explicitly groups players into tiers (Tier 1, Tier 2, ...). Otherwise use null.
+- Use the player's full name exactly as it appears in the article (e.g., "Cooper Flagg", not "Flagg").
+- Skip honorable-mention sections, "watch list" addenda, NBA veterans referenced for comparison, and analyst self-references.
+- If you cannot identify a coherent ordered list of prospects, return entries: [].
+- "draft_year" is the draft year the article is ranking for. Infer it from headers, context, or default to the current calendar year if ambiguous.
+- "published_at" should be the article's publication date if discoverable; otherwise null.
+"""
+
+
+async def _extract_via_gemini(
+    article_text: str,
+    *,
+    client: Optional[genai.Client] = None,
+) -> ExtractedBoard:
+    """Send the article body to Gemini, parse the structured response."""
+    if not article_text.strip():
+        raise BoardExtractionError("Empty article text — nothing to extract.")
+
+    gemini_client = client or _build_gemini_client()
+
+    try:
+        response = await asyncio.wait_for(
+            gemini_client.aio.models.generate_content(
+                model=_GEMINI_MODEL,
+                contents=types.Content(
+                    role="user",
+                    parts=[types.Part.from_text(text=article_text)],
+                ),
+                config=types.GenerateContentConfig(
+                    system_instruction=[
+                        types.Part.from_text(text=_BIG_BOARD_EXTRACTION_PROMPT)
+                    ],
+                    temperature=0.1,
+                    response_mime_type="application/json",
+                ),
+            ),
+            timeout=_GEMINI_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError as exc:
+        raise BoardExtractionError(
+            f"Gemini call timed out after {_GEMINI_TIMEOUT_SECONDS}s"
+        ) from exc
+
+    raw_text = response.text or ""
+    return parse_gemini_response(raw_text)
+
+
+def parse_gemini_response(raw_text: str) -> ExtractedBoard:
+    """Parse Gemini's JSON output into the typed DTO. Pure function."""
+    cleaned = _strip_markdown_fences(raw_text).strip()
+    if not cleaned:
+        raise BoardExtractionError("Gemini returned an empty response.")
+
+    try:
+        payload = json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        raise BoardExtractionError(
+            f"Gemini response was not valid JSON: {exc.msg}"
+        ) from exc
+
+    try:
+        return ExtractedBoard.model_validate(payload)
+    except ValidationError as exc:
+        raise BoardExtractionError(
+            f"Gemini response did not match expected schema: {exc}"
+        ) from exc
+
+
+_MARKDOWN_FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.MULTILINE)
+
+
+def _strip_markdown_fences(text: str) -> str:
+    """Strip ```json ... ``` fences in case the model ignored the instruction to emit raw JSON."""
+    return _MARKDOWN_FENCE_RE.sub("", text)
+
+
+def _build_gemini_client() -> genai.Client:
+    api_key = settings.gemini_summarization_api_key or settings.gemini_api_key
+    if not api_key:
+        raise BoardExtractionError(
+            "GEMINI_SUMMARIZATION_API_KEY or GEMINI_API_KEY must be configured"
+        )
+    return genai.Client(api_key=api_key)
+
+
+# --- Persistence helpers --------------------------------------------------
+
+
+async def _existing_board_for_news_item(
+    db: AsyncSession,
+    *,
+    news_item_id: int,
+    kind: BoardKind,
+) -> Optional[Board]:
+    """Return the most recent Board for this news item + kind, if any."""
+    stmt = (
+        select(Board)
+        .where(Board.news_item_id == news_item_id)  # type: ignore[arg-type]
+        .where(Board.kind == kind)  # type: ignore[arg-type]
+        .order_by(Board.created_at.desc())  # type: ignore[attr-defined]
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+_NAME_SUFFIX_RE = re.compile(
+    r"\s+(jr|sr|ii|iii|iv|v)\.?\s*$",
+    re.IGNORECASE,
+)
+
+
+def normalize_player_name(name: str) -> str:
+    """Return a canonical comparison form of a player name.
+
+    Folds Unicode diacritics (NFKD then ASCII-strip), strips trailing
+    suffix tokens (Jr., Sr., II, III, IV, V), collapses internal
+    whitespace, and lowercases. Used on both sides of the lookup so a
+    "Théo Maledon" DB row matches a "Theo Maledon" extracted name.
+
+    Pure function — unit-tested.
+    """
+    if not name:
+        return ""
+    folded = unicodedata.normalize("NFKD", name)
+    ascii_only = "".join(ch for ch in folded if not unicodedata.combining(ch))
+    without_suffix = _NAME_SUFFIX_RE.sub("", ascii_only)
+    collapsed = re.sub(r"\s+", " ", without_suffix).strip()
+    return collapsed.lower()
+
+
+async def _resolve_player_id(db: AsyncSession, raw_name: str) -> Optional[int]:
+    """Look up a PlayerMaster id by name; fall back to aliases.
+
+    Strategy:
+    1. Normalize the extracted name (``normalize_player_name``).
+    2. Load candidates whose normalized display_name matches exactly.
+       Use ``func.lower(...)`` for the case-insensitive comparison and
+       compute the diacritic-fold in Python so we don't depend on the
+       ``unaccent`` Postgres extension.
+    3. If exactly one candidate matches, return its id.
+    4. If zero, try the same on ``player_aliases.full_name``.
+    5. If multiple candidates match (e.g., two real prospects share a
+       name), treat as unresolved — never guess. The follow-up ticket
+       persists these for admin review.
+
+    Returns ``None`` for empty input, no match, or ambiguous match.
+    """
+    needle = normalize_player_name(raw_name)
+    if not needle:
+        return None
+
+    candidate = await _find_unique_normalized_match(
+        db,
+        column=PlayerMaster.display_name,  # type: ignore[arg-type]
+        id_column=PlayerMaster.id,  # type: ignore[arg-type]
+        needle=needle,
+    )
+    if candidate is not None:
+        return candidate
+
+    return await _find_unique_normalized_match(
+        db,
+        column=PlayerAlias.full_name,  # type: ignore[arg-type]
+        id_column=PlayerAlias.player_id,  # type: ignore[arg-type]
+        needle=needle,
+    )
+
+
+async def _find_unique_normalized_match(
+    db: AsyncSession,
+    *,
+    column,
+    id_column,
+    needle: str,
+) -> Optional[int]:
+    """Return the id whose normalized ``column`` value equals ``needle``.
+
+    Returns ``None`` if zero or multiple candidates match.
+
+    The first-letter prefix narrows the candidate set so we don't pull
+    the entire player table into memory per lookup, while still
+    capturing rows that differ only in diacritics.
+    """
+    first_char = needle[0] if needle else ""
+    if not first_char:
+        return None
+
+    # Cast the column to text for prefix filtering; the narrow filter
+    # keeps the candidate set tiny (one letter's worth of names).
+    stmt = select(id_column, column).where(func.lower(column).like(f"{first_char}%"))
+    result = await db.execute(stmt)
+
+    matches: list[int] = []
+    for row_id, name in result.all():
+        if normalize_player_name(name) == needle:
+            matches.append(int(row_id))
+        if len(matches) > 1:
+            # Ambiguous — bail out without guessing.
+            return None
+
+    return matches[0] if len(matches) == 1 else None

--- a/app/services/board_extraction_service.py
+++ b/app/services/board_extraction_service.py
@@ -19,15 +19,15 @@ import json
 import logging
 import re
 import unicodedata
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Protocol
 
 import httpx
 from bs4 import BeautifulSoup
 from google import genai
 from google.genai import types
-from pydantic import BaseModel, Field, ValidationError
-from sqlalchemy import func, select
+from pydantic import BaseModel, Field, ValidationError, field_validator
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -91,6 +91,22 @@ class ExtractedBoard(BaseModel):
     draft_year: int = Field(ge=2024, le=2040)
     published_at: Optional[datetime] = None
     entries: list[ExtractedBoardEntry] = Field(default_factory=list)
+
+    @field_validator("published_at")
+    @classmethod
+    def _strip_tzinfo(cls, value: Optional[datetime]) -> Optional[datetime]:
+        """Coerce timezone-aware datetimes to naive UTC.
+
+        Gemini frequently emits ISO-8601 with a trailing ``Z`` or explicit
+        offset, which Pydantic parses as a timezone-aware ``datetime``. The
+        DB column for ``Board.published_at`` is naive UTC, and asyncpg
+        refuses to bind a tz-aware datetime to a naive ``timestamp`` column.
+        Strip tzinfo at the DTO boundary so downstream code can stay
+        oblivious.
+        """
+        if value is None or value.tzinfo is None:
+            return value
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
 
 
 # --- Public entry point ----------------------------------------------------
@@ -330,7 +346,11 @@ def is_paywalled(html: str) -> bool:
         for blob in _iter_json_ld_blobs(payload):
             if not isinstance(blob, dict):
                 continue
-            if blob.get("@type") != "NewsArticle":
+            # JSON-LD allows ``@type`` to be a single string OR a list of
+            # strings (e.g. ``["NewsArticle", "Article"]``). Handle both.
+            type_value = blob.get("@type")
+            type_strings = type_value if isinstance(type_value, list) else [type_value]
+            if "NewsArticle" not in type_strings:
                 continue
             # schema.org default is "true" when omitted, so only treat
             # explicit "false" (or stringified equivalents) as gated.
@@ -509,10 +529,11 @@ async def _resolve_player_id(db: AsyncSession, raw_name: str) -> Optional[int]:
 
     Strategy:
     1. Normalize the extracted name (``normalize_player_name``).
-    2. Load candidates whose normalized display_name matches exactly.
-       Use ``func.lower(...)`` for the case-insensitive comparison and
-       compute the diacritic-fold in Python so we don't depend on the
-       ``unaccent`` Postgres extension.
+    2. Load candidate rows and compute the same normalization Python-side
+       to find an exact match. We avoid the ``unaccent`` Postgres
+       extension and don't apply a prefix prefilter (diacritic-leading
+       names would be missed by a SQL ``LIKE`` on the normalized first
+       letter).
     3. If exactly one candidate matches, return its id.
     4. If zero, try the same on ``player_aliases.full_name``.
     5. If multiple candidates match (e.g., two real prospects share a
@@ -553,17 +574,17 @@ async def _find_unique_normalized_match(
 
     Returns ``None`` if zero or multiple candidates match.
 
-    The first-letter prefix narrows the candidate set so we don't pull
-    the entire player table into memory per lookup, while still
-    capturing rows that differ only in diacritics.
+    No SQL-side prefix filter: a prefix like ``LIKE 'e%'`` would miss
+    rows whose first character is a diacritic (e.g. "Éric" → lower form
+    "éric" → does not satisfy ``LIKE 'e%'``), even though the normalized
+    needle starts with ``e``. The candidate tables (``players_master``,
+    ``player_aliases``) are small enough that scanning Python-side is
+    cheap and unambiguously correct.
     """
-    first_char = needle[0] if needle else ""
-    if not first_char:
+    if not needle:
         return None
 
-    # Cast the column to text for prefix filtering; the narrow filter
-    # keeps the candidate set tiny (one letter's worth of names).
-    stmt = select(id_column, column).where(func.lower(column).like(f"{first_char}%"))
+    stmt = select(id_column, column)
     result = await db.execute(stmt)
 
     matches: list[int] = []

--- a/tests/integration/test_board_extraction_service.py
+++ b/tests/integration/test_board_extraction_service.py
@@ -1,0 +1,382 @@
+"""Integration tests for board_extraction_service.extract_board.
+
+Patches the network (fetcher) and Gemini calls; everything else hits the
+real DB through the fixtures in ``tests/integration/conftest.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from app.schemas.boards import Board, BoardEntry, BoardKind, BoardStatus
+from app.schemas.news_items import NewsItem, NewsItemTag
+from app.schemas.news_sources import NewsSource
+from app.schemas.players_master import PlayerMaster
+from app.services import board_extraction_service
+from app.services.board_extraction_service import (
+    ExtractedBoard,
+    ExtractedBoardEntry,
+    extract_board,
+)
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+async def _make_news_item(
+    db: AsyncSession,
+    *,
+    source_id: int,
+    url: str = "https://example.substack.com/p/2026-big-board",
+    external_id: str = "test-board-1",
+) -> NewsItem:
+    item = NewsItem(
+        source_id=source_id,
+        external_id=external_id,
+        title="2026 Big Board",
+        description="The latest update.",
+        url=url,
+        tag=NewsItemTag.BIG_BOARD,
+        published_at=datetime(2026, 3, 15),
+    )
+    db.add(item)
+    await db.flush()
+    return item
+
+
+async def _make_player(db: AsyncSession, *, display_name: str) -> PlayerMaster:
+    player = PlayerMaster(display_name=display_name)
+    db.add(player)
+    await db.flush()
+    return player
+
+
+def _fake_fetcher(text: str):
+    async def _f(url: str) -> str:
+        return text
+
+    return _f
+
+
+def _stub_extraction(monkeypatch, extracted: ExtractedBoard) -> None:
+    """Replace _extract_via_gemini with a fixed-output stub."""
+
+    async def _stub(article_text: str, *, client=None) -> ExtractedBoard:
+        assert article_text, "Service should have fetched non-empty article text"
+        return extracted
+
+    monkeypatch.setattr(board_extraction_service, "_extract_via_gemini", _stub)
+
+
+# --- Happy path ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_board_creates_pending_with_resolved_players(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    monkeypatch,
+) -> None:
+    """A well-formed extraction creates a PENDING Board with matched players."""
+    assert news_source.id is not None
+    item = await _make_news_item(db_session, source_id=news_source.id)
+    flagg = await _make_player(db_session, display_name="Cooper Flagg")
+    harper = await _make_player(db_session, display_name="Dylan Harper")
+
+    _stub_extraction(
+        monkeypatch,
+        ExtractedBoard(
+            draft_year=2026,
+            published_at=datetime(2026, 3, 15),
+            entries=[
+                ExtractedBoardEntry(player_name="Cooper Flagg", rank=1, tier=1),
+                ExtractedBoardEntry(player_name="Dylan Harper", rank=2, tier=1),
+            ],
+        ),
+    )
+
+    assert item.id is not None
+    board = await extract_board(
+        db_session,
+        news_item_id=item.id,
+        fetcher=_fake_fetcher("Plenty of board content here."),
+    )
+
+    assert board is not None
+    assert board.status == BoardStatus.PENDING
+    assert board.kind == BoardKind.BIG_BOARD
+    assert board.draft_year == 2026
+    assert board.size == 2
+
+    entries_stmt = select(BoardEntry).where(BoardEntry.board_id == board.id)
+    result = await db_session.execute(entries_stmt)
+    entries = sorted(result.scalars().all(), key=lambda e: e.position)
+
+    assert [e.player_id for e in entries] == [flagg.id, harper.id]
+    assert [e.position for e in entries] == [1, 2]
+    assert all(e.tier == 1 for e in entries)
+
+
+# --- Unmatched player names ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_board_drops_unmatched_players(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    monkeypatch,
+) -> None:
+    """Unknown player names are dropped silently; matched ones still land."""
+    assert news_source.id is not None
+    item = await _make_news_item(db_session, source_id=news_source.id)
+    flagg = await _make_player(db_session, display_name="Cooper Flagg")
+
+    _stub_extraction(
+        monkeypatch,
+        ExtractedBoard(
+            draft_year=2026,
+            entries=[
+                ExtractedBoardEntry(player_name="Cooper Flagg", rank=1),
+                ExtractedBoardEntry(player_name="Nobody Player", rank=2),
+            ],
+        ),
+    )
+
+    assert item.id is not None
+    board = await extract_board(
+        db_session,
+        news_item_id=item.id,
+        fetcher=_fake_fetcher("article text"),
+    )
+
+    assert board is not None
+    entries_stmt = select(BoardEntry).where(BoardEntry.board_id == board.id)
+    result = await db_session.execute(entries_stmt)
+    entries = result.scalars().all()
+
+    assert len(entries) == 1
+    assert entries[0].player_id == flagg.id
+
+
+# --- No resolvable entries → returns None, no Board created ---------------
+
+
+@pytest.mark.asyncio
+async def test_extract_board_returns_none_when_no_players_match(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    monkeypatch,
+) -> None:
+    assert news_source.id is not None
+    item = await _make_news_item(db_session, source_id=news_source.id)
+
+    _stub_extraction(
+        monkeypatch,
+        ExtractedBoard(
+            draft_year=2026,
+            entries=[
+                ExtractedBoardEntry(player_name="Nobody One", rank=1),
+                ExtractedBoardEntry(player_name="Nobody Two", rank=2),
+            ],
+        ),
+    )
+
+    assert item.id is not None
+    board = await extract_board(
+        db_session,
+        news_item_id=item.id,
+        fetcher=_fake_fetcher("article text"),
+    )
+
+    assert board is None
+    # And no Board row was created.
+    result = await db_session.execute(
+        select(Board).where(Board.news_item_id == item.id)
+    )
+    assert result.scalar_one_or_none() is None
+
+
+# --- Dedup behavior --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_board_returns_existing_pending_unchanged(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    monkeypatch,
+) -> None:
+    """A second call against the same NewsItem returns the existing PENDING board.
+
+    Verifies dedup: the second call does not write a new board.
+    """
+    assert news_source.id is not None
+    item = await _make_news_item(db_session, source_id=news_source.id)
+    await _make_player(db_session, display_name="Cooper Flagg")
+
+    extracted = ExtractedBoard(
+        draft_year=2026,
+        entries=[ExtractedBoardEntry(player_name="Cooper Flagg", rank=1)],
+    )
+    _stub_extraction(monkeypatch, extracted)
+
+    assert item.id is not None
+    first = await extract_board(
+        db_session,
+        news_item_id=item.id,
+        fetcher=_fake_fetcher("article text"),
+    )
+    assert first is not None
+
+    second = await extract_board(
+        db_session,
+        news_item_id=item.id,
+        fetcher=_fake_fetcher("article text"),
+    )
+    assert second is not None
+    assert second.id == first.id
+
+    result = await db_session.execute(
+        select(Board).where(Board.news_item_id == item.id)
+    )
+    boards = result.scalars().all()
+    assert len(boards) == 1
+
+
+# --- Entity resolution: diacritic-insensitive matching --------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_board_matches_across_diacritics(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    monkeypatch,
+) -> None:
+    """A DB row with diacritics matches an extracted ASCII name (and vice versa)."""
+    assert news_source.id is not None
+    item = await _make_news_item(db_session, source_id=news_source.id)
+    maledon = await _make_player(db_session, display_name="Théo Maledon")
+
+    _stub_extraction(
+        monkeypatch,
+        ExtractedBoard(
+            draft_year=2026,
+            entries=[ExtractedBoardEntry(player_name="Theo Maledon", rank=1)],
+        ),
+    )
+
+    assert item.id is not None
+    board = await extract_board(
+        db_session,
+        news_item_id=item.id,
+        fetcher=_fake_fetcher("article text"),
+    )
+
+    assert board is not None
+    entries_stmt = select(BoardEntry).where(BoardEntry.board_id == board.id)
+    result = await db_session.execute(entries_stmt)
+    entries = result.scalars().all()
+    assert len(entries) == 1
+    assert entries[0].player_id == maledon.id
+
+
+@pytest.mark.asyncio
+async def test_extract_board_matches_across_suffix(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    monkeypatch,
+) -> None:
+    """A "Bronny James" in the DB matches an extracted "Bronny James Jr."."""
+    assert news_source.id is not None
+    item = await _make_news_item(db_session, source_id=news_source.id)
+    bronny = await _make_player(db_session, display_name="Bronny James")
+
+    _stub_extraction(
+        monkeypatch,
+        ExtractedBoard(
+            draft_year=2026,
+            entries=[ExtractedBoardEntry(player_name="Bronny James Jr.", rank=1)],
+        ),
+    )
+
+    assert item.id is not None
+    board = await extract_board(
+        db_session,
+        news_item_id=item.id,
+        fetcher=_fake_fetcher("article text"),
+    )
+
+    assert board is not None
+    entries_stmt = select(BoardEntry).where(BoardEntry.board_id == board.id)
+    result = await db_session.execute(entries_stmt)
+    entries = result.scalars().all()
+    assert len(entries) == 1
+    assert entries[0].player_id == bronny.id
+
+
+@pytest.mark.asyncio
+async def test_extract_board_treats_ambiguous_name_as_unresolved(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    monkeypatch,
+) -> None:
+    """Two players sharing a display name → ambiguous match, treated as unresolved.
+
+    The function does not crash or pick arbitrarily; the other (legitimate)
+    entry still lands.
+    """
+    assert news_source.id is not None
+    item = await _make_news_item(db_session, source_id=news_source.id)
+    await _make_player(db_session, display_name="Justin Edwards")
+    await _make_player(db_session, display_name="Justin Edwards")  # collision
+    flagg = await _make_player(db_session, display_name="Cooper Flagg")
+
+    _stub_extraction(
+        monkeypatch,
+        ExtractedBoard(
+            draft_year=2026,
+            entries=[
+                ExtractedBoardEntry(player_name="Cooper Flagg", rank=1),
+                ExtractedBoardEntry(player_name="Justin Edwards", rank=2),
+            ],
+        ),
+    )
+
+    assert item.id is not None
+    board = await extract_board(
+        db_session,
+        news_item_id=item.id,
+        fetcher=_fake_fetcher("article text"),
+    )
+
+    # The unambiguous entry lands; the ambiguous one is dropped (until
+    # #225 enables persisting it as an unresolved entry).
+    assert board is not None
+    entries_stmt = select(BoardEntry).where(BoardEntry.board_id == board.id)
+    result = await db_session.execute(entries_stmt)
+    entries = result.scalars().all()
+    assert len(entries) == 1
+    assert entries[0].player_id == flagg.id
+
+
+# --- MOCK_DRAFT extraction is intentionally not supported in this iteration
+
+
+@pytest.mark.asyncio
+async def test_extract_board_rejects_mock_draft_kind(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+) -> None:
+    assert news_source.id is not None
+    item = await _make_news_item(db_session, source_id=news_source.id)
+    assert item.id is not None
+
+    with pytest.raises(NotImplementedError):
+        await extract_board(
+            db_session,
+            news_item_id=item.id,
+            kind=BoardKind.MOCK_DRAFT,
+        )

--- a/tests/integration/test_board_extraction_service.py
+++ b/tests/integration/test_board_extraction_service.py
@@ -284,6 +284,46 @@ async def test_extract_board_matches_across_diacritics(
 
 
 @pytest.mark.asyncio
+async def test_extract_board_matches_when_db_name_starts_with_diacritic(
+    db_session: AsyncSession,
+    news_source: NewsSource,
+    monkeypatch,
+) -> None:
+    """A DB row starting with a diacritic character is found even though the
+    extracted (normalized) needle starts with a plain ASCII letter.
+
+    Previously a SQL prefix prefilter (LIKE 'e%') would skip "Éric ..." rows
+    because lower('É') != 'e'. The fix loads candidates without a prefix
+    filter and matches Python-side on the normalized form.
+    """
+    assert news_source.id is not None
+    item = await _make_news_item(db_session, source_id=news_source.id)
+    eric = await _make_player(db_session, display_name="Éric Dubois")
+
+    _stub_extraction(
+        monkeypatch,
+        ExtractedBoard(
+            draft_year=2026,
+            entries=[ExtractedBoardEntry(player_name="Eric Dubois", rank=1)],
+        ),
+    )
+
+    assert item.id is not None
+    board = await extract_board(
+        db_session,
+        news_item_id=item.id,
+        fetcher=_fake_fetcher("article text"),
+    )
+
+    assert board is not None
+    entries_stmt = select(BoardEntry).where(BoardEntry.board_id == board.id)
+    result = await db_session.execute(entries_stmt)
+    entries = result.scalars().all()
+    assert len(entries) == 1
+    assert entries[0].player_id == eric.id
+
+
+@pytest.mark.asyncio
 async def test_extract_board_matches_across_suffix(
     db_session: AsyncSession,
     news_source: NewsSource,

--- a/tests/unit/test_board_extraction_parsing.py
+++ b/tests/unit/test_board_extraction_parsing.py
@@ -1,0 +1,262 @@
+"""Unit tests for the pure helpers in ``board_extraction_service``.
+
+No DB, no network. Anything DB-bound lives in the integration suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.board_extraction_service import (
+    BoardExtractionError,
+    extract_article_text,
+    is_paywalled,
+    normalize_player_name,
+    parse_gemini_response,
+)
+
+
+# --- extract_article_text -----------------------------------------------
+
+
+def test_extract_article_text_pulls_substack_body() -> None:
+    """A Substack-style page yields just the article body, no nav/footer."""
+    html = """
+    <html>
+      <head><title>2026 Big Board</title></head>
+      <body>
+        <nav>Site nav</nav>
+        <div class="body markup">
+          <h1>2026 Big Board v3</h1>
+          <p>Final update before the lottery.</p>
+          <p>1. Cooper Flagg, Duke (Tier 1)</p>
+          <p>2. Dylan Harper, Rutgers (Tier 1)</p>
+        </div>
+        <footer>Footer text</footer>
+      </body>
+    </html>
+    """
+    text = extract_article_text(html)
+    assert "Cooper Flagg" in text
+    assert "Dylan Harper" in text
+    assert "Site nav" not in text
+    assert "Footer text" not in text
+
+
+def test_extract_article_text_falls_back_to_article_tag() -> None:
+    """When the Substack-specific selector misses, the <article> tag wins."""
+    html = """
+    <html><body>
+      <article>
+        <h1>The Top 30</h1>
+        <p>1. Player A</p>
+        <p>2. Player B</p>
+      </article>
+    </body></html>
+    """
+    text = extract_article_text(html)
+    assert "Player A" in text
+    assert "Player B" in text
+
+
+def test_extract_article_text_strips_scripts_and_styles() -> None:
+    """Inline JS / CSS never appears in the extracted text."""
+    html = """
+    <html><body>
+      <article>
+        <script>window.injected = 'bad'</script>
+        <style>.x { color: red; }</style>
+        <p>Real content.</p>
+      </article>
+    </body></html>
+    """
+    text = extract_article_text(html)
+    assert "window.injected" not in text
+    assert "color: red" not in text
+    assert "Real content." in text
+
+
+def test_extract_article_text_truncates_long_input() -> None:
+    """Articles longer than the cap are truncated, not raised on."""
+    big_paragraph = "Player " * 20_000
+    html = f"<html><body><article><p>{big_paragraph}</p></article></body></html>"
+    text = extract_article_text(html)
+    assert len(text) <= 30_000
+
+
+# --- is_paywalled (structural JSON-LD detection) ------------------------
+
+
+def _ld_html(is_free: object) -> str:
+    """Build an HTML fragment with a JSON-LD NewsArticle blob."""
+    return f"""
+    <html><head>
+      <script type="application/ld+json">
+      {{
+        "@context": "https://schema.org",
+        "@type": "NewsArticle",
+        "headline": "2026 Big Board",
+        "isAccessibleForFree": {json_value(is_free)}
+      }}
+      </script>
+    </head><body><article><p>Body content.</p></article></body></html>
+    """
+
+
+def json_value(v: object) -> str:
+    """Render a Python value the way it would appear in JSON."""
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, str):
+        return f'"{v}"'
+    return repr(v)
+
+
+def test_is_paywalled_returns_false_for_free_post() -> None:
+    assert is_paywalled(_ld_html(True)) is False
+
+
+def test_is_paywalled_returns_true_for_paid_post() -> None:
+    assert is_paywalled(_ld_html(False)) is True
+
+
+def test_is_paywalled_handles_stringified_false() -> None:
+    """Some publishers emit booleans as strings; recognize both."""
+    assert is_paywalled(_ld_html("false")) is True
+    assert is_paywalled(_ld_html("False")) is True
+
+
+def test_is_paywalled_returns_false_when_flag_absent() -> None:
+    """Default schema.org behavior: missing flag means free."""
+    html = """
+    <html><head>
+      <script type="application/ld+json">
+        {"@context":"https://schema.org","@type":"NewsArticle","headline":"X"}
+      </script>
+    </head><body><p>Content.</p></body></html>
+    """
+    assert is_paywalled(html) is False
+
+
+def test_is_paywalled_returns_false_when_no_json_ld() -> None:
+    """Pages with no JSON-LD aren't treated as paywalled by default."""
+    html = "<html><body><article><p>Just a plain page.</p></article></body></html>"
+    assert is_paywalled(html) is False
+
+
+def test_is_paywalled_handles_graph_form() -> None:
+    """JSON-LD can wrap multiple documents in @graph."""
+    html = """
+    <html><head>
+      <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {"@type": "WebSite", "name": "Site"},
+            {"@type": "NewsArticle", "isAccessibleForFree": false}
+          ]
+        }
+      </script>
+    </head><body></body></html>
+    """
+    assert is_paywalled(html) is True
+
+
+def test_is_paywalled_ignores_non_newsarticle_types() -> None:
+    """A WebPage with isAccessibleForFree=false shouldn't trigger
+    the gate; only NewsArticle counts (that's the doc the article body
+    lives in)."""
+    html = """
+    <html><head>
+      <script type="application/ld+json">
+        {"@type":"WebPage","isAccessibleForFree":false}
+      </script>
+    </head></html>
+    """
+    assert is_paywalled(html) is False
+
+
+# --- normalize_player_name ----------------------------------------------
+
+
+def test_normalize_player_name_basic_lowercase() -> None:
+    assert normalize_player_name("Cooper Flagg") == "cooper flagg"
+
+
+def test_normalize_player_name_strips_diacritics() -> None:
+    assert normalize_player_name("Théo Maledon") == "theo maledon"
+
+
+def test_normalize_player_name_strips_suffix() -> None:
+    assert normalize_player_name("Bronny James Jr.") == "bronny james"
+    assert normalize_player_name("Bronny James Jr") == "bronny james"
+    assert normalize_player_name("Tim Hardaway Sr.") == "tim hardaway"
+    assert normalize_player_name("Robert Williams III") == "robert williams"
+
+
+def test_normalize_player_name_collapses_whitespace() -> None:
+    assert normalize_player_name("  Cooper   Flagg  ") == "cooper flagg"
+
+
+def test_normalize_player_name_empty_input() -> None:
+    assert normalize_player_name("") == ""
+    assert normalize_player_name("   ") == ""
+
+
+def test_normalize_player_name_unchanged_for_ascii_no_suffix() -> None:
+    """The common case: lowercase + trim, otherwise unchanged."""
+    assert normalize_player_name("Dylan Harper") == "dylan harper"
+
+
+# --- parse_gemini_response ----------------------------------------------
+
+
+def test_parse_gemini_response_happy_path() -> None:
+    raw = """
+    {
+      "draft_year": 2026,
+      "published_at": "2026-03-15",
+      "entries": [
+        {"player_name": "Cooper Flagg", "rank": 1, "tier": 1},
+        {"player_name": "Dylan Harper", "rank": 2, "tier": 1}
+      ]
+    }
+    """
+    parsed = parse_gemini_response(raw)
+    assert parsed.draft_year == 2026
+    assert len(parsed.entries) == 2
+    assert parsed.entries[0].player_name == "Cooper Flagg"
+    assert parsed.entries[0].tier == 1
+
+
+def test_parse_gemini_response_strips_markdown_fences() -> None:
+    """Gemini sometimes ignores the no-fences rule; we still cope."""
+    raw = """```json
+    {"draft_year": 2026, "entries": []}
+    ```"""
+    parsed = parse_gemini_response(raw)
+    assert parsed.draft_year == 2026
+    assert parsed.entries == []
+
+
+def test_parse_gemini_response_rejects_non_json() -> None:
+    with pytest.raises(BoardExtractionError):
+        parse_gemini_response("definitely not json")
+
+
+def test_parse_gemini_response_rejects_bad_schema() -> None:
+    """A JSON payload missing required fields fails validation."""
+    with pytest.raises(BoardExtractionError):
+        parse_gemini_response('{"entries": []}')  # missing draft_year
+
+
+def test_parse_gemini_response_rejects_zero_rank() -> None:
+    """Rank must be 1-based per the schema."""
+    raw = '{"draft_year": 2026, "entries": [{"player_name": "X", "rank": 0}]}'
+    with pytest.raises(BoardExtractionError):
+        parse_gemini_response(raw)
+
+
+def test_parse_gemini_response_empty_response_raises() -> None:
+    with pytest.raises(BoardExtractionError):
+        parse_gemini_response("")

--- a/tests/unit/test_board_extraction_parsing.py
+++ b/tests/unit/test_board_extraction_parsing.py
@@ -5,10 +5,13 @@ No DB, no network. Anything DB-bound lives in the integration suite.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
 
 from app.services.board_extraction_service import (
     BoardExtractionError,
+    ExtractedBoard,
     extract_article_text,
     is_paywalled,
     normalize_player_name,
@@ -260,3 +263,75 @@ def test_parse_gemini_response_rejects_zero_rank() -> None:
 def test_parse_gemini_response_empty_response_raises() -> None:
     with pytest.raises(BoardExtractionError):
         parse_gemini_response("")
+
+
+# --- ExtractedBoard timezone normalization ------------------------------
+
+
+def test_extracted_board_strips_tzinfo_from_utc_z() -> None:
+    """A Z-suffixed ISO string lands as a naive UTC datetime."""
+    board = ExtractedBoard.model_validate(
+        {"draft_year": 2026, "published_at": "2026-03-15T00:00:00Z", "entries": []}
+    )
+    assert board.published_at is not None
+    assert board.published_at.tzinfo is None
+    assert board.published_at == datetime(2026, 3, 15, 0, 0, 0)
+
+
+def test_extracted_board_strips_tzinfo_from_explicit_offset() -> None:
+    """A datetime with an explicit non-UTC offset is converted to naive UTC."""
+    board = ExtractedBoard.model_validate(
+        {"draft_year": 2026, "published_at": "2026-03-15T08:00:00+04:00", "entries": []}
+    )
+    assert board.published_at is not None
+    assert board.published_at.tzinfo is None
+    # 08:00 +04:00 == 04:00 UTC
+    assert board.published_at == datetime(2026, 3, 15, 4, 0, 0)
+
+
+def test_extracted_board_keeps_already_naive_datetime() -> None:
+    """A naive datetime passes through untouched."""
+    board = ExtractedBoard.model_validate(
+        {"draft_year": 2026, "published_at": "2026-03-15T12:30:00", "entries": []}
+    )
+    assert board.published_at == datetime(2026, 3, 15, 12, 30, 0)
+    assert board.published_at.tzinfo is None  # type: ignore[union-attr]
+
+
+def test_extracted_board_published_at_none_is_preserved() -> None:
+    board = ExtractedBoard.model_validate({"draft_year": 2026, "entries": []})
+    assert board.published_at is None
+
+
+# --- is_paywalled with @type as a list ----------------------------------
+
+
+def test_is_paywalled_accepts_type_as_list_with_newsarticle() -> None:
+    """JSON-LD validly emits ``@type`` as a list; recognize NewsArticle inside."""
+    html = """
+    <html><head>
+      <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": ["NewsArticle", "Article"],
+          "isAccessibleForFree": false
+        }
+      </script>
+    </head><body></body></html>
+    """
+    assert is_paywalled(html) is True
+
+
+def test_is_paywalled_type_list_without_newsarticle_is_ignored() -> None:
+    """A list of types that doesn't include NewsArticle isn't gated."""
+    html = """
+    <html><head>
+      <script type="application/ld+json">
+        {
+          "@type": ["BlogPosting", "Article"],
+          "isAccessibleForFree": false
+        }
+      </script>
+    </head></html>
+    """
+    assert is_paywalled(html) is False


### PR DESCRIPTION
## Summary

Implements [#211](https://github.com/JonathanBechtel/draft-app/issues/211) — board-extraction service that takes a `NewsItem` tagged BIG_BOARD, fetches its full Substack article page, hands the cleaned body to Gemini, resolves player names to existing `players_master` rows, and persists a PENDING `Board` via the existing `board_service`. RSS descriptions alone are nowhere near long enough for a 30+ entry ranking — the full-page fetch is the load-bearing part.

This PR ships the extraction *service*, not the periodic worker. The auto-ingest worker is #224 and will call into this service.

## Key decisions

- **Paywall detection uses schema.org JSON-LD, not keyword sniffing.** Substack emits a standard `NewsArticle` JSON-LD block with `isAccessibleForFree`. Confirmed against two real Substack big-board URLs from the live news_sources before implementing. Far more reliable than parsing copy text.
- **Player resolution normalizes** diacritics (NFKD-fold), suffix tokens (Jr./Sr./III), and whitespace before matching — handles "Théo Maledon" ↔ "Theo Maledon" and "Bronny James" ↔ "Bronny James Jr." correctly.
- **Ambiguous matches are treated as unresolved** rather than crashing or guessing. If two players share a display name, neither is matched (false positives are worse than dropped entries for consensus).
- **Injectable fetcher and AI client** for clean test isolation — production code passes neither and gets the real httpx + Gemini wiring.
- **MOCK_DRAFT extraction is deferred.** The existing `board_service.create_board` is big-board-flavored (no `kind` / `num_rounds` params). Calling `extract_board(kind=MOCK_DRAFT)` raises `NotImplementedError` for now. Follow-up extends the service then unlocks it.
- **Unresolved-entry persistence + extraction-attempt memory** are intentionally NOT in this PR. They're scoped into [#225](https://github.com/JonathanBechtel/draft-app/issues/225) (a small follow-up that ships before #212 admin polish or #224 worker). Today this PR drops unresolved names with a log line — honest, conservative behavior.

## Test coverage

- 23 unit tests on the pure helpers — article-body parsing, JSON-LD paywall detection (free / paid / @graph form / stringified booleans / no JSON-LD / non-NewsArticle types), name normalization, Gemini-response parsing
- 8 integration tests on the full flow with mocked fetcher + AI — happy path, unmatched players dropped, no-resolvable-entries → None, PENDING dedup, diacritic match, suffix match, ambiguous match handled, MOCK_DRAFT rejected
- `mypy app --ignore-missing-imports` passes on all 138 files
- `pre-commit run --files <changed>` passes clean

## Test plan

- [x] `conda run -n draftguru python -m pytest tests/unit/test_board_extraction_parsing.py -q`
- [x] `scripts/with-db-env.sh conda run -n draftguru env PYTEST_ALLOW_DB=1 python -m pytest tests/integration/test_board_extraction_service.py -q`
- [x] `conda run -n draftguru mypy app --ignore-missing-imports`
- [x] `conda run -n draftguru pre-commit run --files <changed>`
- [ ] Smoke test against a real Substack URL (deferred to follow-up — would consume Gemini quota and writes to local DB; cleaner to verify once #224 auto-ingest worker is in place)

## Followups already scoped

- [#225](https://github.com/JonathanBechtel/draft-app/issues/225) — Entity-resolution schema + extraction memory (nullable `BoardEntry.player_id`, `raw_name` column, `NewsItem.last_extraction_*` fields). Required by #212 and #224
- [#212](https://github.com/JonathanBechtel/draft-app/issues/212) — Admin polish (surface unresolved entries, sort by `confidence_score`)
- [#224](https://github.com/JonathanBechtel/draft-app/issues/224) — Auto-ingest periodic worker
- Mock-draft extraction — small follow-up after `board_service` gains kind awareness