### PR TITLE
fix: anchor test_daily_counts_populated to avoid UTC midnight flake

### DIFF
--- a/tests/integration/test_trending.py
+++ b/tests/integration/test_trending.py
@@ -145,13 +145,18 @@ class TestGetTrendingPlayers:
         db_session.add(player)
         await db_session.flush()
 
+        # Anchor "today's" timestamps to ``now`` itself so the mention's
+        # ``published_at`` is guaranteed to fall in today's UTC date bucket.
+        # The previous ``now - timedelta(hours=1)`` form caused a flake when
+        # CI ran in the first hour after UTC midnight — "1 hour ago" landed
+        # in yesterday's UTC bucket and ``daily_counts[-1]`` came back 0.
         now = datetime.now(timezone.utc).replace(tzinfo=None)
-        pub_today = now - timedelta(hours=1)
+        pub_today = now
         pub_2d = now - timedelta(hours=48)
 
         # Articles published today and 2 days ago
         art_today = make_article(
-            news_source.id, "today-art", hours_ago=1  # type: ignore[arg-type]
+            news_source.id, "today-art", hours_ago=0  # type: ignore[arg-type]
         )
         art_2d = make_article(
             news_source.id, "2d-art", hours_ago=48  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Fixes a latent UTC-boundary flake in `tests/integration/test_trending.py::TestGetTrendingPlayers::test_daily_counts_populated` that surfaced on PR #223's CI run at 2026-05-26T00:25 UTC.

## Root cause

The test set the "today" mention's `published_at` to `now - timedelta(hours=1)`. When CI runs in the first hour after UTC midnight (e.g., 00:25 UTC), that timestamp falls into *yesterday's* UTC date bucket, and the assertion `assert tp.daily_counts[-1] >= 1` fails — even though nothing about the trending logic has changed.

This flake will bite **any** PR whose CI happens to land in the ~00:00–01:00 UTC window. PR #223's CI on the earlier push (2026-05-25 19:09 UTC) passed the same test cleanly.

## Fix

Use `now` itself (always inside today's UTC date by definition) for both the article's `published_at` and the mention's `published_at`. The "1 hour ago" wording was incidental — the test's intent is just "an article published today" — so semantically equivalent.

The 2-day-ago timestamp at `hours=48` is robust regardless of UTC hour (48-hour offsets always land in the right bucket on a non-DST UTC date), so it's left alone.

## Test plan

- [x] `python -m pytest tests/integration/test_trending.py::TestGetTrendingPlayers::test_daily_counts_populated -v` — passes
- [x] Full `tests/integration/test_trending.py` class — 9/9 passing
- [x] `pre-commit run --files tests/integration/test_trending.py` — clean

Once merged, the open PR #223 should be re-run on the merge-base bump and pass.